### PR TITLE
feat: register qwen3_moe rotation config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   auto-detects the layer-key prefix, supporting both the multimodal
   `language_model.model.layers` layout (qwen3_5_moe) and the text-only
   `model.model.layers` layout (DeepSeek).
+- **`qwen3_moe` rotation config registered** (standard attention + SwitchGLU, =
+  `MOE_LLAMA_CONFIG`). Enables Qwen3-MoE conversion (e.g. Qwen3-235B-A22B via
+  `--streaming`); untested pending a conversion.
 
 ## [0.5.0] - 2026-05-26
 

--- a/README.md
+++ b/README.md
@@ -790,6 +790,7 @@ Options:
 | Qwen1.5-MoE | `qwen2_moe` | Yes | Tested |
 | GPT-OSS | `gpt_oss` | Yes | Tested |
 | Qwen3.5-MoE / Qwen3.6-35B-A3B | `qwen3_5_moe` | Yes (256 experts) | Tested (122B, 35B-A3B); 35B streams on a 16 GB Mac mini |
+| Qwen3-MoE | `qwen3_moe` | Yes (SwitchGLU experts) | Config registered (same as the Qwen-MoE siblings); 235B-A22B convertible via `--streaming` (untested pending a conversion) |
 | Nemotron-H (Mamba/attention hybrid) | `nemotron_h` | Yes (512 experts w/ latent MoE on Super-120B) | Tested (Nano-4B, Super-120B) — requires mlx-lm ≥ 0.31.3 |
 | DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
 

--- a/integration/rotation_configs.py
+++ b/integration/rotation_configs.py
@@ -149,6 +149,7 @@ ROTATION_CONFIGS: dict[str, LayerRotationConfig] = {
     "qwen3_5": LLAMA_CONFIG,
     # MoE architectures
     "qwen2_moe": MOE_LLAMA_CONFIG,
+    "qwen3_moe": MOE_LLAMA_CONFIG,       # Qwen3-MoE (e.g. Qwen3-235B-A22B, Qwen3-30B-A3B)
     "qwen3_5_moe": MOE_LLAMA_CONFIG,
     "gpt_oss": MOE_LLAMA_CONFIG,
     # DeepSeek MLA + MoE family. V2-Lite validated end-to-end (convert + resident

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -320,6 +320,12 @@ def test_rotation_configs():
     can_fuse, norm = should_fuse_rotation("layers.0.mlp.gate_proj", config)
     assert can_fuse and norm == "post_attention_layernorm"
 
+    # Qwen3-MoE uses the standard-attention + SwitchGLU MoE config
+    qm = get_rotation_config("qwen3_moe")
+    assert should_fuse_rotation("layers.0.self_attn.q_proj", qm) == (True, "input_layernorm")
+    assert should_fuse_rotation("layers.0.mlp.switch_mlp.gate_proj", qm) == (True, "post_attention_layernorm")
+    assert should_fuse_rotation("layers.0.mlp.switch_mlp.down_proj", qm) == (False, None)
+
     print("test_rotation_configs: PASSED")
 
 


### PR DESCRIPTION
Registers the `qwen3_moe` architecture for TurboQuant conversion. Qwen3-MoE (Qwen3-235B-A22B, Qwen3-30B-A3B) is standard attention + SwitchGLU experts, so it reuses `MOE_LLAMA_CONFIG` exactly like its `qwen2_moe` / `qwen3_5_moe` siblings.

Combined with the `--streaming` converter (#22), **Qwen3-235B-A22B is now convertible on a 64 GB Mac** (all four feasibility gates clear: mlx-lm supports `qwen3_moe`, BF16 dtype, rotation config registered, `--streaming` removes the conversion-RAM ceiling).

- 1-line registry add + README arch-table row + a test assertion in `test_rotation_configs`.
- Untested pending an actual conversion (low risk — identical config to the tested Qwen-MoE siblings).