### PR TITLE
feat: DeepSeek (MLA + MoE) conversion + streaming support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,23 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **DeepSeek (MLA + MoE) conversion + streaming support.** Added a rotation
+  config for the DeepSeek Multi-head Latent Attention + SwitchGLU-MoE family
+  (`deepseek_v2`, `deepseek_v3`, `deepseek_v32`). MLA's input projections
+  (`q_proj`/`q_a_proj`/`kv_a_proj_with_mqa`) fuse into `input_layernorm`; the
+  `q_b_proj`/`kv_b_proj` (nested-norm inputs) and `o_proj` use online rotation;
+  the MoE/MLP fuses exactly like `qwen3_5_moe`. Validated end-to-end on
+  DeepSeek-V2-Lite-Chat: converted to tq3 (6.6 GB) and coherent both resident
+  (~84 tok/s) and via expert streaming. V3/V3.2 reuse the same config (untested,
+  pending a conversion). The streaming loader (`turboquant_mlx.stream`) now
+  auto-detects the layer-key prefix, supporting both the multimodal
+  `language_model.model.layers` layout (qwen3_5_moe) and the text-only
+  `model.model.layers` layout (DeepSeek).
+
 ## [0.5.0] - 2026-05-26
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -633,7 +633,7 @@ python -m turboquant_mlx.stream.stream_generate \
 | `--cache-budget-gb 2` | ~60% | ~175 MB | ~3.0 tok/s | **3.9 GB** |
 | `--cache-budget-gb 8` *(recommended)* | **91%** | ~41 MB | **~4.5 tok/s** | 9.4 GB |
 
-A larger cache keeps more experts resident, raising the hit-rate and cutting SSD reads — the throughput limiter when streaming. `--cache-budget-gb 8` is the sweet spot on a 16 GB machine; drop to `2` if RAM is tight. Streaming currently targets the `qwen3_5_moe` expert layout.
+A larger cache keeps more experts resident, raising the hit-rate and cutting SSD reads — the throughput limiter when streaming. `--cache-budget-gb 8` is the sweet spot on a 16 GB machine; drop to `2` if RAM is tight. Streaming targets the SwitchGLU expert layout used by `qwen3_5_moe` and the DeepSeek MLA+MoE family (`deepseek_v2`/`v3`); the loader auto-detects the model's layer-key prefix.
 
 > **Note:** Qwen3.6 is a thinking-mode model — it emits a reasoning trace before the final answer, so give it a generous `--max-tokens` (512+) for tasks that need a concluding answer.
 
@@ -781,6 +781,7 @@ Options:
 | GPT-OSS | `gpt_oss` | Yes | Tested |
 | Qwen3.5-MoE / Qwen3.6-35B-A3B | `qwen3_5_moe` | Yes (256 experts) | Tested (122B, 35B-A3B); 35B streams on a 16 GB Mac mini |
 | Nemotron-H (Mamba/attention hybrid) | `nemotron_h` | Yes (512 experts w/ latent MoE on Super-120B) | Tested (Nano-4B, Super-120B) — requires mlx-lm ≥ 0.31.3 |
+| DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
 
 ## Project Structure
 

--- a/integration/rotation_configs.py
+++ b/integration/rotation_configs.py
@@ -106,6 +106,29 @@ MOE_LLAMA_CONFIG = LayerRotationConfig(
 )
 
 
+# DeepSeek-V2/V3 family: MLA (Multi-head Latent Attention) + SwitchGLU MoE.
+# Block structure (pre-norm, like LLaMA):
+#   h = x + attn(input_layernorm(x))
+#   out = h + moe_or_mlp(post_attention_layernorm(h))
+# Attention is MLA, not standard QKV:
+#   q   = q_proj(x)                                  (Lite: direct)
+#       | q_b_proj(q_a_layernorm(q_a_proj(x)))       (big V2/V3: low-rank)
+#   kv  = kv_b_proj(kv_a_layernorm(kv_a_proj_with_mqa(x)))
+#   out = o_proj(attn)
+# input_layernorm feeds q_proj/q_a_proj AND kv_a_proj_with_mqa directly, so both
+# fuse into it consistently. q_b_proj/kv_b_proj read *nested* RMSNorms inside the
+# attention module (q_a_layernorm / kv_a_layernorm), which the layer-level fusion
+# path doesn't target — so they use online rotation. The MoE/dense MLP fuses
+# exactly like qwen3_5_moe (post_attention_layernorm -> gate/up; down online).
+DEEPSEEK_MLA_MOE_CONFIG = LayerRotationConfig(
+    fuse_norm_to_projs={
+        "input_layernorm": ["q_proj", "q_a_proj", "kv_a_proj_with_mqa"],
+        "post_attention_layernorm": ["gate_proj", "up_proj"],
+    },
+    online_rotation_layers=["q_b_proj", "kv_b_proj", "o_proj", "down_proj"],
+)
+
+
 # Registry mapping architecture names to rotation configs
 ROTATION_CONFIGS: dict[str, LayerRotationConfig] = {
     "llama": LLAMA_CONFIG,
@@ -128,6 +151,12 @@ ROTATION_CONFIGS: dict[str, LayerRotationConfig] = {
     "qwen2_moe": MOE_LLAMA_CONFIG,
     "qwen3_5_moe": MOE_LLAMA_CONFIG,
     "gpt_oss": MOE_LLAMA_CONFIG,
+    # DeepSeek MLA + MoE family. V2-Lite validated end-to-end (convert + resident
+    # + streaming); V3/V3.2 share the same MLA + SwitchGLU layout and reuse this
+    # config (pending a test conversion — they need ~250 GB of disk).
+    "deepseek_v2": DEEPSEEK_MLA_MOE_CONFIG,
+    "deepseek_v3": DEEPSEEK_MLA_MOE_CONFIG,
+    "deepseek_v32": DEEPSEEK_MLA_MOE_CONFIG,
 }
 
 

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -36,8 +36,15 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
         prefetch_workers=prefetch_workers,
     )
 
-    layers = model.language_model.model.layers
-    prefix = "language_model.model.layers"
+    # Locate the transformer layer stack and its weight-key prefix. Multimodal
+    # MoEs (qwen3_5_moe) nest it under `language_model.model.layers`; text-only
+    # MoEs (deepseek_v2/v3, …) use `model.model.layers`.
+    if hasattr(model, "language_model"):
+        layers = model.language_model.model.layers
+        prefix = "language_model.model.layers"
+    else:
+        layers = model.model.layers
+        prefix = "model.layers"
     swapped = 0
     for i, layer in enumerate(layers):
         sm = getattr(layer.mlp, "switch_mlp", None)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -323,6 +323,34 @@ def test_rotation_configs():
     print("test_rotation_configs: PASSED")
 
 
+def test_deepseek_rotation_config():
+    """DeepSeek MLA + MoE family resolves a config with correct MLA handling."""
+    from turboquant_mlx.integration.rotation_configs import (
+        get_rotation_config, should_fuse_rotation,
+    )
+
+    for arch in ("deepseek_v2", "deepseek_v3", "deepseek_v32"):
+        config = get_rotation_config(arch)
+
+        # MLA input projections fuse into input_layernorm
+        for proj in ("q_proj", "q_a_proj", "kv_a_proj_with_mqa"):
+            can_fuse, norm = should_fuse_rotation(f"layers.0.self_attn.{proj}", config)
+            assert can_fuse and norm == "input_layernorm", (arch, proj)
+
+        # b-projections (nested-norm inputs) and o_proj use online rotation
+        for proj in ("q_b_proj", "kv_b_proj", "o_proj"):
+            can_fuse, norm = should_fuse_rotation(f"layers.0.self_attn.{proj}", config)
+            assert not can_fuse and norm is None, (arch, proj)
+
+        # MoE/MLP fuses like qwen3_5_moe; down_proj is online
+        can_fuse, norm = should_fuse_rotation("layers.1.mlp.switch_mlp.gate_proj", config)
+        assert can_fuse and norm == "post_attention_layernorm", arch
+        can_fuse, norm = should_fuse_rotation("layers.1.mlp.switch_mlp.down_proj", config)
+        assert not can_fuse and norm is None, arch
+
+    print("test_deepseek_rotation_config: PASSED")
+
+
 def test_qjl_packing_roundtrip():
     """Verify 1-bit QJL packing is lossless."""
     from turboquant_mlx.core.qjl import pack_1bit, unpack_1bit


### PR DESCRIPTION
Adds support for the **DeepSeek MLA + SwitchGLU-MoE** architecture family to TurboQuant — the first non-Qwen/Nemotron MoE, and the path toward DeepSeek-V3 on a 64 GB Mac.

## What's in it

- **Rotation config** for `deepseek_v2` / `deepseek_v3` / `deepseek_v32`. DeepSeek uses Multi-head Latent Attention (MLA), not standard QKV:
  - MLA input projections (`q_proj` / `q_a_proj` / `kv_a_proj_with_mqa`) fuse into `input_layernorm`
  - `q_b_proj` / `kv_b_proj` (which read *nested* RMSNorms inside the attention module) and `o_proj` use online rotation
  - the MoE/MLP fuses exactly like `qwen3_5_moe` (`post_attention_layernorm` → gate/up; `down_proj` online)
- **No converter changes needed** — `quantize_model.py` walks `named_modules()` dynamically, so MLA projections + SwitchGLU experts quantize automatically.
- **Streaming loader** now auto-detects the layer-key prefix, supporting both `language_model.model.layers` (qwen3_5_moe, multimodal) and `model.model.layers` (DeepSeek, text-only).
- **Test:** `tests/test_core.py::test_deepseek_rotation_config`.

## Validation

**DeepSeek-V2-Lite-Chat (16B / 2.4B active)** converted to tq3 (6.6 GB, quantized 78 SwitchLinear expert layers + 190 Linear layers):
- **Resident:** coherent output, **~84 tok/s**, 8.4 GB peak.
- **Streaming:** 78 expert projections swapped, coherent output, 0.22 GB resident-after-load.

## Scope / honesty

- **V2 is fully tested** (convert + resident + streaming).
- **V3 / V3.2 are registered and expected to work** (same MLA+MoE layout) but are **untested** — they need ~250 GB of disk for a conversion. Labeled as such in the README arch table.
- DeepSeek-V4 (Flash/Pro) is **not** covered: mlx-lm has no `deepseek_v4` (novel CSA/HCA attention) and it ships natively in FP4, so TurboQuant isn't the right tool — that's gated on upstream mlx-lm support.