### PR TITLE
fix(convert): avoid Metal GPU watchdog on slow storage (0.6.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.6.2] - 2026-05-31
+
+### Fixed
+
+- **Convert no longer hits the Metal GPU watchdog when quantizing a lazily-mmap'd
+  checkpoint off slow storage (e.g. a USB HDD).** Symptom: `convert` (in-memory
+  *and* `--streaming`) aborted with
+  `[METAL] ... kIOGPUCommandBufferCallbackErrorTimeout` shortly after start.
+  Root cause: MLX fused the multi-second weight *read* from the slow disk into
+  the same GPU command buffer as the rotate/quantize, and the watchdog kills any
+  command buffer that stalls on I/O that long — it was **not** tensor size or a
+  slow kernel (rotating a resident 1.3B `lm_head` is ~0.2 s). Fix in
+  `core/polar_quantize.py`: (1) `mx.eval(weight)` at the top of
+  `polar_quantize_weight` forces the disk read as its own step before any GPU
+  compute, keeping the kernels pure-compute; (2) the output-row axis is quantized
+  in ≤64M-element blocks (`_MAX_QUANT_BLOCK_ELEMS`) as a secondary bound on
+  per-command-buffer work. **Bit-identical** to the previous single-pass
+  quantization (each output row quantizes independently; validated 4-block vs
+  1-block exact match). Fast storage never tripped this, which is why prior
+  large-model converts succeeded. Helps any dense / big-vocab model converted
+  off slow storage (validated converting Qwen3.6-27B tq3 g32).
+
 ## [0.6.1] - 2026-05-30
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.6.1"
+__version__ = "0.6.2"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/core/polar_quantize.py
+++ b/core/polar_quantize.py
@@ -14,6 +14,17 @@ from turboquant_mlx.core.rotation import generate_random_signs, rotate_weight
 from turboquant_mlx.core.packing import pack_indices, unpack_indices
 
 
+# Cap on the number of weight elements quantized in a single MLX graph. Large
+# tensors (e.g. a big-vocab lm_head — 248k x 5120 ~ 1.3B params) are split along
+# the output-row axis into blocks of at most this many elements, each evaluated
+# as its own command buffer, so a single GPU submission never exceeds the Metal
+# command-buffer watchdog timeout (kIOGPUCommandBufferCallbackErrorTimeout).
+# Bit-identical to a single-pass quantization: each output row is quantized
+# independently (rotation is per-row; normalization + codebook assignment are
+# per-group within a row), so splitting rows and concatenating changes nothing.
+_MAX_QUANT_BLOCK_ELEMS = 64_000_000
+
+
 def polar_quantize_weight(
     weight: mx.array,
     bits: int = 3,
@@ -47,42 +58,62 @@ def polar_quantize_weight(
 
     n_groups = input_dims // group_size
 
-    # 1. Generate random signs for randomized Hadamard
+    # Materialize the weight off disk BEFORE any GPU compute. With a lazily
+    # mmap'd checkpoint on slow storage (e.g. a USB HDD), MLX would otherwise
+    # fuse the multi-second weight read into the rotation/quantize command
+    # buffer, and the Metal GPU watchdog kills any command buffer that stalls
+    # on I/O that long (kIOGPUCommandBufferCallbackErrorTimeout). Forcing the
+    # read as its own eval keeps the subsequent GPU kernels pure-compute (fast).
+    mx.eval(weight)
+
+    # 1. Generate random signs for randomized Hadamard (shared across all rows)
     signs = generate_random_signs(input_dims, seed=seed)
-
-    # 2. Rotate weight matrix (Gaussianize the distribution)
-    w_rot = rotate_weight(weight.astype(mx.float32), signs.astype(mx.float32))
-
-    # 3. Group-wise normalization
-    # Reshape to (output_dims, n_groups, group_size)
-    w_grouped = w_rot.reshape(output_dims, n_groups, group_size)
+    signs_f32 = signs.astype(mx.float32)
 
     centroids, boundaries = get_codebook(bits, dtype=mx.float32)
-
-    # Per-group scale: use RMS (optimal for Gaussian-distributed values after rotation)
-    # For N(0, sigma^2), RMS = sigma, and Lloyd-Max centroids are for N(0,1)
-    rms = mx.sqrt(mx.mean(w_grouped * w_grouped, axis=-1, keepdims=True))  # (out, n_groups, 1)
-    rms = mx.maximum(rms, mx.array(1e-7))
-
-    # Normalize to unit variance for Lloyd-Max codebook
-    w_normalized = w_grouped / rms  # (out, n_groups, gs)
-
-    # Clip to prevent extreme outliers from saturating the codebook
+    # Clip threshold to prevent extreme outliers from saturating the codebook
     max_centroid = mx.max(mx.abs(centroids))
-    w_normalized = mx.clip(w_normalized, -max_centroid * 1.5, max_centroid * 1.5)
 
-    # 4. Lloyd-Max codebook quantization
-    indices = quantize_scalar(w_normalized, boundaries)  # (out, n_groups, gs) uint8
+    # Quantize the output-row axis in blocks so no single command buffer
+    # exceeds the GPU watchdog timeout (see _MAX_QUANT_BLOCK_ELEMS). Each block
+    # is evaluated on its own; rows quantize independently, so concatenating the
+    # per-block results is bit-identical to a single pass. Small tensors stay a
+    # single block (no overhead).
+    rows_per_block = max(1, _MAX_QUANT_BLOCK_ELEMS // input_dims)
+    packed_parts = []
+    scale_parts = []
+    for r0 in range(0, output_dims, rows_per_block):
+        wb = weight[r0:r0 + rows_per_block].astype(mx.float32)
+        rows = wb.shape[0]
 
-    # Flatten groups back: (out, input_dims)
-    indices_flat = indices.reshape(output_dims, input_dims)
+        # 2. Rotate weight rows (Gaussianize the distribution)
+        w_rot = rotate_weight(wb, signs_f32)
 
-    # 5. Pack indices into uint32
-    packed_weight = pack_indices(indices_flat, bits)
+        # 3. Group-wise normalization: reshape to (rows, n_groups, group_size).
+        # Per-group scale uses RMS (= sigma for N(0, sigma^2) after rotation;
+        # Lloyd-Max centroids are for N(0,1)).
+        w_grouped = w_rot.reshape(rows, n_groups, group_size)
+        rms = mx.sqrt(mx.mean(w_grouped * w_grouped, axis=-1, keepdims=True))
+        rms = mx.maximum(rms, mx.array(1e-7))
+        w_normalized = w_grouped / rms
+        w_normalized = mx.clip(w_normalized, -max_centroid * 1.5, max_centroid * 1.5)
 
-    # Store scales as (out, n_groups) in float16
+        # 4. Lloyd-Max codebook quantization, then 5. pack indices into uint32
+        indices = quantize_scalar(w_normalized, boundaries)
+        indices_flat = indices.reshape(rows, input_dims)
+        packed = pack_indices(indices_flat, bits)
+        scales_b = rms.squeeze(-1).astype(mx.float16)  # (rows, n_groups)
+
+        # Force this block out as its own command buffer (bounds GPU work).
+        mx.eval(packed, scales_b)
+        packed_parts.append(packed)
+        scale_parts.append(scales_b)
+
+    packed_weight = (packed_parts[0] if len(packed_parts) == 1
+                     else mx.concatenate(packed_parts, axis=0))
     # Scale = RMS, so dequant is: centroid * rms
-    scales_out = rms.squeeze(-1).astype(mx.float16)
+    scales_out = (scale_parts[0] if len(scale_parts) == 1
+                  else mx.concatenate(scale_parts, axis=0))
 
     # Get codebook in float16
     codebook_f16 = centroids.astype(mx.float16)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.6.1"
+version = "0.6.2"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Fixes the Metal GPU watchdog timeout (`kIOGPUCommandBufferCallbackErrorTimeout`) that aborted `convert` (both in-memory and `--streaming`) when quantizing a lazily-mmap'd checkpoint off **slow storage** (e.g. a USB HDD).

**Root cause:** MLX fused the multi-second weight *read* from the slow disk into the same GPU command buffer as the rotate/quantize. The watchdog kills any command buffer that stalls on I/O that long. It was **not** tensor size and **not** a slow kernel — rotating a resident 1.3B `lm_head` is ~0.2s.

**Fix (`core/polar_quantize.py`):**
1. `mx.eval(weight)` at the top of `polar_quantize_weight` forces the disk read as its own step before any GPU compute, keeping the kernels pure-compute.
2. The output-row axis is quantized in ≤64M-element blocks (`_MAX_QUANT_BLOCK_ELEMS`) as a secondary bound on per-command-buffer work.

**Bit-identical** to the previous single-pass quantization (each output row quantizes independently; validated 4-block vs 1-block exact match). Fast storage never tripped this, which is why prior large-model converts succeeded.

Validated end-to-end converting **Qwen3.6-27B → tq3 g32** off a USB HDD (previously crashed; now completes, ~13 GB output, coherent generation).

## Tests

`pytest -k "quant or polar or convert"` → 7 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)