### PR TITLE
feat(vlm): mlx-vlm architecture support — DiffusionGemma tq3 + fused expert dequant kernel (0.7.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.7.0] - 2026-06-12
+
+### Added
+
+- **mlx-vlm architecture support (multimodal / diffusion LLMs)** — first
+  target: Google **DiffusionGemma-26B-A4B** (`model_type: diffusion_gemma`,
+  block-diffusion MoE, 25.2B total / 3.8B active). New optional dependency:
+  `pip install "turboquant-mlx-full[vlm]"` (mlx-vlm >= 0.6.3).
+  - `python -m turboquant_mlx.convert_vlm` — converts architectures that live
+    in mlx-vlm rather than mlx-lm. Reuses the model-agnostic
+    `turboquant_quantize` core; applies per-arch full-precision skips
+    (`integration/vlm.py::VLM_SKIP_PATTERNS`): vision/audio towers, MoE
+    routers, and for `diffusion_gemma` the dense per-layer MLP and
+    self-conditioning block (quant-sensitive per the upstream
+    `quant_predicate`).
+  - `python -m turboquant_mlx.generate_vlm` — loads TurboQuant checkpoints
+    through mlx-vlm (`integration/vlm.py::load_turboquant_vlm`; the stock
+    mlx-vlm loader would mis-apply affine `nn.quantize`) and runs mlx-vlm's
+    generation dispatch, including the block-diffusion denoising sampler.
+  - `diffusion_gemma` rotation-config registry entry.
+- **`kernels/polar_dequant_experts.py`** — fused Metal kernel that
+  dequantizes all experts of a `PolarQuantizedSwitchLinear` in one pass
+  (unpack + codebook + group scales). Bit-identical to the previous multi-op
+  Python path and ~11x faster at MoE shapes; now backs `_dequantize_all`.
+
+### Changed
+
+- `PolarQuantizedSwitchLinear` routes **large batched expert calls** (>= 512
+  token-expert routings, e.g. diffusion canvas forwards and large sorted
+  prefills) through fused dequant + `mx.gather_mm` instead of the per-row
+  gather kernel, which re-reads activations per output row at that scale
+  (~2x end-to-end on DiffusionGemma denoising). Guarded by a 2 GiB cap on
+  the materialized expert tensor so many-large-expert models (e.g.
+  512-expert LatentMoE) keep the memory-safe gather kernels (issue #1).
+
 ## [0.6.2] - 2026-05-31
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -893,6 +893,26 @@ Options:
 | Qwen3-MoE | `qwen3_moe` | Yes (128 experts, top-8) | Tested — Qwen3-235B-A22B converted to a hybrid **tq3a-tq2e** build (70.5 GB) on a 16 GB Mac mini via `--streaming`; streams and passes 5/6 quality probes on a 64 GB Mac |
 | Nemotron-H (Mamba/attention hybrid) | `nemotron_h` | Yes (512 experts w/ latent MoE on Super-120B) | Tested (Nano-4B, Super-120B) — requires mlx-lm ≥ 0.31.3 |
 | DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
+| DiffusionGemma (block-diffusion MoE, via **mlx-vlm**) | `diffusion_gemma` | Yes (128 experts, top-8) | Tested (26B-A4B: convert + block-diffusion sampler, coherent at 3-bit — [HF](https://huggingface.co/manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32)). **Experimental**: decode is much slower than native 4-bit until a batched codebook gather-GEMM kernel lands |
+
+### mlx-vlm architectures (multimodal / diffusion)
+
+Architectures that live in [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) rather
+than mlx-lm convert and run through dedicated entry points (v0.7.0+):
+
+```bash
+pip install "turboquant-mlx-full[vlm]"   # adds mlx-vlm >= 0.6.3
+
+# Convert (vision towers, routers, and known quant-sensitive blocks stay full precision)
+python -m turboquant_mlx.convert_vlm \
+    --hf-path google/diffusiongemma-26B-A4B-it \
+    --mlx-path ./diffusiongemma-26B-A4B-it-tq3-g32 --bits 3 -g 32
+
+# Generate (runs mlx-vlm's sampler — block-diffusion denoising for DiffusionGemma)
+python -m turboquant_mlx.generate_vlm \
+    --model ./diffusiongemma-26B-A4B-it-tq3-g32 \
+    --prompt "Write a short paragraph about the ocean." --max-tokens 256
+```
 
 ## Project Structure
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.6.2"
+__version__ = "0.7.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/convert_vlm.py
+++ b/convert_vlm.py
@@ -1,0 +1,141 @@
+"""Convert an mlx-vlm-architecture model (multimodal / diffusion LLM) to
+TurboQuant-compressed MLX format.
+
+For architectures that live in mlx-vlm rather than mlx-lm — e.g. Google's
+DiffusionGemma (model_type ``diffusion_gemma``). The quantize core
+(``turboquant_quantize``) is model-agnostic; this entry point only swaps the
+load/save plumbing to mlx-vlm and applies per-architecture full-precision
+skips (vision towers, routers, known quant-sensitive blocks).
+
+Usage:
+    python -m turboquant_mlx.convert_vlm \\
+        --hf-path google/diffusiongemma-26B-A4B-it \\
+        --mlx-path ./diffusiongemma-26B-A4B-it-tq3-g32 \\
+        --bits 3 --group-size 32
+
+Requires:  pip install "turboquant-mlx-full[vlm]"
+"""
+
+import argparse
+import shutil
+import time
+from pathlib import Path
+
+import mlx.core as mx
+
+import turboquant_mlx.compat  # noqa: F401 — registers upstream patches on import
+import turboquant_mlx.quantize_model as _qm
+from turboquant_mlx.config import TurboQuantConfig
+from turboquant_mlx.quantize_model import turboquant_quantize, _detect_architecture
+from turboquant_mlx.integration.vlm import _require_mlx_vlm, vlm_should_quantize
+
+_AUX_FILES = (
+    "tokenizer.json", "tokenizer_config.json", "chat_template.jinja",
+    "processor_config.json", "generation_config.json",
+    "preprocessor_config.json", "special_tokens_map.json",
+)
+
+
+def convert_vlm(
+    hf_path: str,
+    mlx_path: str,
+    bits: int = 3,
+    group_size: int = 32,
+    rotation: str = "hadamard",
+    rotation_seed: int = 42,
+    attn_bits: int = None,
+    mlp_bits: int = None,
+):
+    """Convert an mlx-vlm model to TurboQuant format. See module docstring."""
+    _require_mlx_vlm()
+    from mlx_vlm.utils import (
+        get_model_path, load_config, load_model, save_config, save_weights,
+    )
+
+    mlx_path = Path(mlx_path)
+    if mlx_path.exists():
+        raise ValueError(
+            f"Cannot save to {mlx_path} as it already exists. "
+            "Delete it or specify a new path."
+        )
+
+    hf_path = Path(get_model_path(hf_path))
+
+    tq_config = TurboQuantConfig(
+        bits=bits,
+        group_size=group_size,
+        rotation=rotation,
+        rotation_seed=rotation_seed,
+        fuse_rotations=False,  # online rotation everywhere (production default)
+        use_qjl=False,
+        attn_bits=attn_bits,
+        mlp_bits=mlp_bits,
+    )
+
+    print(f"[INFO] Loading {hf_path} via mlx-vlm (lazy)")
+    config = load_config(hf_path)
+    model = load_model(hf_path, lazy=True)
+
+    arch = _detect_architecture(config)
+    print(f"[INFO] Architecture: {arch}")
+    print(f"[INFO] Quantizing with TurboQuant ({bits}-bit, gs={group_size}, "
+          f"rotation={rotation})")
+
+    orig_should_quantize = _qm._should_quantize
+    _qm._should_quantize = vlm_should_quantize(arch, orig_should_quantize)
+    try:
+        t0 = time.time()
+        model, config = turboquant_quantize(model, config, tq_config)
+        mx.eval(model.parameters())
+        print(f"[INFO] Quantization completed in {time.time() - t0:.1f}s")
+    finally:
+        _qm._should_quantize = orig_should_quantize
+
+    print(f"[INFO] Saving to {mlx_path}")
+    save_weights(mlx_path, model, donate_weights=True)
+    config.pop("quantization_config", None)
+    save_config(config, mlx_path / "config.json")
+    for fname in _AUX_FILES:
+        src = hf_path / fname
+        if src.exists():
+            shutil.copy(src, mlx_path / fname)
+
+    total = sum(f.stat().st_size for f in mlx_path.glob("*.safetensors"))
+    print(f"[INFO] Done! Model saved to {mlx_path} ({total / 1024**3:.2f} GB)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Convert an mlx-vlm model to TurboQuant-compressed MLX format"
+    )
+    parser.add_argument("--hf-path", "--model", type=str, required=True,
+                        help="HuggingFace model path or local path")
+    parser.add_argument("--mlx-path", type=str, required=True,
+                        help="Output directory for the MLX model")
+    parser.add_argument("--bits", "-b", type=int, default=3, choices=[2, 3, 4],
+                        help="Quantization bit-width (default: 3)")
+    parser.add_argument("--group-size", "-g", type=int, default=32,
+                        choices=[32, 64, 128], help="Group size (default: 32)")
+    parser.add_argument("--rotation", type=str, default="hadamard",
+                        choices=["hadamard", "blockwise_hadamard", "none"])
+    parser.add_argument("--rotation-seed", type=int, default=42)
+    parser.add_argument("--attn-bits", type=int, default=None, choices=[2, 3, 4],
+                        help="Override bits for attention-block linears")
+    parser.add_argument("--mlp-bits", type=int, default=None, choices=[2, 3, 4],
+                        help="Override bits for MLP / MoE expert linears")
+    args = parser.parse_args()
+
+    convert_vlm(
+        hf_path=args.hf_path,
+        mlx_path=args.mlx_path,
+        bits=args.bits,
+        group_size=args.group_size,
+        rotation=args.rotation,
+        rotation_seed=args.rotation_seed,
+        attn_bits=args.attn_bits,
+        mlp_bits=args.mlp_bits,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/generate_vlm.py
+++ b/generate_vlm.py
@@ -1,0 +1,65 @@
+"""Generate with a TurboQuant-compressed mlx-vlm model (multimodal/diffusion).
+
+Loads the model via turboquant_mlx.integration.vlm (PolarQuantized layers),
+then runs mlx-vlm's generation dispatch — for diffusion architectures such as
+DiffusionGemma that is the block-diffusion denoising sampler.
+
+Usage:
+    python -m turboquant_mlx.generate_vlm \\
+        --model manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32 \\
+        --prompt "Write a short paragraph about the ocean." \\
+        --max-tokens 256 --temp 0.0
+
+Requires:  pip install "turboquant-mlx-full[vlm]"
+"""
+
+import argparse
+import time
+
+import mlx.core as mx
+
+import turboquant_mlx.compat  # noqa: F401 — registers upstream patches on import
+from turboquant_mlx.generate import resolve_model_path
+from turboquant_mlx.integration.vlm import _require_mlx_vlm, load_turboquant_vlm
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Generate text with a TurboQuant-compressed mlx-vlm model"
+    )
+    parser.add_argument("--model", type=str, required=True,
+                        help="TurboQuant model directory or HF repo ID")
+    parser.add_argument("--prompt", type=str,
+                        default="Write a short paragraph about the ocean.")
+    parser.add_argument("--max-tokens", type=int, default=256)
+    parser.add_argument("--temp", "--temperature", type=float, default=0.0,
+                        help="Sampling temperature (default: 0.0)")
+    parser.add_argument("--image", type=str, default=None,
+                        help="Optional image path/URL for multimodal prompts")
+    args = parser.parse_args()
+
+    _require_mlx_vlm()
+    from mlx_vlm import generate
+    from mlx_vlm.prompt_utils import apply_chat_template
+
+    model_path = resolve_model_path(args.model)
+
+    t0 = time.time()
+    model, processor, config = load_turboquant_vlm(model_path)
+    print(f"[INFO] Loaded in {time.time() - t0:.1f}s")
+
+    num_images = 1 if args.image else 0
+    formatted = apply_chat_template(processor, config, args.prompt,
+                                    num_images=num_images)
+    generate(
+        model, processor, formatted,
+        image=[args.image] if args.image else None,
+        max_tokens=args.max_tokens,
+        temperature=args.temp,
+        verbose=True,
+    )
+    print(f"peak memory: {mx.get_peak_memory() / 1024**3:.2f} GB")
+
+
+if __name__ == "__main__":
+    main()

--- a/integration/rotation_configs.py
+++ b/integration/rotation_configs.py
@@ -158,6 +158,10 @@ ROTATION_CONFIGS: dict[str, LayerRotationConfig] = {
     "deepseek_v2": DEEPSEEK_MLA_MOE_CONFIG,
     "deepseek_v3": DEEPSEEK_MLA_MOE_CONFIG,
     "deepseek_v32": DEEPSEEK_MLA_MOE_CONFIG,
+    # DiffusionGemma (block-diffusion MoE, lives in mlx-vlm — see convert_vlm).
+    # Same pre-norm attn + SwitchGLU-style expert layout as MoE LLaMA; only
+    # consulted when fuse_rotations=True (production uses online rotation).
+    "diffusion_gemma": MOE_LLAMA_CONFIG,
 }
 
 

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -1,0 +1,119 @@
+"""mlx-vlm integration: convert/load TurboQuant models whose architectures
+live in mlx-vlm rather than mlx-lm (multimodal and diffusion LLMs).
+
+mlx-vlm's stock loader cannot be used directly on a TurboQuant checkpoint:
+it sees ``config["quantization"]`` and applies ``nn.quantize`` (affine),
+which does not understand the polar codebook format. ``load_turboquant_vlm``
+replicates its model-construction steps and swaps in PolarQuantized layers
+instead (mirroring ``turboquant_mlx.generate.load_turboquant`` for mlx-lm).
+
+Requires the optional dependency:  pip install "turboquant-mlx-full[vlm]"
+"""
+
+import glob
+from pathlib import Path
+
+import mlx.core as mx
+
+from turboquant_mlx.config import TurboQuantConfig
+from turboquant_mlx.generate import _prepare_polar_layers
+
+
+def _require_mlx_vlm():
+    try:
+        import mlx_vlm  # noqa: F401
+        from mlx_vlm import utils  # noqa: F401
+    except ImportError as e:
+        raise ImportError(
+            "mlx-vlm >= 0.6.3 is required for VLM/diffusion architectures. "
+            'Install with: pip install "turboquant-mlx-full[vlm]"'
+        ) from e
+
+
+# Per-architecture layers kept at full precision IN ADDITION to the always-on
+# skips (vision/audio towers via mlx_vlm.utils.skip_multimodal_module, MoE
+# routers, embeddings). Substring match on the module path.
+#
+# diffusion_gemma: the model's own upstream quant_predicate pins the router
+# and the dense per-layer MLP at >= 8-bit (quant-sensitive); the
+# self-conditioning MLP feeds every denoise step and is tiny. ".mlp." matches
+# only the dense MLP — experts live under ".experts." as SwitchLinear.
+VLM_SKIP_PATTERNS: dict[str, tuple[str, ...]] = {
+    "diffusion_gemma": ("router", "self_conditioning", "embed_vision", ".mlp."),
+}
+
+
+def vlm_should_quantize(arch: str, base_predicate):
+    """Wrap the converter's _should_quantize with VLM-specific skips."""
+    _require_mlx_vlm()
+    from mlx_vlm.utils import skip_multimodal_module
+
+    skip_patterns = VLM_SKIP_PATTERNS.get(arch, ())
+
+    def predicate(path, module):
+        if skip_multimodal_module(path):
+            return False
+        if any(s in path for s in skip_patterns):
+            return False
+        return base_predicate(path, module)
+
+    return predicate
+
+
+def load_turboquant_vlm(model_path, lazy=False):
+    """Load a TurboQuant-compressed mlx-vlm model.
+
+    Args:
+        model_path: Local directory containing the TurboQuant checkpoint.
+        lazy: If True, don't evaluate parameters immediately.
+
+    Returns:
+        (model, processor, config) tuple. ``config`` is the raw dict with the
+        "quantization" key removed (as mlx-vlm's prompt utilities expect).
+    """
+    _require_mlx_vlm()
+    from mlx_vlm.utils import (
+        apply_generation_config_defaults,
+        get_model_and_args,
+        load_config,
+        load_processor,
+        update_module_configs,
+    )
+
+    model_path = Path(model_path)
+    config = load_config(model_path)
+
+    tq_dict = config.pop("quantization", None)
+    if tq_dict is None or tq_dict.get("mode") != "turboquant":
+        raise ValueError(f"{model_path} is not a TurboQuant checkpoint")
+    tq_config = TurboQuantConfig.from_dict(tq_dict)
+    config.pop("quantization_config", None)
+
+    model_class, _ = get_model_and_args(config=config)
+    config.setdefault("text_config", config.pop("llm_config", {}))
+    config.setdefault("vision_config", {})
+    config.setdefault("audio_config", {})
+    model_config = model_class.ModelConfig.from_dict(config)
+    model_config = update_module_configs(
+        model_config, model_class, config,
+        ["text", "vision", "perceiver", "projector", "audio"],
+    )
+    model_config = apply_generation_config_defaults(model_config, config)
+    model = model_class.Model(model_config)
+
+    weights = {}
+    for wf in sorted(glob.glob(str(model_path / "model*.safetensors"))):
+        weights.update(mx.load(wf))
+
+    # TurboQuant checkpoints are saved from the model tree (mlx format),
+    # so no weight sanitization is needed before loading.
+    _prepare_polar_layers(model, weights, tq_config)
+    model.load_weights(list(weights.items()), strict=False)
+
+    if not lazy:
+        mx.eval(model.parameters())
+    model.model_path = model_path
+    model.eval()
+
+    processor = load_processor(model_path)
+    return model, processor, config

--- a/kernels/polar_dequant_experts.py
+++ b/kernels/polar_dequant_experts.py
@@ -1,0 +1,94 @@
+"""Fused Metal kernel: dequantize all experts of a PolarQuantized switch layer.
+
+Unpacks the codebook indices, applies the per-group scales, and writes fp16
+expert weights in one pass — one thread per (expert, row, group). This is
+pure-bandwidth work and replaces the multi-op Python unpack path (~11x faster
+at DiffusionGemma expert shapes, bit-identical output).
+
+Used by PolarQuantizedSwitchLinear._dequantize_all and by the large-batch
+routing path (dequant + mx.gather_mm), where materializing fp16 weights once
+per call beats per-row gather kernels that re-read activations per output row.
+"""
+
+import mlx.core as mx
+
+_kernel_cache: dict[tuple[int, int], object] = {}
+
+
+def _get_kernel(bits: int, group_size: int):
+    key = (bits, group_size)
+    if key in _kernel_cache:
+        return _kernel_cache[key]
+
+    n_codes = 1 << bits
+    elems_per_u32 = 32 // bits
+    mask = (1 << bits) - 1
+
+    source = f"""
+    uint gid = thread_position_in_grid.x;
+    uint n_groups = scales_shape[2];
+    uint out_rows = scales_shape[1];
+    uint pw_cols = packed_weight_shape[2];
+    uint in_dims = n_groups * {group_size}u;
+    uint total = scales_shape[0] * out_rows * n_groups;
+    if (gid >= total) return;
+
+    uint g = gid % n_groups;
+    uint row = (gid / n_groups) % out_rows;
+    uint e = gid / (n_groups * out_rows);
+
+    float cb[{n_codes}];
+    for (uint i = 0; i < {n_codes}u; i++) {{ cb[i] = float(codebook[i]); }}
+
+    float scale = float(scales[gid]);
+    uint pw_base = (e * out_rows + row) * pw_cols;
+    uint out_base = (e * out_rows + row) * in_dims + g * {group_size}u;
+
+    for (uint t = 0; t < {group_size}u; t++) {{
+        uint col = g * {group_size}u + t;
+        uint word = packed_weight[pw_base + col / {elems_per_u32}u];
+        uint code = (word >> ((col % {elems_per_u32}u) * {bits}u)) & {mask}u;
+        out[out_base + t] = T(cb[code] * scale);
+    }}
+    """
+    _kernel_cache[key] = mx.fast.metal_kernel(
+        name=f"polar_dequant_experts_{bits}bit_gs{group_size}",
+        input_names=["packed_weight", "scales", "codebook"],
+        output_names=["out"],
+        source=source,
+        ensure_row_contiguous=True,
+    )
+    return _kernel_cache[key]
+
+
+def polar_dequant_experts(
+    packed_weight: mx.array,
+    scales: mx.array,
+    codebook: mx.array,
+    bits: int,
+    group_size: int,
+) -> mx.array:
+    """Dequantize packed expert weights to float.
+
+    Args:
+        packed_weight: (num_experts, output_dims, packed_cols) uint32.
+        scales: (num_experts, output_dims, n_groups) float16.
+        codebook: (2^bits,) float16.
+        bits: Quantization bit-width (2, 3, or 4).
+        group_size: Elements per quantization group.
+
+    Returns:
+        (num_experts, output_dims, n_groups * group_size) in scales.dtype.
+    """
+    kernel = _get_kernel(bits, group_size)
+    num_experts, output_dims, n_groups = scales.shape
+    input_dims = n_groups * group_size
+    total = num_experts * output_dims * n_groups
+    return kernel(
+        inputs=[packed_weight, scales, codebook],
+        template=[("T", scales.dtype)],
+        grid=(total, 1, 1),
+        threadgroup=(256, 1, 1),
+        output_shapes=[(num_experts, output_dims, input_dims)],
+        output_dtypes=[scales.dtype],
+    )[0]

--- a/layers/polar_switch_linear.py
+++ b/layers/polar_switch_linear.py
@@ -23,6 +23,19 @@ from turboquant_mlx.core.rotation import rotate_input
 # Use Python kernels - native C++ extension has ABI issues with MLX
 from turboquant_mlx.kernels.polar_gather_qmv import polar_gather_qmv
 from turboquant_mlx.kernels.polar_multi_gather_qmv import polar_multi_gather_qmv
+from turboquant_mlx.kernels.polar_dequant_experts import polar_dequant_experts
+
+# Above this many (token, expert) routings, materializing fp16 expert weights
+# once (fused dequant + mx.gather_mm) beats the per-row gather kernels, which
+# re-read the activation vector from global memory per output row. Diffusion
+# canvas forwards (e.g. DiffusionGemma: 256 tokens x top-8 = 2048 routings)
+# sit far above this; autoregressive decode sits far below.
+_GATHER_MM_MIN_ROUTINGS = 512
+
+# ... but only when the full dequantized expert tensor stays small. Models
+# with hundreds of large experts (e.g. 512-expert LatentMoE) would OOM on the
+# materialization (issue #1), so they keep the gather kernels at any k.
+_GATHER_MM_MAX_DEQUANT_BYTES = 2 << 30
 
 
 class PolarQuantizedSwitchLinear(nn.Module):
@@ -76,35 +89,22 @@ class PolarQuantizedSwitchLinear(nn.Module):
         self.freeze()
 
     def _dequantize_all(self) -> mx.array:
-        """Dequantize all expert weights to float16 (vectorized).
+        """Dequantize all expert weights to float16 (fused Metal kernel).
 
-        Processes all experts in a single batched operation instead of
-        looping, which is much faster on Metal.
+        Single-pass unpack + codebook lookup + group scaling — bit-identical
+        to the previous multi-op Python path and ~11x faster at MoE shapes.
 
         Returns:
             (num_experts, output_dims, input_dims) float16 tensor.
         """
-        from turboquant_mlx.core.packing import unpack_indices
-        from turboquant_mlx.core.codebook import dequantize_scalar
+        return polar_dequant_experts(
+            self.weight, self.scales, self.codebook,
+            self.bits, self.group_size,
+        )
 
-        # self.weight: (num_experts, output_dims, packed_cols)
-        # self.scales: (num_experts, output_dims, n_groups)
-        n_groups = self.input_dims // self.group_size
-
-        # Unpack all experts at once — unpack_indices handles batch dims
-        indices = unpack_indices(self.weight, self.bits, self.input_dims)
-        # indices: (num_experts, output_dims, input_dims) uint8
-
-        # Codebook lookup — vectorized across all experts
-        w_deq = dequantize_scalar(indices, self.codebook)
-        # w_deq: (num_experts, output_dims, input_dims) float16
-
-        # Apply per-group scales
-        w_deq = w_deq.reshape(self.num_experts, self.output_dims, n_groups, self.group_size)
-        scales_expanded = mx.expand_dims(self.scales, axis=-1)
-        w_deq = w_deq * scales_expanded
-
-        return w_deq.reshape(self.num_experts, self.output_dims, self.input_dims)
+    def _dequant_bytes(self) -> int:
+        """Size of the fully materialized fp16 expert tensor."""
+        return self.num_experts * self.output_dims * self.input_dims * 2
 
     def __call__(self, x, indices, sorted_indices=False):
         # Apply online rotation to input if not fused into preceding norm
@@ -146,6 +146,24 @@ class PolarQuantizedSwitchLinear(nn.Module):
             return y
 
         if n_tokens == k:
+            # Large batched routing (diffusion canvas / big prefill via
+            # SwitchMLP's do_sort): the per-row gather kernel re-reads x per
+            # output row, so past _GATHER_MM_MIN_ROUTINGS it loses to a fused
+            # dequant + native gather_mm — but only when the materialized
+            # fp16 expert tensor stays small (512-expert models would OOM).
+            if (k >= _GATHER_MM_MIN_ROUTINGS
+                    and self._dequant_bytes() <= _GATHER_MM_MAX_DEQUANT_BYTES):
+                w_deq = self._dequantize_all()
+                y = mx.gather_mm(
+                    x,
+                    w_deq.swapaxes(-1, -2),
+                    rhs_indices=indices,
+                    sorted_indices=sorted_indices,
+                )
+                if "bias" in self:
+                    y = y + mx.expand_dims(self["bias"][indices], -2)
+                return y
+
             # Multi-input decode: k expert vectors (down_proj path)
             # x shape: (..., k, 1, input_dims) — one vector per expert
             # Use polar_multi_gather_qmv to avoid dequantizing all experts

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.6.2"
+version = "0.7.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -46,6 +46,7 @@ dependencies = [
 [project.optional-dependencies]
 eval = ["datasets", "transformers"]
 dev = ["pytest", "build", "twine"]
+vlm = ["mlx-vlm>=0.6.3"]
 
 [project.urls]
 Homepage = "https://github.com/manjunathshiva/turboquant-mlx"

--- a/tests/test_polar_dequant_experts.py
+++ b/tests/test_polar_dequant_experts.py
@@ -1,0 +1,92 @@
+"""Tests for the fused expert-dequant kernel and the large-batch switch routing."""
+
+import math
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.kernels.polar_dequant_experts import polar_dequant_experts
+from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
+
+
+def _make_layer(num_experts=4, output_dims=64, input_dims=128, bits=3, group_size=32):
+    mx.random.seed(0)
+    w = mx.random.normal((num_experts, output_dims, input_dims)).astype(mx.float16)
+    return PolarQuantizedSwitchLinear.from_switch_linear(
+        None, bits=bits, group_size=group_size, seed=7, float_weight=w,
+    )
+
+
+def _dequantize_all_reference(layer):
+    """The pre-0.7.0 multi-op Python dequant path, kept as the test oracle."""
+    from turboquant_mlx.core.packing import unpack_indices
+    from turboquant_mlx.core.codebook import dequantize_scalar
+
+    n_groups = layer.input_dims // layer.group_size
+    indices = unpack_indices(layer.weight, layer.bits, layer.input_dims)
+    w_deq = dequantize_scalar(indices, layer.codebook)
+    w_deq = w_deq.reshape(layer.num_experts, layer.output_dims, n_groups,
+                          layer.group_size)
+    w_deq = w_deq * mx.expand_dims(layer.scales, axis=-1)
+    return w_deq.reshape(layer.num_experts, layer.output_dims, layer.input_dims)
+
+
+@pytest.mark.parametrize("bits", [2, 3, 4])
+@pytest.mark.parametrize("group_size", [32, 64])
+def test_kernel_matches_python_dequant(bits, group_size):
+    layer = _make_layer(bits=bits, group_size=group_size)
+    ref = _dequantize_all_reference(layer)
+    got = polar_dequant_experts(
+        layer.weight, layer.scales, layer.codebook, bits, group_size,
+    )
+    mx.eval(ref, got)
+    assert got.shape == ref.shape
+    assert float(mx.abs(got - ref).max()) == 0.0  # bit-identical
+
+
+def test_dequantize_all_uses_kernel():
+    layer = _make_layer()
+    ref = _dequantize_all_reference(layer)
+    got = layer._dequantize_all()
+    mx.eval(ref, got)
+    assert float(mx.abs(got - ref).max()) == 0.0
+
+
+def test_large_batch_routing_matches_gather_kernel():
+    """The >=512-routing gather_mm path must match polar_multi_gather_qmv."""
+    layer = _make_layer(num_experts=8, output_dims=32, input_dims=64)
+    k = 1024  # above _GATHER_MM_MIN_ROUTINGS, sorted-prefill style shapes
+    mx.random.seed(1)
+    x = mx.random.normal((k, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.sort(mx.random.randint(0, layer.num_experts, (k,)).astype(mx.uint32))
+    mx.eval(x, idx)
+
+    y_fast = layer(x, idx, sorted_indices=True)
+
+    # Force the original kernel path by lowering k below the threshold split:
+    # call per-chunk so each call stays under the routing threshold.
+    chunks = []
+    step = 256
+    for s in range(0, k, step):
+        chunks.append(layer(x[s:s + step], idx[s:s + step], sorted_indices=True))
+    y_ref = mx.concatenate(chunks, axis=0)
+    mx.eval(y_fast, y_ref)
+
+    assert y_fast.shape == y_ref.shape
+    # The gather kernel keeps codebook*x products in fp32; the gather_mm path
+    # rounds dequantized weights to fp16 first — so compare relatively.
+    a = y_fast.astype(mx.float32)
+    b = y_ref.astype(mx.float32)
+    rel = float(mx.linalg.norm(a - b) / (mx.linalg.norm(b) + 1e-12))
+    assert rel < 2e-3
+
+
+def test_small_k_keeps_gather_kernel_path():
+    """Decode-scale calls (k below threshold) must be unaffected."""
+    layer = _make_layer(num_experts=8, output_dims=32, input_dims=64)
+    x = mx.random.normal((1, 1, 8, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.random.randint(0, layer.num_experts, (1, 1, 8)).astype(mx.uint32)
+    mx.eval(x, idx)
+    y = layer(x, idx)
+    mx.eval(y)
+    assert y.shape == (1, 1, 8, 1, layer.output_dims)


### PR DESCRIPTION
## Summary

Adds **mlx-vlm architecture support** to TurboQuant — convert, load, and generate for models whose architectures live in [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) rather than mlx-lm. First supported model: **google/diffusiongemma-26B-A4B-it** (block-diffusion MoE, 25.2B total / 3.8B active, `model_type: diffusion_gemma`), converted to tq3-g32 and published as [manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32](https://huggingface.co/manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32).

## What's in here

- **`convert_vlm.py`** (`python -m turboquant_mlx.convert_vlm`) — mlx-vlm load/save around the model-agnostic `turboquant_quantize` core. Per-arch full-precision skips live in `integration/vlm.py::VLM_SKIP_PATTERNS`: vision/audio towers, MoE routers, and for `diffusion_gemma` also the dense per-layer MLP + self-conditioning block (the upstream model's own `quant_predicate` pins those at >=8-bit).
- **`generate_vlm.py`** + **`integration/vlm.py::load_turboquant_vlm`** — TQ-aware loader (stock `mlx_vlm.load_model` sees `config["quantization"]` and mis-applies affine `nn.quantize`), feeding mlx-vlm's generation dispatch including the block-diffusion denoising sampler.
- **`kernels/polar_dequant_experts.py`** — fused one-pass expert dequant (unpack + codebook + group scales). **Bit-identical** to the old multi-op Python path and ~11x faster (3.6 ms vs 41 ms at DiffusionGemma shapes); now backs `PolarQuantizedSwitchLinear._dequantize_all`.
- **`PolarQuantizedSwitchLinear`** — batched calls with >=512 token-expert routings (diffusion canvas forwards, large sorted prefills) route to fused dequant + `mx.gather_mm` instead of the per-row gather kernel (which re-reads activations per output row at that scale). ~2x end-to-end on DiffusionGemma denoising. Guarded by a 2 GiB cap on materialized weights so many-large-expert models (512-expert LatentMoE, issue #1) keep the memory-safe gather kernels.
- `diffusion_gemma` rotation-config entry, `[vlm]` extra (`mlx-vlm>=0.6.3`), version **0.7.0**, CHANGELOG, README section + architecture-table row.

## Validation

- `pytest tests/` — **55 passed** (new: kernel bit-identity across bits 2/3/4 × gs 32/64; large-batch routing parity vs gather kernel; decode-path regression guard)
- `convert_vlm` on the real 48 GB bf16 checkpoint: 60 SwitchLinear + 115 Linear quantized, 13.84 GB out, byte-count identical to the script prototype
- `generate_vlm` on the converted model: correct math/recall/code spot checks, 21.5 GB peak
- Known limitation (documented in README + model card): DiffusionGemma decode is ~1.6 tok/s vs ~35 for native 4-bit — closing that needs a batched codebook gather-GEMM kernel (follow-up)

## Release

Version bumped to 0.7.0 in `pyproject.toml` + `__init__.py`. After merge, tagging `v0.7.0` fires the release workflow (PyPI via OIDC, gated on the `pypi` environment approval).