### PR TITLE
feat: memory-bounded (streaming) converter for models larger than RAM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Memory-bounded (streaming) converter — `convert --streaming`.** The default
+  converter materializes the entire quantized model in RAM before saving, which
+  caps conversion at ~130B params on a 64 GB Mac. The new path writes each
+  quantized layer to a safetensors shard and frees it during the quantization
+  loop (via a `turboquant_quantize(on_quantized=…)` callback + a
+  `StreamingShardWriter`), keeping peak memory to ~one shard (5 GB) plus the
+  single layer being processed — so 200B+ MoEs (Qwen3-235B, DeepSeek-V3) convert
+  on a 64 GB machine. Output is **byte-identical** to the in-memory converter
+  (verified on DeepSeek-V2-Lite-Chat: 1181/1181 tensors at fixed `PYTHONHASHSEED`).
 - **DeepSeek (MLA + MoE) conversion + streaming support.** Added a rotation
   config for the DeepSeek Multi-head Latent Attention + SwitchGLU-MoE family
   (`deepseek_v2`, `deepseek_v3`, `deepseek_v32`). MLA's input projections

--- a/README.md
+++ b/README.md
@@ -145,6 +145,14 @@ python -m turboquant_mlx.convert \
     --hf-path openai/gpt-oss-20b \
     --mlx-path ./gpt-oss-20b-tq2 \
     --bits 2 --group-size 64
+
+# Very large model whose quantized form won't fit in RAM (200B+): --streaming
+# writes each layer to a shard and frees it, so peak memory stays ~one shard
+# (5 GB) + one layer — letting 235B/671B-class MoEs convert on a 64 GB Mac.
+python -m turboquant_mlx.convert \
+    --hf-path Qwen/Qwen3-235B-A22B-Instruct-2507 \
+    --mlx-path ./qwen3-235b-tq3 \
+    --bits 3 --group-size 64 --streaming
 ```
 
 ### 2. Generate text
@@ -501,7 +509,7 @@ python -m turboquant_mlx.convert \
 
 **Model size:** 48 GB
 
-> **Note:** Conversion requires temporarily loading the full model. With 120B parameters, peak memory during conversion may reach ~50-55 GB. On a 64 GB machine this is tight — close all other applications before running. The converter processes layers sequentially and frees memory after each expert is quantized.
+> **Note:** The default converter materializes the full quantized model in RAM before saving, so peak memory ≈ the quantized model size (~50–55 GB for a 120B). On a 64 GB machine that caps conversion at ~130B params. For anything larger, add **`--streaming`**: it writes each quantized layer to a shard and frees it, keeping peak memory to ~one 5 GB shard plus the layer being processed — so 200B+ models (Qwen3-235B, DeepSeek-V3) convert on a 64 GB Mac. Output is byte-identical to the in-memory path.
 
 #### Step 2: Generate text
 

--- a/convert.py
+++ b/convert.py
@@ -176,12 +176,37 @@ def configure_parser() -> argparse.ArgumentParser:
         help="Override bits for MLP and MoE expert linears. "
              "Defaults to --bits when omitted.",
     )
+    parser.add_argument(
+        "--streaming",
+        action="store_true",
+        help="Memory-bounded conversion: write each quantized layer to a shard "
+             "and free it, so the full quantized model never resides in RAM. "
+             "Use for models too big to convert in memory (e.g. 200B+ on 64 GB). "
+             "(--dtype override is not supported in this mode.)",
+    )
     return parser
 
 
 def main():
     parser = configure_parser()
     args = parser.parse_args()
+    if args.streaming:
+        if args.dtype is not None:
+            print("[WARNING] --dtype is ignored in --streaming mode")
+        from turboquant_mlx.convert_streaming import convert_streaming
+        convert_streaming(
+            hf_path=args.hf_path,
+            mlx_path=args.mlx_path,
+            bits=args.bits,
+            group_size=args.group_size,
+            rotation=args.rotation,
+            rotation_seed=args.rotation_seed,
+            fuse_rotations=args.fuse_rotations,
+            use_qjl=args.use_qjl,
+            attn_bits=args.attn_bits,
+            mlp_bits=args.mlp_bits,
+        )
+        return
     convert(
         hf_path=args.hf_path,
         mlx_path=args.mlx_path,

--- a/convert_streaming.py
+++ b/convert_streaming.py
@@ -1,0 +1,179 @@
+"""Memory-bounded (sharded-streaming) TurboQuant conversion.
+
+The standard converter (:mod:`turboquant_mlx.convert`) materializes the entire
+quantized model in RAM before saving, which caps practical conversion at
+~130B params on a 64 GB Mac (the quantized model itself must fit in memory).
+
+This path writes each quantized layer to a safetensors shard and frees it
+*during* the quantization loop, so peak memory stays at roughly one shard
+(~5 GB) plus the single layer being processed. That lets 200B+ MoEs convert on
+a 64 GB machine. The output is identical to ``convert.py`` (same quantization,
+same seeds) — only *when* tensors are written to disk differs.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import os
+import shutil
+import time
+from pathlib import Path
+
+import mlx.core as mx
+from mlx.utils import tree_flatten
+from mlx_lm.utils import (
+    MAX_FILE_SIZE_GB,
+    create_model_card,
+    hf_repo_to_path,
+    load,
+    save_config,
+)
+
+import turboquant_mlx.compat  # noqa: F401 — registers upstream patches on import
+from turboquant_mlx.config import TurboQuantConfig
+from turboquant_mlx.quantize_model import turboquant_quantize
+
+
+class StreamingShardWriter:
+    """Write tensors into safetensors shards incrementally, mlx-lm style.
+
+    Tensors are buffered until the buffer would exceed ``max_file_size_gb``,
+    then flushed to a shard file and freed. The final ``model.safetensors.index.json``
+    is written by :meth:`finalize` once the total shard count is known.
+    """
+
+    def __init__(self, dst_path, max_file_size_gb: int = MAX_FILE_SIZE_GB):
+        self.dst = Path(dst_path)
+        self.dst.mkdir(parents=True, exist_ok=True)
+        # int() so tests can pass a fractional GB to force small shards
+        self.max_bytes = int(max_file_size_gb * (2 ** 30))
+        self._buf: dict = {}
+        self._buf_bytes = 0
+        self._shard_idx = 0
+        self._tmp_files: list[Path] = []
+        self._name_to_shard: dict[str, int] = {}
+        self.total_size = 0
+        self.total_params = 0
+
+    def add(self, name: str, arr) -> None:
+        mx.eval(arr)
+        nb = arr.nbytes
+        # Mirror mlx_lm.make_shards: start a new shard before adding a tensor
+        # that would overflow the current one.
+        if self._buf and self._buf_bytes + nb > self.max_bytes:
+            self._flush()
+        self._buf[name] = arr
+        self._buf_bytes += nb
+        self._name_to_shard[name] = self._shard_idx
+        self.total_size += nb
+        self.total_params += arr.size
+
+    def _flush(self) -> None:
+        tmp = self.dst / f"__tq_shard_{self._shard_idx:05d}.safetensors"
+        mx.save_safetensors(str(tmp), self._buf, metadata={"format": "mlx"})
+        self._tmp_files.append(tmp)
+        self._buf = {}
+        self._buf_bytes = 0
+        self._shard_idx += 1
+
+    def finalize(self) -> int:
+        if self._buf:
+            self._flush()
+        n = len(self._tmp_files)
+        if n == 0:
+            raise RuntimeError("StreamingShardWriter: no tensors were written")
+        single = n == 1
+        idx_to_name: dict[int, str] = {}
+        for i, tmp in enumerate(self._tmp_files):
+            final = "model.safetensors" if single else \
+                f"model-{i + 1:05d}-of-{n:05d}.safetensors"
+            os.replace(tmp, self.dst / final)
+            idx_to_name[i] = final
+        weight_map = {k: idx_to_name[self._name_to_shard[k]]
+                      for k in sorted(self._name_to_shard)}
+        index = {
+            "metadata": {
+                "total_size": self.total_size,
+                "total_parameters": self.total_params,
+            },
+            "weight_map": weight_map,
+        }
+        with open(self.dst / "model.safetensors.index.json", "w") as f:
+            json.dump(index, f, indent=4)
+        return n
+
+
+def convert_streaming(
+    hf_path: str,
+    mlx_path: str = "mlx_model",
+    bits: int = 3,
+    group_size: int = 64,
+    rotation: str = "hadamard",
+    rotation_seed: int = 42,
+    fuse_rotations: bool = True,
+    use_qjl: bool = False,
+    attn_bits: int = None,
+    mlp_bits: int = None,
+    max_file_size_gb: int = MAX_FILE_SIZE_GB,
+):
+    """Convert an HF model to TurboQuant MLX format with bounded peak memory.
+
+    Identical output to :func:`turboquant_mlx.convert.convert`, but each
+    quantized layer is streamed to disk and freed, so the full quantized model
+    is never resident. Use this for models whose quantized size exceeds RAM.
+    """
+    mlx_path = Path(mlx_path)
+    if mlx_path.exists():
+        raise ValueError(
+            f"Cannot save to {mlx_path} as it already exists. "
+            "Delete it or specify a new path."
+        )
+
+    tq_config = TurboQuantConfig(
+        bits=bits, group_size=group_size, rotation=rotation,
+        rotation_seed=rotation_seed, fuse_rotations=fuse_rotations,
+        use_qjl=use_qjl, attn_bits=attn_bits, mlp_bits=mlp_bits,
+    )
+
+    print(f"[INFO] Loading model from {hf_path} (lazy)")
+    model, tokenizer, config = load(hf_path, return_config=True, lazy=True)
+    arch = config.get("model_type", "unknown")
+    print(f"[INFO] Streaming TurboQuant convert: {bits}-bit, gs={group_size}, "
+          f"arch={arch}, shard={max_file_size_gb} GB")
+
+    writer = StreamingShardWriter(mlx_path, max_file_size_gb)
+
+    def on_quantized(path, module):
+        # Write every parameter of this just-quantized layer, then it gets freed.
+        for sub, arr in tree_flatten(module.parameters()):
+            writer.add(f"{path}.{sub}", arr)
+
+    t0 = time.time()
+    # Pass 1: quantized layers are streamed + freed via the callback.
+    model, config = turboquant_quantize(
+        model, config, tq_config, on_quantized=on_quantized,
+    )
+    # Pass 2: the remaining (non-quantized) params — norms (with fused rotations),
+    # embeddings, routers, any dimension-skipped layers. Small vs. the experts.
+    for name, arr in tree_flatten(model.parameters()):
+        writer.add(name, arr)
+    n_shards = writer.finalize()
+    print(f"[INFO] Quantized + streamed in {time.time() - t0:.1f}s "
+          f"({writer.total_size / 1024**3:.2f} GB across {n_shards} shard(s))")
+
+    # Config + tokenizer + aux files — mirror the tail of mlx_lm.utils.save.
+    save_config(config, config_path=mlx_path / "config.json")
+    tokenizer.save_pretrained(mlx_path)
+
+    src_path = Path(hf_path)
+    hf_repo = None
+    if not src_path.exists():
+        hf_repo = hf_path
+        src_path = hf_repo_to_path(hf_path)
+    for pattern in ("*.py", "generation_config.json"):
+        for fpath in glob.glob(str(src_path / pattern)):
+            shutil.copy(fpath, mlx_path)
+    create_model_card(mlx_path, hf_repo)
+
+    print(f"[INFO] Done! Model saved to {mlx_path}")

--- a/quantize_model.py
+++ b/quantize_model.py
@@ -124,11 +124,20 @@ def turboquant_quantize(
     model: nn.Module,
     config: dict,
     tq_config: TurboQuantConfig,
+    on_quantized=None,
 ) -> tuple[nn.Module, dict]:
     """Apply TurboQuant weight quantization to a model.
 
     Memory-efficient: replaces each layer immediately after quantization
     and releases references to original weights for garbage collection.
+
+    If ``on_quantized`` is given, it is called as ``on_quantized(path, module)``
+    right after each layer is quantized and evaluated, and that layer is then
+    replaced on the model with a paramless stub instead of the quantized module.
+    This lets a streaming converter write each layer to disk and free it, so the
+    full quantized model never has to reside in memory at once. Non-quantized
+    params (norms, embeddings, routers) stay on the model for the caller to write
+    afterward.
     """
     arch = _detect_architecture(config)
     rotation_config = None
@@ -211,7 +220,13 @@ def turboquant_quantize(
             )
             # Replace immediately and release all references
             mx.eval(pq_switch.parameters())
-            _set_nested_attr(model, path, pq_switch)
+            if on_quantized is not None:
+                # Streaming convert: write this layer to disk, then drop its
+                # params so the full quantized model never resides in memory.
+                on_quantized(path, pq_switch)
+                _set_nested_attr(model, path, nn.Identity())
+            else:
+                _set_nested_attr(model, path, pq_switch)
             del float_weight, module, bias_tensor, pq_switch
             gc.collect()
             n_switch += 1
@@ -286,7 +301,12 @@ def turboquant_quantize(
         )
 
         # Replace immediately to free original weights
-        _set_nested_attr(model, path, pq_layer)
+        if on_quantized is not None:
+            mx.eval(pq_layer.parameters())
+            on_quantized(path, pq_layer)
+            _set_nested_attr(model, path, nn.Identity())
+        else:
+            _set_nested_attr(model, path, pq_layer)
         del module, pq_layer
         n_quantized += 1
 

--- a/tests/test_convert_streaming.py
+++ b/tests/test_convert_streaming.py
@@ -1,0 +1,49 @@
+"""Unit test for the streaming shard writer (no model / disk-of-a-model needed).
+
+The end-to-end guarantee — that ``--streaming`` conversion is byte-identical to
+the in-memory converter — is validated manually on real models (it depends on a
+fixed PYTHONHASHSEED, since the per-layer rotation seed uses ``hash()``). Here we
+just exercise the shard writer's sharding, naming, index, and reload-fidelity.
+"""
+
+import glob
+import json
+import tempfile
+from pathlib import Path
+
+import mlx.core as mx
+
+from turboquant_mlx.convert_streaming import StreamingShardWriter
+
+
+def test_streaming_shard_writer_multishard():
+    tensors = {
+        "model.a.weight": mx.arange(16, dtype=mx.uint32).reshape(4, 4),
+        "model.a.scales": (mx.ones((4, 1)) * 2).astype(mx.float16),
+        "model.a.codebook": mx.arange(8, dtype=mx.float32),
+        "model.b.weight": mx.arange(8, dtype=mx.uint32),
+    }
+    with tempfile.TemporaryDirectory() as d:
+        # tiny threshold -> one tensor per shard, exercising the -of-N naming
+        w = StreamingShardWriter(d, max_file_size_gb=1e-9)
+        for k, v in tensors.items():
+            w.add(k, v)
+        n = w.finalize()
+        assert n >= 2, f"expected multiple shards, got {n}"
+
+        idx = json.load(open(Path(d) / "model.safetensors.index.json"))
+        assert set(idx["weight_map"]) == set(tensors)
+        assert idx["metadata"]["total_size"] == sum(v.nbytes for v in tensors.values())
+        # every referenced shard file actually exists
+        for fname in set(idx["weight_map"].values()):
+            assert (Path(d) / fname).exists(), fname
+
+        # reloading the shards reproduces every tensor exactly
+        loaded = {}
+        for f in glob.glob(str(Path(d) / "*.safetensors")):
+            loaded.update(mx.load(f))
+        assert set(loaded) == set(tensors)
+        for k, v in tensors.items():
+            assert mx.array_equal(loaded[k], v).item(), k
+
+    print("test_streaming_shard_writer_multishard: PASSED")


### PR DESCRIPTION
Removes the conversion-RAM ceiling that capped TurboQuant conversion at ~130B params on a 64 GB Mac.

## Problem

`convert.py` ends with `mx.eval(model.parameters())` + `save()`, which materializes the **entire quantized model in RAM** before writing. So peak memory ≈ the quantized model size (~50 GB for a 120B), and anything past ~130B (Qwen3-235B → ~96 GB, DeepSeek-V3 → ~270 GB) can't convert on a 64 GB machine — *regardless of disk*.

## Fix

A streaming path that writes each quantized layer to a safetensors shard and **frees it during the quantization loop**, so peak memory stays ~one shard (5 GB) + the single layer being processed.

- **`quantize_model.turboquant_quantize`** gains an optional `on_quantized(path, module)` callback. When set, each quantized layer is handed to the callback and then replaced on the model with a paramless `nn.Identity` stub, so quantized params don't accumulate. (Default behavior unchanged when the callback is absent.)
- **`convert_streaming.py`**: `StreamingShardWriter` (incremental mlx-lm-format shards + `model.safetensors.index.json`) and `convert_streaming()` — pass 1 streams the quantized layers, pass 2 writes the small remaining params (norms with fused rotations, embeddings, routers).
- **`convert.py`**: `--streaming` flag routes to the bounded path.

## Validation

- **Byte-identical to the in-memory converter** on DeepSeek-V2-Lite-Chat — **1181/1181 tensors**, same key set, 0 mismatches (at fixed `PYTHONHASHSEED`; the per-layer rotation seed uses `hash()`, which Python randomizes per process — a pre-existing quirk, not introduced here).
- Same layer counts (78 SwitchLinear + 190 Linear), same 6.63 GB / 2-shard output.
- Unit test `tests/test_convert_streaming.py` covers the shard writer (multi-shard naming, index.json, reload fidelity).

## Why it matters

This is the convert-side analog of the expert-streaming *loader*: together they make the full pipeline — convert **and** run frontier-size MoEs — fit on a Mac. It unblocks **Qwen3-235B-A22B** (arch + dtype already supported) and **DeepSeek-V3** conversions locally; no cloud needed.

Builds on #21 (DeepSeek MLA+MoE support).