### PR TITLE
ci(release): add PyPI Trusted Publishing via OIDC

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,24 @@
 name: Release
 
-# Auto-create a GitHub Release whenever a vX.Y.Z tag is pushed.
-# Workflow: bump version -> twine upload -> git tag vX.Y.Z -> git push --tags
-# The tag push fires this workflow and the GitHub Release appears with
-# auto-generated notes from the commits since the previous tag.
+# Triggered by a tag push (vX.Y.Z). Three jobs:
+#   1. release      - create the GitHub Release with auto-generated notes
+#   2. build-sdist  - build the source distribution (sdist only; the C++ /
+#                     Metal extension is platform-specific and built on
+#                     install, so we don't ship binary wheels yet)
+#   3. publish-pypi - upload the sdist to PyPI via OIDC Trusted Publishing
+#                     (no API tokens; scoped to the "pypi" environment so
+#                     a maintainer must approve before upload)
+#
+# Setup required on PyPI side (one-time):
+#   https://pypi.org/manage/project/turboquant-mlx-full/settings/publishing/
+#   Add a Trusted Publisher:
+#     - Owner:                manjunathshiva
+#     - Repository name:      turboquant-mlx
+#     - Workflow filename:    release.yml
+#     - Environment name:     pypi
+# Setup required on GitHub side (one-time):
+#   Repo Settings -> Environments -> New environment "pypi" -> require
+#   manual approval (so an unintended tag push can't auto-upload).
 
 on:
   push:
@@ -15,6 +30,7 @@ permissions:
 
 jobs:
   release:
+    name: Create GitHub Release
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -31,3 +47,66 @@ jobs:
             --title "$TAG" \
             --generate-notes \
             --verify-tag
+
+  build-sdist:
+    name: Build sdist
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.12'
+
+      - name: Install build tooling
+        run: python -m pip install --upgrade build twine
+
+      - name: Build sdist
+        run: python -m build --sdist
+
+      - name: Check distribution metadata
+        run: twine check dist/*
+
+      - name: Verify tag matches package version
+        run: |
+          TAG="${GITHUB_REF#refs/tags/v}"
+          PKG_VERSION=$(python -c "import re; m=re.search(r'__version__\s*=\s*\"([^\"]+)\"', open('__init__.py').read()); print(m.group(1))")
+          if [ "$TAG" != "$PKG_VERSION" ]; then
+            echo "Tag v$TAG does not match __version__ $PKG_VERSION" >&2
+            exit 1
+          fi
+          echo "Tag v$TAG matches __version__ $PKG_VERSION"
+
+      - name: Upload sdist artifact
+        uses: actions/upload-artifact@v5
+        with:
+          name: sdist
+          path: dist/*.tar.gz
+          if-no-files-found: error
+
+  publish-pypi:
+    name: Publish to PyPI (OIDC)
+    needs: build-sdist
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/p/turboquant-mlx-full
+    permissions:
+      id-token: write
+    steps:
+      - name: Download sdist artifact
+        uses: actions/download-artifact@v5
+        with:
+          name: sdist
+          path: dist/
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          # Sdist only - the C++ extension is built per-host on install.
+          # If we ever ship cibuildwheel-built wheels, add them to the
+          # artifact and they'll upload automatically alongside the sdist.
+          packages-dir: dist/
+          skip-existing: true


### PR DESCRIPTION
## Summary
Adds two jobs to the release workflow so future tag pushes auto-publish to PyPI without manual \`twine upload\`:

- **build-sdist** — builds the sdist, runs \`twine check\`, and verifies the tag matches \`__version__\` to catch drift before publishing.
- **publish-pypi** — uploads via OIDC (\`pypa/gh-action-pypi-publish\`), scoped to a \`pypi\` GitHub Environment so a maintainer must click "Approve" before each upload.

## Required one-time setup (before merging)
1. **PyPI side**: https://pypi.org/manage/project/turboquant-mlx-full/settings/publishing/ → add a Trusted Publisher with owner=manjunathshiva, repo=turboquant-mlx, workflow=release.yml, environment=pypi.
2. **GitHub side**: Settings → Environments → New environment "pypi" with Required reviewers (yourself).

Both are documented in the workflow header comment.

## Test plan
- [x] Workflow YAML syntax-valid
- [x] Tag-vs-version check has a clear failure mode (mismatch -> exit 1)
- [x] \`skip-existing: true\` so retagging an already-published version is a safe no-op
- [ ] PyPI Trusted Publisher configured
- [ ] GitHub Environment "pypi" configured with Required reviewers
- [ ] First real test: cut v0.3.1 tag and confirm full chain (GitHub Release + sdist + approval prompt + PyPI upload)