### PR TITLE
stream: parallel expert prefetch (v0.5.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,29 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2026-05-26
+
+### Added
+
+- **Parallel expert prefetch for streaming MoE (`turboquant_mlx.stream`).**
+  The experts missing for a layer are now `pread` concurrently on a thread
+  pool instead of one at a time. Because `pread` is positional and releases
+  the GIL, the per-layer disk stall drops from the sum of the slice reads to
+  roughly the slowest one; MLX array construction and `eval` stay on the
+  calling thread, so output is **bit-identical** to the serial path. Controlled
+  by `--prefetch-workers` (default `8`; `1` restores the old serial behavior).
+  Measured on Qwen3.6-35B-A3B-tq3-g32 at a 1 GB cache budget: decode **3.2 →
+  6.0 tok/s (~1.9×)** and prefill **5.4 → 13.9 tok/s (~2.6×)**, same 3.48 GB
+  peak, identical generated text.
+
+### Notes
+
+- Frequency-based hot-expert *pinning* was prototyped alongside prefetch and
+  **rejected**: reserving budget for a frozen "hot" set consistently lowered
+  the cache hit rate versus a plain adaptive LRU in single-stream decode
+  (49.0% → 38.8% at the same 1 GB budget), because the tight-budget streaming
+  regime is exactly where starving the LRU hurts most. Not shipped.
+
 ## [0.4.1] - 2026-05-25
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -558,6 +558,8 @@ turboquant-generate \
 
 The model is ~16 GB on disk, so it won't fit fully resident in 16 GB alongside the OS (resident decode peaks ~18 GB). Expert streaming pages only the router-selected experts from disk per token (LRU-cached), keeping resident memory to a few GB. Output is **bit-identical** to the fully-resident model. (`os.pread` + macOS `F_NOCACHE` keep the OS page cache from ballooning while streaming.)
 
+Since `v0.5.0` the missing experts for each layer are read **in parallel** on a thread pool (`--prefetch-workers`, default `8`), hiding SSD latency behind compute — ~1.9× faster decode at a tight cache budget, still bit-identical. Pass `--prefetch-workers 1` for the serial baseline.
+
 ```bash
 python -m turboquant_mlx.stream.stream_generate \
     --model manjunathshiva/Qwen3.6-35B-A3B-tq3-g32 \

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.4.1"
+__version__ = "0.5.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.4.1"
+version = "0.5.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -21,15 +21,20 @@ from .streaming_switch import ExpertCache, StreamingSwitchLinear
 _PROJS = ("gate_proj", "up_proj", "down_proj")
 
 
-def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False):
+def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
+                   prefetch_workers: int = 8):
     """Returns (model, tokenizer, cache).
 
     cache_budget_gb bounds total resident expert memory (LRU-evicted).
+    prefetch_workers parallelizes per-layer expert reads (1 = serial baseline).
     """
     local_path = str(resolve_model_path(model_path))
     model, tok = load_turboquant(local_path, lazy=True, fast=fast)
     reader = SafetensorsExpertReader(local_path)
-    cache = ExpertCache(reader, int(cache_budget_gb * 1e9))
+    cache = ExpertCache(
+        reader, int(cache_budget_gb * 1e9),
+        prefetch_workers=prefetch_workers,
+    )
 
     layers = model.language_model.model.layers
     prefix = "language_model.model.layers"

--- a/stream/safetensors_reader.py
+++ b/stream/safetensors_reader.py
@@ -98,11 +98,16 @@ class SafetensorsExpertReader:
         return self._index[key].shape[0]
 
     # -- the hot path --------------------------------------------------
-    def read_expert(self, key: str, expert: int) -> mx.array:
-        """Return slice ``[expert]`` of a stacked tensor as an mx.array.
+    def read_expert_np(self, key: str, expert: int):
+        """Return ``(numpy_array, mlx_dtype)`` for slice ``[expert]``.
 
-        For a tensor of shape (E, d0, d1, ...) this returns shape (d0, d1, ...)
-        and copies only that expert's bytes into an MLX buffer.
+        This is the disk half of :meth:`read_expert`: a positional ``os.pread``
+        (which releases the GIL and ignores the file offset, so it is safe to
+        call concurrently on the same fd) plus a zero-copy ``np.frombuffer``
+        view. The MLX array — which we keep on a single thread — is built by
+        the caller. Splitting it this way lets the expert cache fan the
+        per-layer ``pread``s across a thread pool without ever touching MLX
+        from a worker thread.
         """
         loc = self._index[key]
         np_dt, itemsize, mlx_dt = _DTYPES[loc.dtype]
@@ -114,8 +119,17 @@ class SafetensorsExpertReader:
         # pread on an F_NOCACHE fd: copies just this expert's bytes, without
         # growing the resident page cache.
         raw = os.pread(self._fds[loc.file_idx], nbytes, start)
-        buf = np.frombuffer(raw, dtype=np_dt, count=per_expert)
-        return mx.array(buf.reshape(loc.shape[1:]), dtype=mlx_dt)
+        buf = np.frombuffer(raw, dtype=np_dt, count=per_expert).reshape(loc.shape[1:])
+        return buf, mlx_dt
+
+    def read_expert(self, key: str, expert: int) -> mx.array:
+        """Return slice ``[expert]`` of a stacked tensor as an mx.array.
+
+        For a tensor of shape (E, d0, d1, ...) this returns shape (d0, d1, ...)
+        and copies only that expert's bytes into an MLX buffer.
+        """
+        buf, mlx_dt = self.read_expert_np(key, expert)
+        return mx.array(buf, dtype=mlx_dt)
 
     def close(self):
         for fd in self._fds:

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -42,12 +42,17 @@ def main():
     p.add_argument("--temp", type=float, default=0.7)
     p.add_argument("--cache-budget-gb", type=float, default=3.0,
                    help="Max resident expert memory (LRU-evicted). Lower = less RAM, more disk reads.")
+    p.add_argument("--prefetch-workers", type=int, default=8,
+                   help="Threads for parallel per-layer expert reads. 1 = serial baseline.")
     p.add_argument("--fast", action="store_true", help="Disable QJL correction for faster decode.")
     p.add_argument("--no-chat-template", action="store_true")
     args = p.parse_args()
 
     t0 = time.time()
-    model, tok, cache = load_streaming(args.model, cache_budget_gb=args.cache_budget_gb, fast=args.fast)
+    model, tok, cache = load_streaming(
+        args.model, cache_budget_gb=args.cache_budget_gb, fast=args.fast,
+        prefetch_workers=args.prefetch_workers,
+    )
     print(f"[stream] loaded in {time.time() - t0:.1f}s | resident RSS={_rss_gb():.2f} GB")
 
     prompt = args.prompt

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import math
 from collections import OrderedDict
+from concurrent.futures import ThreadPoolExecutor
 
 import numpy as np
 import mlx.core as mx
@@ -31,9 +32,16 @@ class ExpertCache:
     Shared across every streaming layer so a single byte budget bounds the
     total resident expert memory. Keyed by (weight_key, expert) which is
     globally unique (weight_key already encodes layer + projection).
+
+    The experts missing for a single ``gather`` are read in one batch and,
+    when ``prefetch_workers > 1``, their ``pread``s are fanned across a thread
+    pool. ``pread`` releases the GIL, so the per-layer disk stall drops from the
+    sum of the slice reads to roughly the slowest one. MLX array construction
+    and ``eval`` stay on the calling thread, so the produced tensors are
+    bit-identical to the serial path.
     """
 
-    def __init__(self, reader, budget_bytes: int):
+    def __init__(self, reader, budget_bytes: int, *, prefetch_workers: int = 8):
         self.reader = reader
         self.budget = budget_bytes
         self.cur = 0
@@ -42,39 +50,82 @@ class ExpertCache:
         self.hits = 0
         self.misses = 0
         self.bytes_read = 0
+        # parallel prefetch
+        self._workers = max(1, int(prefetch_workers))
+        self._pool = (ThreadPoolExecutor(max_workers=self._workers)
+                      if self._workers > 1 else None)
 
-    def _get_one(self, wkey: str, skey: str, e: int):
-        ck = (wkey, e)
-        hit = self._od.get(ck)
-        if hit is not None:
-            self._od.move_to_end(ck)
-            self.hits += 1
-            return hit[0], hit[1]
-        w = self.reader.read_expert(wkey, e)
-        s = self.reader.read_expert(skey, e)
-        mx.eval(w, s)  # force the slice copy out of mmap into an MLX buffer now
-        nb = w.nbytes + s.nbytes
-        self._od[ck] = (w, s, nb)
-        self.cur += nb
-        self.misses += 1
-        self.bytes_read += nb
-        self._evict()
-        return w, s
+    # -- loading -------------------------------------------------------
+    def _load_serial(self, miss_pairs):
+        out = {}
+        for wkey, skey, e in miss_pairs:
+            w = self.reader.read_expert(wkey, e)
+            s = self.reader.read_expert(skey, e)
+            mx.eval(w, s)  # force the slice copy out of mmap into an MLX buffer
+            out[(wkey, e)] = (w, s, w.nbytes + s.nbytes)
+        return out
+
+    def _load_parallel(self, miss_pairs):
+        # fan the (GIL-releasing) preads across the pool, then build + eval the
+        # MLX arrays on this thread so MLX is never touched from a worker.
+        tasks = []
+        for wkey, skey, e in miss_pairs:
+            tasks.append((wkey, e))
+            tasks.append((skey, e))
+        bufs = list(self._pool.map(lambda t: self.reader.read_expert_np(*t), tasks))
+        arrs = [mx.array(buf, dtype=dt) for (buf, dt) in bufs]
+        mx.eval(*arrs)
+        out = {}
+        for i, (wkey, _skey, e) in enumerate(miss_pairs):
+            w, s = arrs[2 * i], arrs[2 * i + 1]
+            out[(wkey, e)] = (w, s, w.nbytes + s.nbytes)
+        return out
 
     def _evict(self):
         while self.cur > self.budget and len(self._od) > 1:
-            _, (_w, _s, nb) = self._od.popitem(last=False)
+            _, (_w, _s, nb) = self._od.popitem(last=False)  # oldest
             self.cur -= nb
 
     def gather(self, wkey: str, skey: str, experts: list[int]):
         """Return stacked (n, out, packed) weight + (n, out, ng) scales for
         ``experts`` (in the given order)."""
+        # classify against the current resident set, then load all misses in
+        # one (optionally parallel) batch.
+        miss_pairs = []
+        for e in experts:
+            ck = (wkey, e)
+            if ck in self._od:
+                self.hits += 1
+            else:
+                self.misses += 1
+                miss_pairs.append((wkey, skey, e))
+
+        if miss_pairs:
+            loaded = (self._load_parallel(miss_pairs) if self._pool
+                      else self._load_serial(miss_pairs))
+            for ck, entry in loaded.items():
+                self._od[ck] = entry
+                self.cur += entry[2]
+                self.bytes_read += entry[2]
+
+        # Build the stack *before* evicting so freshly loaded slices are still
+        # present (and held by ``ws``/``ss``, so eviction can't free them out
+        # from under this call).
         ws, ss = [], []
         for e in experts:
-            w, s = self._get_one(wkey, skey, e)
+            ck = (wkey, e)
+            w, s, _ = self._od[ck]
+            self._od.move_to_end(ck)
             ws.append(w)
             ss.append(s)
+
+        self._evict()
         return mx.stack(ws, axis=0), mx.stack(ss, axis=0)
+
+    def close(self):
+        if self._pool is not None:
+            self._pool.shutdown(wait=False)
+            self._pool = None
 
     def stats(self):
         tot = self.hits + self.misses

--- a/tests/test_stream_cache.py
+++ b/tests/test_stream_cache.py
@@ -1,0 +1,72 @@
+"""Unit tests for the streaming ExpertCache parallel prefetch.
+
+These exercise the cache logic with a fake reader (no model, no disk), so they
+run in CI in milliseconds. The invariant that protects the feature: parallel
+prefetch is *byte-identical* to the serial baseline.
+"""
+
+import numpy as np
+import mlx.core as mx
+
+from turboquant_mlx.stream.streaming_switch import ExpertCache
+
+
+class FakeReader:
+    """Deterministic stand-in for SafetensorsExpertReader.
+
+    weight slices are uint32, scales slices are float16; each expert's content
+    is a unique function of (key, expert) so byte-equality is meaningful.
+    """
+
+    def __init__(self, cols: int = 8):
+        self.cols = cols
+        self.read_calls = 0
+
+    def _content(self, key: str, expert: int):
+        if "scales" in key:
+            return (np.arange(self.cols, dtype=np.float16) + expert), mx.float16
+        return (np.arange(self.cols, dtype=np.uint32) + expert * 10), mx.uint32
+
+    def read_expert_np(self, key: str, expert: int):
+        self.read_calls += 1
+        return self._content(key, expert)
+
+    def read_expert(self, key: str, expert: int):
+        buf, dt = self._content(key, expert)
+        return mx.array(buf, dtype=dt)
+
+
+def _gather_np(workers, experts):
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=workers)
+    w, s = cache.gather("L0.gate.weight", "L0.gate.scales", experts)
+    return np.array(w), np.array(s)
+
+
+def test_parallel_matches_serial():
+    w1, s1 = _gather_np(1, [3, 1, 2, 7, 0])
+    w8, s8 = _gather_np(8, [3, 1, 2, 7, 0])
+    assert np.array_equal(w1, w8)
+    assert np.array_equal(s1, s8)
+
+
+def test_gather_preserves_expert_order():
+    # weight content at column 0 is expert*10, so the stack must echo the
+    # requested order regardless of parallel scheduling.
+    w, _ = _gather_np(4, [5, 0, 2])
+    assert [int(w[i][0]) for i in range(3)] == [50, 0, 20]
+
+
+def test_hit_miss_accounting():
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=1)
+    cache.gather("k.weight", "k.scales", [0, 1])
+    assert cache.misses == 2 and cache.hits == 0
+    cache.gather("k.weight", "k.scales", [0, 1])
+    assert cache.hits == 2 and cache.misses == 2
+
+
+def test_eviction_respects_budget():
+    cache = ExpertCache(FakeReader(), budget_bytes=200, prefetch_workers=1)
+    for e in range(40):
+        cache.gather("k.weight", "k.scales", [e])
+    # never grows unbounded: resident bytes stay within ~one entry of budget.
+    assert cache.cur <= 200 + 48


### PR DESCRIPTION
Fan the per-layer expert `pread`s across a thread pool instead of reading them one at a time. `pread` is positional and releases the GIL, so the per-layer disk stall drops from the sum of the slice reads to roughly the slowest one; MLX array construction and `eval` stay on the calling thread, so output is **bit-identical** to the serial path.

Controlled by `--prefetch-workers` (default `8`; `1` restores the old serial behavior).

## Validation (this 64 GB M4 Max, greedy, md5-verified)

| Model | Cache budget | workers 1 → 8 | Peak | Output |
|-------|--------------|---------------|------|--------|
| Qwen3.6-35B-A3B | 1 GB | decode 3.2 → 6.0 tok/s (~1.9×) | 3.48 GB (unchanged) | identical |
| Qwen3.5-122B-A10B | 4 GB | decode 1.74 → 2.90 tok/s (~1.67×) | 9.16 GB (unchanged) | identical |

On the 122B the hit rate (41.3%) and total disk read (102.6 GB) are **identical** between serial and parallel — prefetch changes only *when* reads happen, not *what* is read. The speedup is pure SSD-read/compute overlap.

## Rejected: hot-expert pinning

Frequency-based pinning was prototyped alongside this and **dropped**: reserving cache budget for a frozen "hot" set consistently lowered the LRU hit rate in single-stream decode (35B @ 1 GB: 49.0% → 38.8% at 768-pin, → 46.6% at 256-pin), because the tight-budget streaming regime is exactly where starving the adaptive LRU hurts most. Documented in CHANGELOG; no pinning code ships.

## Changes
- `stream/safetensors_reader.py`: split out `read_expert_np` (the GIL-releasing `pread` half) so reads can run on worker threads.
- `stream/streaming_switch.py`: `ExpertCache` batches misses and reads them via a `ThreadPoolExecutor` (`prefetch_workers`); serial path preserved at `workers=1`.
- `stream/loader.py`, `stream/stream_generate.py`: thread `--prefetch-workers` through.
- `tests/test_stream_cache.py`: FakeReader unit tests incl. the parallel==serial byte-identity guard.
- Version 0.4.1 → 0.5.0; CHANGELOG + README updated.