### PR TITLE
v0.3.0: relicense to Apache-2.0, add NOTICE/CITATION/CONTRIBUTING

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,50 @@
+# Changelog
+
+All notable changes to this project are documented in this file. The format
+is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
+project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.3.0] - 2026-05-03
+
+### Changed
+
+- **License relicensed from MIT to Apache-2.0.** The MIT license that covered
+  versions 0.1.x and 0.2.0 is preserved verbatim in `LICENSE-MIT` for
+  reference; users of those versions retain their MIT rights. All new
+  contributions and releases (0.3.0 and later) are governed by `LICENSE`
+  (Apache-2.0).
+- `pyproject.toml` `license` field updated to `Apache-2.0`; classifier
+  updated accordingly. Author field corrected to legal name
+  (`Manjunath Janardhan`).
+
+### Added
+
+- `NOTICE` file with copyright + attribution boilerplate (Apache-2.0
+  requires this to propagate into derivative works).
+- `CITATION.cff` so GitHub renders a "Cite this repository" widget and
+  academic users have a defined citation form.
+- `CONTRIBUTING.md` with the Developer Certificate of Origin (DCO) and
+  `Signed-off-by` instructions for contributors.
+
+### Notes
+
+- Why the relicense: Apache-2.0 adds an explicit patent grant, mandates
+  NOTICE propagation in derivative works, and is the standard open-source
+  license for ML/quantization tooling. MIT remains valid for all 0.1.x and
+  0.2.0 releases.
+
+## [0.2.0] - 2026-04-30
+
+KV cache v0.2: mixed K/V bits (`--kv-k-bits`/`--kv-v-bits`),
+attention-sink protection (`--kv-min-tokens`), per-head_dim PPL harness,
+production CLI for `turboquant-generate` and `turboquant-serve`. Validated
+on GPT-OSS-20B/120B and Qwen3.5-122B.
+
+## [0.1.6] - 2026-04-12
+
+Hybrid quantization (`--attn-bits`/`--mlp-bits`) targeting 48 GB Apple
+Silicon Macs. Long-context Metal kernel fixes.
+
+## Earlier versions
+
+See `git log` for the full history of versions 0.1.0 through 0.1.5.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,57 @@
+cff-version: 1.2.0
+title: "TurboQuant-MLX: Extreme weight and KV cache compression for LLMs on Apple Silicon"
+message: "If you use this software, please cite it using the metadata from this file."
+type: software
+authors:
+  - family-names: "Janardhan"
+    given-names: "Manjunath"
+    email: "manjunath.shiva@gmail.com"
+repository-code: "https://github.com/manjunathshiva/turboquant-mlx"
+url: "https://github.com/manjunathshiva/turboquant-mlx"
+abstract: >
+  TurboQuant-MLX is an MLX implementation of Google Research's TurboQuant
+  (Zandieh et al., 2025) for Apple Silicon. It provides 2-/3-/4-bit weight
+  compression via Hadamard rotation + Lloyd-Max codebooks, KV cache
+  compression with attention-sink protection, hybrid bit allocation for
+  mixture-of-experts models, and fused Metal kernels for dense and MoE
+  decode. Validated on GPT-OSS-20B, GPT-OSS-120B, Qwen3.5-122B, and
+  Nemotron-3-Super-120B.
+keywords:
+  - mlx
+  - quantization
+  - llm
+  - kv-cache
+  - apple-silicon
+  - turboquant
+  - polarquant
+  - mixture-of-experts
+license: Apache-2.0
+preferred-citation:
+  type: software
+  title: "TurboQuant-MLX"
+  authors:
+    - family-names: "Janardhan"
+      given-names: "Manjunath"
+  url: "https://github.com/manjunathshiva/turboquant-mlx"
+references:
+  - type: article
+    title: "TurboQuant: Online Vector Quantization with Optimal Distortion-Rate Trade-off"
+    authors:
+      - family-names: "Zandieh"
+        given-names: "Amir"
+      - family-names: "Han"
+        given-names: "Minsik"
+      - family-names: "Dalca"
+        given-names: "Andre"
+      - family-names: "Shin"
+        given-names: "Jungwoo"
+      - family-names: "Wang"
+        given-names: "Brian"
+      - family-names: "Zhang"
+        given-names: "Yichao"
+      - family-names: "Bordegoni"
+        given-names: "Matteo"
+      - family-names: "Tian"
+        given-names: "Yuan"
+    year: 2025
+    url: "https://arxiv.org/abs/2504.19874"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,87 @@
+# Contributing to TurboQuant-MLX
+
+Thanks for your interest! This document covers how to set up a dev
+environment, the rules for submitting changes, and how to sign your
+commits so the project's license chain stays clean.
+
+## Code of Conduct
+
+By participating in this project you agree to abide by the community
+[Code of Conduct](CODE_OF_CONDUCT.md) — be respectful, assume good faith,
+and keep discussion focused on the work.
+
+## Development setup
+
+```bash
+git clone https://github.com/manjunathshiva/turboquant-mlx.git
+cd turboquant-mlx
+python -m venv .venv && source .venv/bin/activate
+pip install -e ".[dev,eval]"
+```
+
+You'll need macOS on Apple Silicon, Xcode Command Line Tools, and
+CMake 3.27+ to build the Metal kernels.
+
+## Running tests
+
+```bash
+pytest tests/
+```
+
+48 tests should pass on a clean checkout. The KV cache tests require
+`mlx-lm>=0.31.3`.
+
+## How to propose a change
+
+1. Open a GitHub issue first to discuss substantial changes (new kernels,
+   new architecture support, API breaks). Small fixes can go straight to a PR.
+2. Fork, branch, implement, add tests, run the suite, open a PR.
+3. Keep PRs focused — one logical change per PR makes review tractable.
+4. Match existing code style (PEP 8, type hints on public APIs, docstrings
+   on exported functions).
+
+## Sign-off (Developer Certificate of Origin)
+
+This project uses the [Developer Certificate of Origin](https://developercertificate.org/)
+(DCO) instead of a contributor-license agreement. By signing off your
+commits, you certify that you wrote the code (or have the right to
+contribute it) and agree to release it under the project's license
+(Apache-2.0 for v0.3.0 and later).
+
+To sign off, add a `Signed-off-by` trailer to every commit:
+
+```bash
+git commit -s -m "your commit message"
+```
+
+`-s` is a shortcut that automatically appends:
+
+```
+Signed-off-by: Your Name <your.email@example.com>
+```
+
+Configure git once with the name and email you want to appear in the trailer:
+
+```bash
+git config user.name "Your Name"
+git config user.email "your.email@example.com"
+```
+
+PRs without sign-off will be asked to add it before merge. There is no
+separate CLA to sign and no rights assignment — you keep copyright over
+your contribution; the DCO simply confirms you have the right to
+contribute it under Apache-2.0.
+
+The full DCO text is at https://developercertificate.org/ (it's short —
+one screen).
+
+## Reporting security issues
+
+Do **not** open a public issue for security vulnerabilities. See
+[SECURITY.md](SECURITY.md) for the disclosure policy.
+
+## License
+
+By contributing to this project, you agree that your contributions will
+be licensed under the [Apache License 2.0](LICENSE) for v0.3.0 and later
+releases.

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,200 @@
-MIT License
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
 
-Copyright (c) 2025 Manjunath Shiva
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+   1. Definitions.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for describing the origin of the Work and
+      reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may accept support,
+      indemnity, warranty, or other liability obligations and/or rights
+      consistent with this License. However, in accepting such obligations,
+      You may act only on Your own behalf and on Your sole responsibility,
+      not on behalf of any other Contributor, and only if You agree to
+      indemnify, defend, and hold each Contributor harmless for any
+      liability incurred by, or claims asserted against, such Contributor
+      by reason of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright 2026 Manjunath Janardhan
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/LICENSE-MIT
+++ b/LICENSE-MIT
@@ -1,0 +1,27 @@
+MIT License
+
+Copyright (c) 2026 Manjunath Janardhan
+
+This MIT License covers TurboQuant-MLX versions 0.1.0 through 0.2.0.
+Versions 0.3.0 and later are released under the Apache License, Version 2.0
+(see the LICENSE file). This file is preserved as a record of the license
+under which earlier versions were made available; users of those earlier
+versions retain their rights under MIT.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,39 @@
+TurboQuant-MLX
+Copyright 2026 Manjunath Janardhan
+
+This product includes software developed by Manjunath Janardhan.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+----------------------------------------------------------------------
+
+This software implements the TurboQuant algorithm described in:
+
+  Zandieh, A., Han, M., Dalca, A., Shin, J., Wang, B., Zhang, Y.,
+  Bordegoni, M., Tian, Y., et al. (2025).
+  "TurboQuant: Online Vector Quantization with Optimal Distortion-Rate
+  Trade-off."
+  https://arxiv.org/abs/2504.19874
+
+The original TurboQuant algorithm is research published by the authors
+above. The MLX implementation, hybrid bit-allocation strategy, KV cache
+compression integration, and fused Metal kernels in this repository are
+the original work of Manjunath Janardhan.
+
+----------------------------------------------------------------------
+
+Versions 0.1.x through 0.2.0 of this software were released under the
+MIT License. Starting with version 0.3.0, this software is released
+under the Apache License, Version 2.0. Versions previously distributed
+under MIT remain available under their original license; the relicense
+applies only to versions 0.3.0 and later. See CHANGELOG.md for details.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, 
 | GPT-OSS-120B | [Affine 4-bit (mlx-community)](https://huggingface.co/mlx-community/gpt-oss-120b-4bit) | 4 | — | 65.8 GB | *Doesn't fit 64GB* |
 | GPT-OSS-120B | MXFP4 (original) | 4 | — | 63.5 GB | *Doesn't fit 64GB* |
 | GPT-OSS-120B | TurboQuant | 3 | — | 48 GB | **44 tok/s** |
+| **[GPT-OSS-120B (hybrid for 48GB)](https://huggingface.co/manjunathshiva/gpt-oss-120b-tq3a-tq2e-g32)** | **TQ 3-attn / 2-experts, gs=32** | **2/3 mix** | **—** | **~35 GB** | **42–50 tok/s** |
 | GPT-OSS-120B | TurboQuant | 2 | — | 32 GB | 51 tok/s (poor quality) |
 | Qwen3.5-122B-A10B | BF16 (original) | 16 | — | ~240 GB | *Doesn't fit 64GB* |
 | **Qwen3.5-122B-A10B** | **TurboQuant** | **3** | **—** | **~50 GB** | **26.5 tok/s** |

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,7 +30,6 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,12 +8,13 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.2.0"
+version = "0.3.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "MIT"}
-authors = [{name = "Manjunath Shiva"}]
+license = "Apache-2.0"
+license-files = ["LICENSE", "LICENSE-MIT", "NOTICE"]
+authors = [{name = "Manjunath Janardhan", email = "manjunath.shiva@gmail.com"}]
 keywords = [
     "mlx",
     "quantization",
@@ -29,7 +30,7 @@ classifiers = [
     "Development Status :: 4 - Beta",
     "Intended Audience :: Science/Research",
     "Intended Audience :: Developers",
-    "License :: OSI Approved :: MIT License",
+    "License :: OSI Approved :: Apache Software License",
     "Operating System :: MacOS",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.10",


### PR DESCRIPTION
## Summary
- Relicense from v0.3.0 onward to **Apache-2.0**; v0.1.x and v0.2.0 keep their original MIT terms (preserved verbatim in `LICENSE-MIT`).
- Add `NOTICE` (Apache attribution propagation), `CITATION.cff` (renders the GitHub "Cite this repository" widget + cites Zandieh et al. 2025), `CONTRIBUTING.md` (with DCO `Signed-off-by` requirement), `CHANGELOG.md` (keep-a-changelog format).
- README: add the GPT-OSS-120B hybrid (`tq3a-tq2e g32`) row pointing at https://huggingface.co/manjunathshiva/gpt-oss-120b-tq3a-tq2e-g32 — the new 48 GB Mac target build.
- `pyproject.toml` + `__init__.py` bumped to `0.3.0`; license metadata switched to Apache-2.0; author corrected to legal name **Manjunath Janardhan**.

## Why Apache-2.0 (not MIT)
- Explicit **patent grant** — protects users and contributors from later patent claims.
- **Mandatory NOTICE propagation** in derivative works — keeps attribution intact downstream.
- Standard open-source license for ML / quantization tooling — easier for legal review at adopting orgs.
- Existing MIT-licensed releases (0.1.x, 0.2.0) are unaffected; users on those versions retain their MIT rights forever.

## Test plan
- [x] DCO sign-off present on commit
- [x] `pyproject.toml` validates (`license = "Apache-2.0"`, `license-files` references all three files)
- [x] `__version__` matches pyproject version (`0.3.0`)
- [x] Every name reference in new/modified files reads "Manjunath Janardhan" (no stale "Shiva")
- [x] Every copyright year is 2026
- [ ] CI green
- [ ] PyPI build dry-run on the branch (optional — can be done before tagging v0.3.0)