### PR TITLE
Expert streaming for MoE models (v0.4.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,36 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.0] - 2026-05-25
+
+### Added
+
+- **Expert streaming for MoE models (`turboquant_mlx.stream`).** Run MoE
+  checkpoints whose weights exceed available RAM by paging only the
+  router-selected experts from disk per token (LRU-cached), keeping the full
+  `(num_experts, ...)` expert tensors out of memory. Output is bit-identical
+  to the fully-resident model. New CLI:
+  `python -m turboquant_mlx.stream.stream_generate --model <repo> --cache-budget-gb <GB>`.
+  - Validated on a 16 GB Mac mini running the ~16 GB
+    `Qwen3.6-35B-A3B-tq3-g32` (`qwen3_5_moe`, 256 experts): 3.9 GB peak RSS
+    at `--cache-budget-gb 2` (~3 tok/s) up to 9.4 GB / ~4.5 tok/s at
+    `--cache-budget-gb 8`. Disk read is the throughput limiter; a larger cache
+    budget raises the expert hit-rate and cuts per-token SSD traffic.
+  - Uses `os.pread` + macOS `F_NOCACHE` so streaming tens of GB of expert
+    slices doesn't balloon resident page cache; RSS tracks MLX managed memory.
+
+### Fixed
+
+- `stream_generate` reported throughput by dividing `--max-tokens` by
+  wall-time, overstating tok/s whenever the model stopped at EOS before the
+  cap. It now counts the tokens actually generated.
+
+### Notes
+
+- Streaming currently targets the `qwen3_5_moe` expert layout
+  (`language_model.model.layers[*].mlp.switch_mlp.{gate,up,down}_proj`);
+  generalizing to other MoE architectures is future work.
+
 ## [0.3.0] - 2026-05-03
 
 ### Changed

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/docs/design/layer_streaming_poc.md
+++ b/docs/design/layer_streaming_poc.md
@@ -1,0 +1,374 @@
+# Layer- and expert-streaming for trillion-class MoE on 64 GB Macs
+
+**Branch:** `poc/layer-streaming-1t`
+**Status:** design — no code yet
+**Goal:** run a 1T-class MoE (Kimi K2, DeepSeek-V3 class) on a single 64 GB
+Apple Silicon Mac by combining TurboQuant 3-bit weights with AirLLM-style
+on-disk streaming. Trade tokens/sec for memory; aim for a usable-if-patient
+range (≥ 0.1 tok/s), not a benchmark winner.
+
+---
+
+## 1. Why we even looked at AirLLM
+
+AirLLM (lyogavin/airllm, Apache 2.0) advertises "70B on 4 GB VRAM" by
+splitting the model into per-layer files on disk and loading one layer
+at a time during the forward pass. It has an MLX backend, so on paper
+it's the closest existing reference for what we'd build.
+
+A read of the cloned repo (`/tmp/airllm-poc/` at HEAD on 2026-05-16)
+turns up a less rosy picture than the README implies — see §3.
+
+---
+
+## 2. What AirLLM actually does on MLX today
+
+Cloned source: `air_llm/airllm/`
+
+### 2.1 Per-layer split-and-save (one-time preprocessing)
+
+`utils.py:188 split_and_save_layers` walks `model.safetensors.index.json`,
+groups tensors by `model.layers.{i}.*` prefix, and writes one shard per
+layer. On the MLX backend the persister is
+`persist/mlx_model_persister.py:77 persist_model`, which converts each
+layer's state dict to fp16 numpy and saves as `<layer>.mlx.npz`. A
+sibling `.mlx.done` marker file signals "fully written" so partial runs
+don't corrupt the cache.
+
+Layer naming is HF-conventional: `model.embed_tokens`,
+`model.layers.{0..N-1}`, `model.norm`, `lm_head`. A whole MoE block
+(all 8 Mixtral experts, all 256 Qwen3-MoE experts, etc.) lands in a
+**single** `model.layers.{i}.mlx.npz` file.
+
+### 2.2 The streaming forward pass (MLX path)
+
+`airllm_llama_mlx.py:265 model_generate` is the core loop. For the
+prompt pass:
+
+```python
+# embed
+self.tok_embeddings = nn.Embedding(...)
+self.tok_embeddings.update(persister.load_model('model.embed_tokens', ...))
+x = self.tok_embeddings(x); mx.eval(x); del self.tok_embeddings; gc.collect()
+
+for il in range(n_layers):
+    l = TransformerBlock(args=self.model_args)
+    l.update(persister.load_model(f'model.layers.{il}', ...)['layers'][il])
+    x, c = l(x, mask=mask)
+    mx.eval(x)
+    cache.append(c)            # per-layer KV stays in RAM across tokens
+    del l; gc.collect()        # weights are evicted every layer
+```
+
+Decode pass (`airllm_llama_mlx.py:367`) is the same shape, reusing
+`cache[i]`.
+
+Key properties of the MLX path:
+
+| | |
+|---|---|
+| Per-step RAM | **one transformer block's weights** + KV-cache-list + activations |
+| Per-token disk read | **whole model** (all layers, embed, norm, lm_head) |
+| Layer architecture | hard-coded Llama-2 (`RMSNorm`/`RoPE`/GQA `Attention`/SiLU `FeedForward` in `airllm_llama_mlx.py:71–177`) |
+| Quantization | **none** — weights stored as fp16 `.npz`, no codebook, no scales |
+| Prefetching | **none on MLX** — the `ThreadPoolExecutor` + `torch.cuda.Stream` pipeline lives in `airllm_base.py:441–487` and is CUDA-only |
+| Eviction policy | `del l; gc.collect()` — eager, every layer, no LRU |
+| MoE awareness | **none** — `airllm_mixtral.py` is a 22-line trivial subclass that only disables BetterTransformer |
+
+### 2.3 The "compression" feature is a CUDA-only red herring
+
+The 4bit/8bit option uses `bitsandbytes` (`utils.py:157
+compress_layer_state_dict`), which is CUDA-only. On the MLX path
+compression is silently unavailable — you get fp16 npz files at full
+size. So on Mac, AirLLM is reading the **fp16** model from disk every
+token. For a 1T model that's ~2 TB streamed per token over NVMe.
+
+---
+
+## 3. Gap analysis vs. what we need
+
+| Gap | AirLLM today | Required for our target |
+|---|---|---|
+| **G1. Quantized layer files** | fp16 `.npz` | TurboQuant 3-bit packed indices + per-group fp16 scales + per-codebook table |
+| **G2. Expert-level granularity** | one file per *layer* (all experts inside) | one file (or one shard offset) per *expert*, so router top-k drives the read |
+| **G3. Lazy paging** | `mx.load(npz)` loads the entire tensor eagerly | safetensors mmap so the OS page cache and SSD readahead do the work |
+| **G4. Prefetch on MLX** | none | overlap layer N compute with layer N+1 disk fetch (threadpool or `mx.async_load`) |
+| **G5. Eviction policy** | eager `del` every step | LRU on a fixed RAM budget so hot experts stay resident |
+| **G6. MoE-architecture support** | trivial Mixtral subclass with no expert routing in the loop | a real MoE block driver that consumes router logits and only materializes top-k experts |
+| **G7. Architecture coverage** | Llama-2 only on MLX | Nemotron-H, Qwen3-MoE, DeepSeek-V3, Kimi K2 — each is its own block class in MLX |
+
+G1 and G2 together are the load-bearing pair. G2 alone (smaller reads)
+buys order-of-magnitude speedups on MoE; G1 alone buys a 5–6× cut on
+disk bandwidth. Both stack.
+
+---
+
+## 4. Throughput model
+
+64 GB unified-memory Mac, NVMe SSD sustained ≈ 5 GB/s sequential read,
+no kernel-level surprises. The decode-time bottleneck is *I/O*, not
+compute — once compute is hidden behind I/O via prefetch, throughput
+is just `bytes_read_per_token / disk_bandwidth`.
+
+### 4.1 Dense 1T
+
+| Build | On disk | Bytes/token | Floor latency | Tok/s |
+|---|---|---|---|---|
+| fp16 (AirLLM as-is) | 2 TB | 2 TB | 400 s | 0.0025 |
+| TQ 2-bit g32 | 250 GB | 250 GB | 50 s | 0.02 |
+| TQ 3-bit g32 | 375 GB | 375 GB | 75 s | 0.013 |
+
+Dense 1T is technically runnable but practically a slideshow.
+**Not the target.**
+
+### 4.2 MoE 1T (Kimi K2 / DeepSeek-V3 class, ~30 B active per token)
+
+Active params per token = attention + shared + top-k experts ≈ 30 B.
+
+| Build | Active-bytes/token | Floor latency | Tok/s |
+|---|---|---|---|
+| fp16 (AirLLM "expert-aware" — doesn't exist) | 60 GB | 12 s | 0.08 |
+| TQ 2-bit g32 expert-aware | 7.5 GB | 1.5 s | 0.67 |
+| **TQ 3-bit g32 expert-aware** | **11 GB** | **2.2 s** | **0.45** |
+
+With realistic overheads (codebook dequant, kernel launch, KV cache
+maintenance) shave 30–50%. Realistic target: **0.2–0.4 tok/s**, i.e.
+**1 token every 2.5–5 s**. Slow, but interactive-ish for chat-length
+outputs; a 500-token response in ~25–40 min.
+
+### 4.3 The prefetch ceiling
+
+If layer N's compute takes 1 s and layer N+1's I/O takes 2.2 s, the
+critical path is the slower of the two (2.2 s) plus a fixed overhead.
+Without prefetch you pay 1 + 2.2 = 3.2 s per layer-step; with it, 2.2 s.
+~30% speedup, which matches the AirLLM README's CUDA claim. Worth
+having but not the headline lever.
+
+### 4.4 Sanity check vs. the AirLLM 70B-on-4GB number
+
+AirLLM's claim is the dense-4bit-on-CUDA case: 70 B × 0.5 byte = 35 GB
+on disk, streamed in 7 s/token over PCIe + NVMe combined. Their
+published numbers are ~0.5–1 tok/s on consumer hardware. Our MoE 1T
+math (0.2–0.4 tok/s) is in the same ballpark per byte streamed — the
+1T number works only because **active-params << total params**.
+
+---
+
+## 5. What we'd build
+
+### 5.1 Module layout
+
+```
+turboquant_mlx/
+└── stream/                       # NEW
+    ├── __init__.py
+    ├── persist.py                # TQ-aware per-expert sharding (replaces airllm utils.split_and_save_layers)
+    ├── loader.py                 # mmap + async fetch + LRU cache
+    ├── block.py                  # MoE-aware block driver (consumes router top-k)
+    ├── archs/
+    │   ├── llama.py              # parity check vs airllm_llama_mlx.py on a small model
+    │   ├── mixtral.py            # first real MoE (8 experts) — minimal interesting case
+    │   ├── qwen3_moe.py
+    │   ├── deepseek_v3.py
+    │   └── kimi_k2.py
+    └── stream_generate.py        # entrypoint, mirrors generate.py
+```
+
+### 5.2 On-disk format
+
+Per-expert sharded TQ checkpoint:
+
+```
+<model>.tq-stream/
+├── manifest.json                 # arch, n_layers, n_experts_per_layer, group_size,
+│                                 # tq codebook (per-bit-width), layer→file mapping
+├── meta/                         # tied across layers
+│   ├── embed_tokens.tq           # codebook + packed indices + scales
+│   ├── norm.tq
+│   └── lm_head.tq                # often tied to embed; if so, just a symlink
+└── layers/
+    └── {i}/
+        ├── attn.tq               # qkv + o (3-bit per --attn-bits if hybrid)
+        ├── attn_norm.fp16        # tiny, stays loaded
+        ├── ffn_norm.fp16
+        ├── router.fp16           # tiny, stays loaded
+        ├── shared_expert.tq      # if arch has one (DSV3, Nemotron-3)
+        └── experts/
+            ├── 000.tq
+            ├── 001.tq
+            └── ... (up to 511 for nemotron-3, 128 for DSV3, 384 for K2)
+```
+
+The `.tq` file is a safetensors layout (`mx.load(...,
+return_metadata=True)` friendly) holding three arrays — `codebook`
+(shape `[2**bits]`, fp16), `indices` (shape `[out_features,
+in_features // group_size, group_size]`, packed uint8), `scales`
+(shape `[out_features, in_features // group_size]`, fp16). Reusing
+safetensors gives us mmap for free.
+
+**Why one file per expert and not one large per-layer file with
+offsets?** Both work. Per-file is simpler, plays well with the OS page
+cache, and means the LRU evictor can call `madvise(MADV_DONTNEED)` per
+expert. Per-layer-with-offsets gives one fewer syscall per expert but
+needs a custom range-load path. Start with per-file; revisit if open()
+overhead shows up in profiling.
+
+### 5.3 Hot loop (MoE-aware, decode pass)
+
+```python
+# pseudo-code, MoE block step
+def moe_block_step(x, layer_idx, kv_cache, loader, lru):
+    # tiny tensors — always resident
+    attn_norm, ffn_norm = lru.get_resident(layer_idx, ['attn_norm', 'ffn_norm'])
+    router            = lru.get_resident(layer_idx, ['router'])
+
+    # attention — already prefetched by previous step
+    attn_w = lru.get(layer_idx, 'attn', prefetched=True)
+    x = attn_norm(x); x = attn_w(x, kv_cache); del attn_w  # eviction managed by LRU
+
+    # routing
+    h = ffn_norm(x)
+    routing_logits = router(h)
+    topk_experts = topk_indices(routing_logits, k=K)   # shape [B*L, K]
+
+    # kick off prefetch of likely-next experts (heuristic: top-k from a
+    # smoothed running estimate, or just the same set from the next layer)
+    loader.prefetch_next_experts(layer_idx + 1, topk_experts)
+
+    # materialize and fuse only the experts this token actually needs
+    out = zeros_like(h)
+    for e in unique(topk_experts):
+        we = lru.get(layer_idx, f'experts/{e}')
+        out += routing_weight[e] * we(h)
+    return x + out
+```
+
+The eviction predicate is *"keep if predicted hot in next 2 layers,
+else drop"*. A naive LRU is the floor; a router-trace-trained predictor
+is the ceiling.
+
+### 5.4 Persistence pipeline
+
+Read the existing TQ checkpoint (produced by `convert.py`), split per
+expert, write the streaming layout. Roughly:
+
+```python
+def make_stream_checkpoint(tq_in: Path, out: Path, arch_spec):
+    weights = safetensors_open(tq_in / 'model.safetensors.index.json')
+    for layer_idx, name in arch_spec.iter_layer_components(weights):
+        # name = 'layer.7.experts.42' or 'layer.7.attn'
+        write_tq_shard(out / shard_path(name), weights, name)
+    write_manifest(out / 'manifest.json', arch_spec, ...)
+```
+
+This is the moral equivalent of AirLLM's
+`utils.py:188 split_and_save_layers` but TQ- and MoE-aware. **We reuse
+no AirLLM code** — the path mapping (`map_torch_to_mlx` in
+`mlx_model_persister.py:16`) is Llama-2 hardcoded and doesn't help us.
+
+---
+
+## 6. PoC milestones
+
+Each stage gates the next. Stop and re-plan if a stage misses its
+acceptance bar.
+
+| M | Goal | Acceptance | Effort |
+|---|---|---|---|
+| **M1** | Reproduce AirLLM's MLX layer-streaming on a small Llama (Llama-3.2-1B) using **our own loader** (mmap'd safetensors, no npz). | Generates same tokens as `mlx_lm` baseline within rounding; peak RAM ≤ size of one transformer block + activations. | 1–2 days |
+| **M2** | Swap the fp16 layer reads for TQ-quantized layer reads on the same Llama-3.2-1B (post-`convert.py`). | Same generation parity; on-disk shrinks ~5×; tok/s within 30% of M1. | 2 days |
+| **M3** | Mixtral-8x7B (or Qwen3-30B-A3B) MoE block driver. Loads only top-k experts per token, not all experts. | Generates coherent text; per-token bytes-read ≈ (active params × bytes/param) within 2×. | 3–5 days |
+| **M4** | Threadpool prefetch (layer N+1 fetch overlaps layer N compute). MLX has `mx.async_eval`/`stream` primitives — investigate before rolling our own. | ≥ 25% speedup over M3 on Mixtral; **no** generation regressions. | 2 days |
+| **M5** | DeepSeek-V3 (or equivalent reachable 1T-class) end-to-end. Accept any tok/s ≥ 0.1. | Coherent 256-token output on a stress prompt; documented on a 64 GB Mac. | 1–2 weeks (mostly arch-specific block code, KV cache, attention variants) |
+
+Total: ~4 weeks elapsed if everything goes well, more realistically
+6–8 with debugging the long tail of MoE arch quirks (latent MoE,
+multi-token-prediction heads, hybrid Mamba/attention layouts).
+
+---
+
+## 7. Open questions / decision points
+
+1. **MLX `mx.async_eval` vs. ThreadPoolExecutor.** MLX has lazy
+   evaluation; if `mx.load` is non-blocking up until the first op that
+   forces materialization, we may be able to express prefetch in pure
+   MLX without a thread pool. Needs a 10-line measurement before M4.
+
+2. **Should we ship this as part of `turboquant-mlx-full`, or a new
+   sibling package `turboquant-stream`?** Lean toward the latter — keeps
+   the install footprint of the core small for users who don't need it.
+   Decide at M3 when the API is stable enough.
+
+3. **KV cache strategy for very long context on small RAM.** Per-layer
+   KV scales linearly with sequence length. For a 1T model at 8K
+   context, KV alone can be tens of GB even at fp16. We already have
+   `TurboQuantKVCache`; making it the default in the streaming path
+   keeps RAM steady. **Wire this in at M3, not later.**
+
+4. **Speculative expert prefetch.** Naive policy: prefetch the same
+   top-k expert IDs from layer N for layer N+1. Better: train a tiny
+   predictor from a routing-trace log. Don't bother before M4.
+
+5. **Whether to attempt a *true* 1T (Kimi K2-class, ~1 T total,
+   ~30 B active) or settle for DeepSeek-V3 (671 B total, 37 B active)
+   as the headline.** K2's per-expert size is smaller (more experts,
+   so more variety, but each individually cheaper to load); V3 has
+   better-documented Apple Silicon attempts. Pick at M4 based on what
+   actually downloads cleanly.
+
+6. **Disk footprint.** A TQ-3-bit copy of Kimi K2 is ~375 GB. The
+   original BF16 is ~2 TB. The streaming layout adds ~5% overhead for
+   per-expert shard headers. Need to verify the user's disk has room.
+
+---
+
+## 8. What's reusable from AirLLM, concretely
+
+Short list — most of AirLLM doesn't help us. What does:
+
+- **The high-level driver shape** — "build empty block → load weights
+  → run → del" — `airllm_llama_mlx.py:304–323`. Sound pattern; we'll
+  mirror it.
+- **The KV-cache-list-per-layer convention** —
+  `airllm_llama_mlx.py:266–316`. Already how MLX users handle this; no
+  innovation but a clean reference.
+- **The `<layer>.done` marker convention** —
+  `mlx_model_persister.py:71`. Cheap, catches half-written shards
+  during preprocessing crashes. Worth copying.
+- **The HF→cache→split flow** — `utils.py:341
+  find_or_create_local_splitted_path`. We'll write our own (TQ- and
+  MoE-aware), but the shape of "if no local split, pull from HF, split,
+  cache" is exactly right.
+
+What we won't reuse: `map_torch_to_mlx`, `airllm_base.py` (CUDA-only),
+the bitsandbytes compression path, the BetterTransformer fallback
+plumbing, the `tok_embeddings`-renaming weight-key surgery.
+
+---
+
+## 9. Why not just contribute upstream to AirLLM
+
+Tempting, but no. Upstream is structured around HF Transformers'
+`GenerationMixin` (see `airllm_base.py:46`), which we don't use in
+turboquant-mlx. MoE-aware streaming would require gutting
+`airllm_mixtral.py` and replacing it; that's a fork, not a contribution.
+We also need TQ-quantized files as a first-class storage format, which
+they have no reason to adopt. Cleaner to build alongside and credit
+AirLLM in the README + paper as prior art.
+
+---
+
+## 10. Decision needed before code starts
+
+Pick one of:
+
+- **A.** Greenlight M1+M2 (1B Llama parity + TQ swap, ~3–4 days). Then
+  reassess at the M2/M3 boundary based on measured throughput.
+- **B.** Greenlight all the way through M3 (Mixtral MoE block, ~1 week
+  end-to-end). Larger commitment but the result is the first
+  interesting demo.
+- **C.** Hold pending arXiv submission. The streaming work doesn't
+  affect the paper as submitted; it'd be a follow-up.
+
+Recommendation: **A** — small step, fast feedback, low cost if the
+numbers don't pan out on real hardware.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.3.0"
+version = "0.4.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/stream/__init__.py
+++ b/stream/__init__.py
@@ -1,0 +1,9 @@
+"""Layer/expert streaming for TurboQuant-MLX.
+
+Runs MoE models far larger than RAM by keeping only the small resident
+tensors (norms, routers, attention, shared experts, embeddings) in memory
+and streaming the router-selected experts from an mmap'd safetensors file
+on demand, with an LRU cache.
+
+Status: proof-of-concept (qwen3_5_moe). See docs/design/layer_streaming_poc.md.
+"""

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -1,0 +1,65 @@
+"""Load a TurboQuant MoE model with its experts streamed from disk.
+
+Reuses ``load_turboquant(lazy=True)`` to build the full model with weights
+left mmap-backed and *unmaterialized*, then swaps every MoE expert layer
+(``switch_mlp.{gate,up,down}_proj``) for a ``StreamingSwitchLinear`` before any
+forward runs — so the big (num_experts, ...) expert tensors are never
+evaluated into RAM. Everything else (embeddings, norms, attention, router,
+shared expert) stays resident as usual.
+"""
+
+from __future__ import annotations
+
+import mlx.core as mx
+
+from turboquant_mlx.generate import load_turboquant, resolve_model_path
+from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
+
+from .safetensors_reader import SafetensorsExpertReader
+from .streaming_switch import ExpertCache, StreamingSwitchLinear
+
+_PROJS = ("gate_proj", "up_proj", "down_proj")
+
+
+def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False):
+    """Returns (model, tokenizer, cache).
+
+    cache_budget_gb bounds total resident expert memory (LRU-evicted).
+    """
+    local_path = str(resolve_model_path(model_path))
+    model, tok = load_turboquant(local_path, lazy=True, fast=fast)
+    reader = SafetensorsExpertReader(local_path)
+    cache = ExpertCache(reader, int(cache_budget_gb * 1e9))
+
+    layers = model.language_model.model.layers
+    prefix = "language_model.model.layers"
+    swapped = 0
+    for i, layer in enumerate(layers):
+        sm = getattr(layer.mlp, "switch_mlp", None)
+        if sm is None:
+            continue
+        for proj in _PROJS:
+            res = getattr(sm, proj, None)
+            if not isinstance(res, PolarQuantizedSwitchLinear):
+                continue
+            cb, sg = res.codebook, res.signs
+            mx.eval(cb, sg)  # tiny — pin resident, let the rest of res be freed
+            st = StreamingSwitchLinear(
+                input_dims=res.input_dims,
+                output_dims=res.output_dims,
+                num_experts=res.num_experts,
+                bits=res.bits,
+                group_size=res.group_size,
+                needs_rotation=res._needs_rotation,
+                codebook=cb,
+                signs=sg,
+                weight_key=f"{prefix}.{i}.mlp.switch_mlp.{proj}.weight",
+                scales_key=f"{prefix}.{i}.mlp.switch_mlp.{proj}.scales",
+                cache=cache,
+            )
+            setattr(sm, proj, st)
+            swapped += 1
+
+    print(f"[stream] swapped {swapped} expert projections to streaming "
+          f"(budget {cache_budget_gb:.1f} GB)")
+    return model, tok, cache

--- a/stream/safetensors_reader.py
+++ b/stream/safetensors_reader.py
@@ -1,0 +1,129 @@
+"""Read individual MoE expert slices out of mmap'd safetensors shards.
+
+TurboQuant stores each expert projection as a stacked tensor
+
+    weight: (num_experts, output_dims, packed_cols)  uint32
+    scales: (num_experts, output_dims, n_groups)      float16
+
+contiguous along the expert axis, so expert ``e`` is a single contiguous byte
+range. This reader builds an offset index across all shards and hands back
+just the bytes for one expert as an ``mx.array`` — never materializing the
+full (256, ...) tensor. That is the primitive the streaming MoE block uses to
+keep resident memory bounded.
+
+Only the dtypes that actually get streamed are supported (U32 weights, F16
+scales); everything else in the model is loaded resident the normal way.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import glob
+import json
+import os
+import struct
+from dataclasses import dataclass
+
+import numpy as np
+import mlx.core as mx
+
+# macOS: tell the OS not to keep this fd's data in the unified buffer cache,
+# so streaming 14+ GB of expert slices doesn't balloon resident page cache on
+# a memory-constrained machine. Advisory; pairs with our own LRU expert cache.
+_F_NOCACHE = getattr(fcntl, "F_NOCACHE", 48)
+
+# safetensors dtype string -> (numpy dtype, itemsize, mlx dtype)
+_DTYPES = {
+    "U32": (np.uint32, 4, mx.uint32),
+    "F16": (np.float16, 2, mx.float16),
+    "F32": (np.float32, 4, mx.float32),
+}
+
+
+@dataclass
+class _TensorLoc:
+    file_idx: int          # index into self._mmaps
+    dtype: str             # safetensors dtype string
+    shape: tuple           # full tensor shape
+    abs_begin: int         # absolute byte offset of element 0 in the file
+
+
+class SafetensorsExpertReader:
+    """Offset index + mmap pool for reading per-expert weight/scale slices.
+
+    Parameters
+    ----------
+    model_path : str
+        Directory holding ``model*.safetensors``.
+    """
+
+    def __init__(self, model_path: str):
+        self.model_path = model_path
+        files = sorted(glob.glob(os.path.join(model_path, "model*.safetensors")))
+        if not files:
+            raise FileNotFoundError(f"No model*.safetensors in {model_path}")
+        self._files = files
+        self._fds: list[int] = []
+        self._index: dict[str, _TensorLoc] = {}
+
+        for fi, f in enumerate(files):
+            fd = os.open(f, os.O_RDONLY)
+            try:
+                fcntl.fcntl(fd, _F_NOCACHE, 1)
+            except OSError:
+                pass  # F_NOCACHE is best-effort
+            self._fds.append(fd)
+            header_len = struct.unpack("<Q", os.pread(fd, 8, 0))[0]
+            header = json.loads(os.pread(fd, header_len, 8))
+            data_start = 8 + header_len  # tensor data section begins here
+            for name, meta in header.items():
+                if name == "__metadata__":
+                    continue
+                begin, _end = meta["data_offsets"]
+                self._index[name] = _TensorLoc(
+                    file_idx=fi,
+                    dtype=meta["dtype"],
+                    shape=tuple(meta["shape"]),
+                    abs_begin=data_start + begin,
+                )
+
+    # -- introspection -------------------------------------------------
+    def has(self, key: str) -> bool:
+        return key in self._index
+
+    def shape(self, key: str) -> tuple:
+        return self._index[key].shape
+
+    def num_experts(self, key: str) -> int:
+        return self._index[key].shape[0]
+
+    # -- the hot path --------------------------------------------------
+    def read_expert(self, key: str, expert: int) -> mx.array:
+        """Return slice ``[expert]`` of a stacked tensor as an mx.array.
+
+        For a tensor of shape (E, d0, d1, ...) this returns shape (d0, d1, ...)
+        and copies only that expert's bytes into an MLX buffer.
+        """
+        loc = self._index[key]
+        np_dt, itemsize, mlx_dt = _DTYPES[loc.dtype]
+        per_expert = 1
+        for d in loc.shape[1:]:
+            per_expert *= d
+        nbytes = per_expert * itemsize
+        start = loc.abs_begin + expert * nbytes
+        # pread on an F_NOCACHE fd: copies just this expert's bytes, without
+        # growing the resident page cache.
+        raw = os.pread(self._fds[loc.file_idx], nbytes, start)
+        buf = np.frombuffer(raw, dtype=np_dt, count=per_expert)
+        return mx.array(buf.reshape(loc.shape[1:]), dtype=mlx_dt)
+
+    def close(self):
+        for fd in self._fds:
+            try:
+                os.close(fd)
+            except Exception:
+                pass
+        self._fds = []
+
+    def __del__(self):
+        self.close()

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -63,8 +63,10 @@ def main():
                         sampler=sampler, verbose=True)
     dt = time.time() - t
     print("=" * 60)
-    n = args.max_tokens
-    print(f"[stream] {n} tok in {dt:.1f}s = {n / dt:.1f} tok/s | "
+    # Count tokens actually generated (the model may stop at EOS before
+    # max_tokens) — dividing max_tokens by wall-time overstates the rate.
+    n = len(tok.encode(text))
+    print(f"[stream] {n} generated tok in {dt:.1f}s = {n / dt:.1f} tok/s (end-to-end) | "
           f"peak RSS={_rss_gb():.2f} GB | mlx_peak={mx.get_peak_memory() / 1e9:.2f} GB")
     s = cache.stats()
     print(f"[stream] expert cache: hit_rate={s['hit_rate']:.1%} resident={s['resident_gb']:.2f} GB "

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -1,0 +1,75 @@
+"""Generate from a TurboQuant MoE model with experts streamed from disk.
+
+Runs a model whose weights exceed available RAM by keeping only the resident
+tensors in memory and streaming router-selected experts on demand.
+
+Example (Qwen3.6-35B-A3B, ~16 GB on disk, runs in ~5 GB RAM):
+
+    python -m turboquant_mlx.stream.stream_generate \\
+        --model manjunathshiva/Qwen3.6-35B-A3B-tq3-g32 \\
+        --prompt "Explain why the sky is blue." \\
+        --max-tokens 256 --cache-budget-gb 3
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import subprocess
+import time
+
+import mlx.core as mx
+
+import turboquant_mlx.compat  # noqa: F401
+from mlx_lm import generate as mlx_generate
+from mlx_lm.sample_utils import make_sampler
+
+from .loader import load_streaming
+
+
+def _rss_gb() -> float:
+    out = subprocess.check_output(["ps", "-o", "rss=", "-p", str(os.getpid())])
+    return int(out) / 1024 / 1024
+
+
+def main():
+    p = argparse.ArgumentParser(
+        description="Stream-generate from a TurboQuant MoE model (experts paged from disk)."
+    )
+    p.add_argument("--model", required=True, help="Local path or HF repo id of a TurboQuant model.")
+    p.add_argument("--prompt", default="Why is the sky blue?")
+    p.add_argument("--max-tokens", type=int, default=256)
+    p.add_argument("--temp", type=float, default=0.7)
+    p.add_argument("--cache-budget-gb", type=float, default=3.0,
+                   help="Max resident expert memory (LRU-evicted). Lower = less RAM, more disk reads.")
+    p.add_argument("--fast", action="store_true", help="Disable QJL correction for faster decode.")
+    p.add_argument("--no-chat-template", action="store_true")
+    args = p.parse_args()
+
+    t0 = time.time()
+    model, tok, cache = load_streaming(args.model, cache_budget_gb=args.cache_budget_gb, fast=args.fast)
+    print(f"[stream] loaded in {time.time() - t0:.1f}s | resident RSS={_rss_gb():.2f} GB")
+
+    prompt = args.prompt
+    if not args.no_chat_template and hasattr(tok, "apply_chat_template"):
+        prompt = tok.apply_chat_template(
+            [{"role": "user", "content": args.prompt}], add_generation_prompt=True
+        )
+
+    sampler = make_sampler(temp=args.temp)
+    print("=" * 60)
+    t = time.time()
+    text = mlx_generate(model, tok, prompt=prompt, max_tokens=args.max_tokens,
+                        sampler=sampler, verbose=True)
+    dt = time.time() - t
+    print("=" * 60)
+    n = args.max_tokens
+    print(f"[stream] {n} tok in {dt:.1f}s = {n / dt:.1f} tok/s | "
+          f"peak RSS={_rss_gb():.2f} GB | mlx_peak={mx.get_peak_memory() / 1e9:.2f} GB")
+    s = cache.stats()
+    print(f"[stream] expert cache: hit_rate={s['hit_rate']:.1%} resident={s['resident_gb']:.2f} GB "
+          f"disk_read={s['bytes_read_gb']:.1f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -1,0 +1,188 @@
+"""Streaming replacement for PolarQuantizedSwitchLinear.
+
+Holds no resident expert weights. On each forward it discovers the
+router-selected experts, loads *only those* expert slices from the mmap'd
+safetensors (through an LRU ``ExpertCache``), and runs the exact same fused
+polar kernels as the resident layer — assembling a small (n_selected, ...)
+weight stack and remapping the routing indices to local positions.
+
+Output is numerically identical to PolarQuantizedSwitchLinear because it uses
+the same kernels on the same expert bytes; only the *set* of experts present
+in memory at any moment differs.
+"""
+
+from __future__ import annotations
+
+import math
+from collections import OrderedDict
+
+import numpy as np
+import mlx.core as mx
+import mlx.nn as nn
+
+from turboquant_mlx.core.rotation import rotate_input
+from turboquant_mlx.kernels.polar_gather_qmv import polar_gather_qmv
+from turboquant_mlx.kernels.polar_multi_gather_qmv import polar_multi_gather_qmv
+
+
+class ExpertCache:
+    """Process-wide LRU cache of per-expert (weight, scales) mx.arrays.
+
+    Shared across every streaming layer so a single byte budget bounds the
+    total resident expert memory. Keyed by (weight_key, expert) which is
+    globally unique (weight_key already encodes layer + projection).
+    """
+
+    def __init__(self, reader, budget_bytes: int):
+        self.reader = reader
+        self.budget = budget_bytes
+        self.cur = 0
+        self._od: "OrderedDict[tuple, tuple]" = OrderedDict()
+        # stats
+        self.hits = 0
+        self.misses = 0
+        self.bytes_read = 0
+
+    def _get_one(self, wkey: str, skey: str, e: int):
+        ck = (wkey, e)
+        hit = self._od.get(ck)
+        if hit is not None:
+            self._od.move_to_end(ck)
+            self.hits += 1
+            return hit[0], hit[1]
+        w = self.reader.read_expert(wkey, e)
+        s = self.reader.read_expert(skey, e)
+        mx.eval(w, s)  # force the slice copy out of mmap into an MLX buffer now
+        nb = w.nbytes + s.nbytes
+        self._od[ck] = (w, s, nb)
+        self.cur += nb
+        self.misses += 1
+        self.bytes_read += nb
+        self._evict()
+        return w, s
+
+    def _evict(self):
+        while self.cur > self.budget and len(self._od) > 1:
+            _, (_w, _s, nb) = self._od.popitem(last=False)
+            self.cur -= nb
+
+    def gather(self, wkey: str, skey: str, experts: list[int]):
+        """Return stacked (n, out, packed) weight + (n, out, ng) scales for
+        ``experts`` (in the given order)."""
+        ws, ss = [], []
+        for e in experts:
+            w, s = self._get_one(wkey, skey, e)
+            ws.append(w)
+            ss.append(s)
+        return mx.stack(ws, axis=0), mx.stack(ss, axis=0)
+
+    def stats(self):
+        tot = self.hits + self.misses
+        return {
+            "hit_rate": (self.hits / tot) if tot else 0.0,
+            "hits": self.hits,
+            "misses": self.misses,
+            "resident_experts": len(self._od),
+            "resident_gb": self.cur / 1e9,
+            "bytes_read_gb": self.bytes_read / 1e9,
+        }
+
+
+class StreamingSwitchLinear(nn.Module):
+    """Drop-in for PolarQuantizedSwitchLinear that streams experts from disk."""
+
+    def __init__(
+        self,
+        *,
+        input_dims: int,
+        output_dims: int,
+        num_experts: int,
+        bits: int,
+        group_size: int,
+        needs_rotation: bool,
+        codebook: mx.array,
+        signs: mx.array,
+        weight_key: str,
+        scales_key: str,
+        cache: ExpertCache,
+    ):
+        super().__init__()
+        self.input_dims = input_dims
+        self.output_dims = output_dims
+        self.num_experts = num_experts
+        self.bits = bits
+        self.group_size = group_size
+        self._needs_rotation = needs_rotation
+        # small resident tensors
+        self.codebook = codebook
+        self.signs = signs
+        # streaming wiring (underscored so they are not treated as params)
+        self._weight_key = weight_key
+        self._scales_key = scales_key
+        self._cache = cache
+        self.freeze()
+
+    def _dequantize_selected(self, w_sel: mx.array, s_sel: mx.array) -> mx.array:
+        """Dequantize only the selected experts to float16 (prefill path).
+
+        Mirrors PolarQuantizedSwitchLinear._dequantize_all but on an
+        (n_sel, out, packed) stack instead of all num_experts.
+        """
+        from turboquant_mlx.core.packing import unpack_indices
+        from turboquant_mlx.core.codebook import dequantize_scalar
+
+        n_sel = w_sel.shape[0]
+        n_groups = self.input_dims // self.group_size
+        idx = unpack_indices(w_sel, self.bits, self.input_dims)
+        w_deq = dequantize_scalar(idx, self.codebook)
+        w_deq = w_deq.reshape(n_sel, self.output_dims, n_groups, self.group_size)
+        w_deq = w_deq * mx.expand_dims(s_sel, axis=-1)
+        return w_deq.reshape(n_sel, self.output_dims, self.input_dims)
+
+    def __call__(self, x, indices, sorted_indices=False):
+        if self._needs_rotation:
+            x = rotate_input(x, self.signs)
+
+        n_tokens = 1 if x.ndim <= 2 else math.prod(x.shape[:-2])
+        k = indices.shape[-1] if indices.ndim >= 1 else 1
+
+        # Discover selected experts (forces a tiny GPU->CPU sync on the
+        # routing indices — unavoidable: we must know what to load).
+        idx_global = np.asarray(
+            indices.reshape(-1).astype(mx.uint32).tolist(), dtype=np.int64
+        )
+        sel = sorted(set(int(v) for v in idx_global))
+        remap = {e: i for i, e in enumerate(sel)}
+        w_sel, s_sel = self._cache.gather(self._weight_key, self._scales_key, sel)
+        idx_local_flat = mx.array([remap[int(v)] for v in idx_global], dtype=mx.uint32)
+
+        if n_tokens == 1:
+            x_flat = x.reshape(-1)
+            y = polar_gather_qmv(
+                w_sel, s_sel, self.codebook,
+                x_flat, idx_local_flat, self.bits, self.group_size,
+            )
+            return y.reshape(list(indices.shape) + [1, self.output_dims])
+
+        if n_tokens == k:
+            x_2d = x.reshape(k, self.input_dims)
+            y = polar_multi_gather_qmv(
+                w_sel, s_sel, self.codebook,
+                x_2d, idx_local_flat, self.bits, self.group_size,
+            )
+            return y.reshape(list(indices.shape) + [1, self.output_dims])
+
+        # Prefill: dequantize only the selected experts, gather_mm locally.
+        w_deq = self._dequantize_selected(w_sel, s_sel)
+        idx_local = idx_local_flat.reshape(indices.shape)
+        return mx.gather_mm(
+            x, w_deq.swapaxes(-1, -2),
+            rhs_indices=idx_local, sorted_indices=False,
+        )
+
+    def _extra_repr(self):
+        return (
+            f"input_dims={self.input_dims}, output_dims={self.output_dims}, "
+            f"num_experts={self.num_experts}, bits={self.bits}, "
+            f"group_size={self.group_size}, STREAMING key={self._weight_key}"
+        )


### PR DESCRIPTION
## Summary

Adds `turboquant_mlx.stream` — per-expert disk streaming for `qwen3_5_moe` MoE
checkpoints — so a model whose weights exceed available RAM can run by paging
only the router-selected experts from disk per token (LRU-cached). The full
`(num_experts, …)` expert tensors are never all resident. Bumps the package to
**0.4.0**.

### What's in `stream/`
- `safetensors_reader.py` — reads one expert's contiguous byte slice via
  `os.pread` + macOS `F_NOCACHE` (keeps resident page cache from ballooning).
- `streaming_switch.py` — `StreamingSwitchLinear` + byte-budgeted LRU
  `ExpertCache`; reuses the existing `polar_gather_qmv` / `polar_multi_gather_qmv`
  decode kernels, which already touch only the selected experts.
- `loader.py` — `load_streaming()` swaps the expert projections after a
  `lazy=True` load, before the big tensors materialize.
- `stream_generate.py` — CLI with `--cache-budget-gb`.

## Validation

Output is **bit-identical** to the fully-resident model (greedy end-to-end
output identical; decode max_abs_diff = 0).

Measured on a **base 16 GB Apple M4 Mac mini** running the ~16 GB
`manjunathshiva/Qwen3.6-35B-A3B-tq3-g32` (256 experts):

| `--cache-budget-gb` | hit-rate | disk read / tok | decode | peak RSS |
|---|---|---|---|---|
| 2 | ~60% | ~175 MB | ~3.0 tok/s | 3.9 GB |
| 8 | 91% | ~41 MB | ~4.5 tok/s | 9.4 GB |

A 35B model runs in <4 GB RAM with no sysctl bump; raising the cache budget
trades RAM for fewer SSD reads (the throughput limiter) and ~50% more speed.

## Notes / scope
- Targets the `qwen3_5_moe` expert layout
  (`language_model.model.layers[*].mlp.switch_mlp.{gate,up,down}_proj`);
  generalizing to other MoE archs is future work.
- Also fixes a `stream_generate` tok/s mis-report (divided by `--max-tokens`
  instead of tokens actually generated).