### PR TITLE
Fix: include turboquant_mlx.stream in the package (0.4.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.4.1] - 2026-05-25
+
+### Fixed
+
+- **Packaging: `turboquant_mlx.stream` was omitted from the 0.4.0
+  distribution.** The `[tool.setuptools] packages` list enumerates packages
+  explicitly and the new `stream` subpackage was not added, so 0.4.0 shipped
+  without the streaming code (`import turboquant_mlx.stream` failed after a
+  PyPI install; the feature was only reachable from a source checkout). Added
+  `turboquant_mlx.stream` to the packages list. Expert streaming now works
+  from `pip install turboquant-mlx-full`.
+
 ## [0.4.0] - 2026-05-25
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.4.0"
+__version__ = "0.4.1"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.4.0"
+version = "0.4.1"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -67,6 +67,7 @@ packages = [
     "turboquant_mlx.layers",
     "turboquant_mlx.kernels",
     "turboquant_mlx.integration",
+    "turboquant_mlx.stream",
 ]
 include-package-data = true
 


### PR DESCRIPTION
## Problem

`turboquant-mlx-full==0.4.0` shipped **without the streaming code**. The
`[tool.setuptools] packages` list in `pyproject.toml` enumerates packages
explicitly, and the `turboquant_mlx.stream` subpackage (added in 0.4.0) was
never added to it. Confirmed against the published sdist — it contains
`core`, `layers`, `kernels`, `integration` but **no `stream/`**. So
`import turboquant_mlx.stream` fails after `pip install`; the feature was only
reachable from a source checkout.

## Fix

- Add `turboquant_mlx.stream` to the `packages` list.
- Bump to **0.4.1** (`__init__.py` + `pyproject.toml`) + CHANGELOG entry.

## Verification

Rebuilt the sdist locally — it now includes all five stream modules:

```
turboquant_mlx_full-0.4.1/stream/__init__.py
turboquant_mlx_full-0.4.1/stream/loader.py
turboquant_mlx_full-0.4.1/stream/safetensors_reader.py
turboquant_mlx_full-0.4.1/stream/stream_generate.py
turboquant_mlx_full-0.4.1/stream/streaming_switch.py
```