### PR TITLE
feat(vlm): 16 GB Mac support — expert layer protection + 8-bit affine extras (0.8.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-06-12
+
+### Added — 16 GB Mac support for VLM/diffusion models
+
+- **`convert_vlm --protect-expert-layers 0,1,2,27,28,29 --protect-bits 3`** —
+  expert layer protection: keep the listed layers' experts at 3-bit while the
+  rest drop to `--bits` (e.g. 2-bit). On DiffusionGemma-26B-A4B, unprotected
+  2-bit experts break arithmetic entirely (17×23 → "3"); protecting the
+  first/last three layers restores it (391, correct multi-step chains) for
+  +0.2 GB.
+- **`convert_vlm --quantize-extras`** — quantizes the remaining bf16 modules
+  (embeddings, dense per-layer MLP, vision tower) to 8-bit affine; routers
+  and self-conditioning stay full precision. `load_turboquant_vlm` applies
+  the matching `nn.quantize` on load (affine modules are recognized by
+  having `.scales` without `.codebook`). Mini build of DiffusionGemma:
+  **9.79 GB** on disk, ~12.4 GB peak at `--max-tokens 120` — vs 13.84 GB /
+  OOM before.
+- **`generate_vlm --max-denoising-steps / --max-canvas-length`** — speed and
+  memory knobs for diffusion sampling (quantized models need more denoise
+  steps to converge; capping trades quality for speed).
+
+### Changed
+
+- `_prepare_polar_layers` now infers each layer's bit width from its saved
+  **codebook size** (2^bits entries) instead of re-deriving it from path
+  rules — required for per-layer bit assignments (layer protection) and
+  immune to config/path drift.
+
 ## [0.7.1] - 2026-06-12
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.7.1"
+__version__ = "0.8.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/convert_vlm.py
+++ b/convert_vlm.py
@@ -17,8 +17,10 @@ Requires:  pip install "turboquant-mlx-full[vlm]"
 """
 
 import argparse
+import re
 import shutil
 import time
+import types
 from pathlib import Path
 
 import mlx.core as mx
@@ -35,6 +37,10 @@ _AUX_FILES = (
     "preprocessor_config.json", "special_tokens_map.json",
 )
 
+# --quantize-extras: affine quantization for the non-TurboQuant remainder.
+_EXTRAS_BITS = 8
+_EXTRAS_GROUP = 64
+
 
 def convert_vlm(
     hf_path: str,
@@ -45,6 +51,9 @@ def convert_vlm(
     rotation_seed: int = 42,
     attn_bits: int = None,
     mlp_bits: int = None,
+    quantize_extras: bool = False,
+    protect_expert_layers: list = None,
+    protect_bits: int = 3,
 ):
     """Convert an mlx-vlm model to TurboQuant format. See module docstring."""
     _require_mlx_vlm()
@@ -72,6 +81,27 @@ def convert_vlm(
         mlp_bits=mlp_bits,
     )
 
+    if protect_expert_layers:
+        # Layer protection: keep the experts of the listed layers at
+        # `protect_bits` while the rest use the default `bits`. The cheapest
+        # quality lift for 2-bit experts — the first/last layers carry the
+        # most quant-sensitive expert work. The loader needs no knowledge of
+        # this: per-layer bits are inferred from each saved codebook's size.
+        protected = set(int(i) for i in protect_expert_layers)
+        layer_rx = re.compile(r"\.layers\.(\d+)\.")
+        base_bfp = tq_config.bits_for_path
+
+        def _bits_for_path(self, path):
+            if ".experts." in path:
+                m = layer_rx.search(path)
+                if m and int(m.group(1)) in protected:
+                    return protect_bits
+            return base_bfp(path)
+
+        tq_config.bits_for_path = types.MethodType(_bits_for_path, tq_config)
+        print(f"[INFO] Expert layer protection: layers {sorted(protected)} "
+              f"-> {protect_bits}b")
+
     print(f"[INFO] Loading {hf_path} via mlx-vlm (lazy)")
     config = load_config(hf_path)
     model = load_model(hf_path, lazy=True)
@@ -90,6 +120,40 @@ def convert_vlm(
         print(f"[INFO] Quantization completed in {time.time() - t0:.1f}s")
     finally:
         _qm._should_quantize = orig_should_quantize
+
+    if quantize_extras:
+        # Memory-constrained targets (e.g. 16 GB Mac mini): quantize the
+        # remaining bf16 modules (embeddings, dense MLP, vision tower) to
+        # mlx 8-bit affine. Polar layers are untouched (no `to_quantized`);
+        # routers and self-conditioning stay full precision — both are tiny
+        # and routing/conditioning fidelity matters more than their bytes.
+        import mlx.nn as nn
+
+        n_extra = [0]
+
+        def _extras_predicate(p, m):
+            if not hasattr(m, "to_quantized"):
+                return False
+            if "router" in p or "self_conditioning" in p:
+                return False
+            if hasattr(m, "weight") and m.weight.shape[-1] % _EXTRAS_GROUP != 0:
+                return False  # e.g. vision MLP down (4304-wide) stays bf16
+            n_extra[0] += 1
+            return True
+
+        nn.quantize(model, group_size=_EXTRAS_GROUP, bits=_EXTRAS_BITS,
+                    class_predicate=_extras_predicate)
+        mx.eval(model.parameters())
+        config["quantization"]["affine_extras"] = {
+            "bits": _EXTRAS_BITS, "group_size": _EXTRAS_GROUP,
+        }
+        print(f"[INFO] Quantized {n_extra[0]} extra modules to "
+              f"{_EXTRAS_BITS}-bit affine (embeddings/dense MLP/vision)")
+
+    if protect_expert_layers:
+        config["quantization"]["protected_expert_layers"] = sorted(
+            int(i) for i in protect_expert_layers)
+        config["quantization"]["protect_bits"] = protect_bits
 
     print(f"[INFO] Saving to {mlx_path}")
     save_weights(mlx_path, model, donate_weights=True)
@@ -123,6 +187,17 @@ def main():
                         help="Override bits for attention-block linears")
     parser.add_argument("--mlp-bits", type=int, default=None, choices=[2, 3, 4],
                         help="Override bits for MLP / MoE expert linears")
+    parser.add_argument("--quantize-extras", action="store_true",
+                        help="Also quantize embeddings, dense MLP and vision "
+                             "tower to 8-bit affine (for memory-constrained "
+                             "machines, e.g. 16 GB Macs)")
+    parser.add_argument("--protect-expert-layers", type=str, default=None,
+                        help="Comma-separated layer indices whose EXPERTS keep "
+                             "--protect-bits instead of --bits (quality lift "
+                             "for 2-bit experts, e.g. '0,1,2,27,28,29')")
+    parser.add_argument("--protect-bits", type=int, default=3,
+                        choices=[3, 4],
+                        help="Bit width for protected expert layers (default 3)")
     args = parser.parse_args()
 
     convert_vlm(
@@ -134,6 +209,11 @@ def main():
         rotation_seed=args.rotation_seed,
         attn_bits=args.attn_bits,
         mlp_bits=args.mlp_bits,
+        quantize_extras=args.quantize_extras,
+        protect_expert_layers=(
+            [int(i) for i in args.protect_expert_layers.split(",")]
+            if args.protect_expert_layers else None),
+        protect_bits=args.protect_bits,
     )
 
 

--- a/generate.py
+++ b/generate.py
@@ -68,7 +68,13 @@ def _prepare_polar_layers(model, weights, tq_config):
         has_bias = f"{path}.bias" in weights
         has_qjl = f"{path}.qjl_packed" in weights
 
-        layer_bits = tq_config.bits_for_path(path)
+        # Authoritative per-layer bit width: the saved codebook has 2^bits
+        # entries. This survives any per-layer bit assignment the converter
+        # used (hybrids, layer protection) without re-deriving path rules.
+        cb_size = int(weights[f"{path}.codebook"].shape[-1])
+        layer_bits = max(1, cb_size.bit_length() - 1)
+        if (1 << layer_bits) != cb_size:  # non-power-of-two: fall back
+            layer_bits = tq_config.bits_for_path(path)
 
         if has_switch and isinstance(module, SwitchLinear):
             num_experts, output_dims, input_dims = module.weight.shape

--- a/generate_vlm.py
+++ b/generate_vlm.py
@@ -36,6 +36,13 @@ def main():
                         help="Sampling temperature (default: 0.0)")
     parser.add_argument("--image", type=str, default=None,
                         help="Optional image path/URL for multimodal prompts")
+    parser.add_argument("--max-denoising-steps", type=int, default=None,
+                        help="Cap diffusion denoising steps (model default 48)."
+                             " Lower = faster, mild quality cost (try 24)")
+    parser.add_argument("--max-canvas-length", type=int, default=None,
+                        help="Cap the diffusion canvas length (model default "
+                             "256). Lower = smaller activation memory, useful "
+                             "on 16 GB machines (try 128)")
     args = parser.parse_args()
 
     _require_mlx_vlm()
@@ -51,12 +58,18 @@ def main():
     num_images = 1 if args.image else 0
     formatted = apply_chat_template(processor, config, args.prompt,
                                     num_images=num_images)
+    gen_kwargs = {}
+    if args.max_denoising_steps is not None:
+        gen_kwargs["max_denoising_steps"] = args.max_denoising_steps
+    if args.max_canvas_length is not None:
+        gen_kwargs["diffusion_max_canvas_length"] = args.max_canvas_length
     generate(
         model, processor, formatted,
         image=[args.image] if args.image else None,
         max_tokens=args.max_tokens,
         temperature=args.temp,
         verbose=True,
+        **gen_kwargs,
     )
     print(f"peak memory: {mx.get_peak_memory() / 1024**3:.2f} GB")
 

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -108,6 +108,25 @@ def load_turboquant_vlm(model_path, lazy=False):
     # TurboQuant checkpoints are saved from the model tree (mlx format),
     # so no weight sanitization is needed before loading.
     _prepare_polar_layers(model, weights, tq_config)
+
+    # Checkpoints converted with --quantize-extras also carry 8-bit affine
+    # modules (embeddings, dense MLP, vision tower). Affine layers have
+    # `.scales` but no `.codebook` in the saved weights.
+    affine = tq_dict.get("affine_extras")
+    if affine:
+        import mlx.nn as nn
+
+        nn.quantize(
+            model,
+            group_size=int(affine["group_size"]),
+            bits=int(affine["bits"]),
+            class_predicate=lambda p, m: (
+                hasattr(m, "to_quantized")
+                and f"{p}.scales" in weights
+                and f"{p}.codebook" not in weights
+            ),
+        )
+
     model.load_weights(list(weights.items()), strict=False)
 
     if not lazy:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.7.1"
+version = "0.8.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

Addresses the 16 GB Mac mini OOM on DiffusionGemma TurboQuant builds: the tq3 checkpoint needs ~14.2 GB against the mini's ~12.1 GB Metal budget. This PR adds the two conversion levers that get a quality-preserving build under it, plus the sampler knobs.

## What's in here

- **`convert_vlm --protect-expert-layers 0,1,2,27,28,29 --protect-bits 3`** — expert layer protection. Raw 2-bit experts break arithmetic on DiffusionGemma (17×23 → "3"); protecting the first/last three layers' experts at 3-bit **restores math** (391 ✓, multi-step chains ✓) for +0.2 GB. Cheapest rung of the 2-bit quality ladder.
- **`convert_vlm --quantize-extras`** — embeddings, dense per-layer MLP, and vision tower drop from bf16 to **8-bit affine** (~1.6 GB saved); routers and self-conditioning stay full precision. `load_turboquant_vlm` recognizes affine modules on load (`.scales` without `.codebook`) and applies the matching `nn.quantize`.
- **`generate_vlm --max-denoising-steps / --max-canvas-length`** — documented speed/memory knobs (quantized diffusion needs more denoise steps to converge; capping trades quality for speed).
- **Loader robustness**: `_prepare_polar_layers` now infers per-layer bits from each saved **codebook's size** (2^bits entries) instead of re-deriving path rules — required for per-layer bit maps and immune to the bits_for_path/path-drift hazard class.

## Mini build measured (attn 3b + experts 2b w/ 6 protected layers + 8-bit extras, g32)

| | tq3-g32 | mini build |
|---|---|---|
| Size on disk | 13.84 GB | **9.79 GB** |
| Peak (`--max-tokens 120`) | ~18 GB | **~12.4 GB** |
| 17×23 | 391 ✓ | **391 ✓** |
| 144/12+7×3 (steps) | 33 ✓ | **33 ✓** |
| In-context recall | exact | **exact** |
| Prose | minor artifacts | minor artifacts |

(Unprotected 2-bit experts for comparison: math broken, prose noisy.)

## Validation

- 72 tests pass (includes the codebook-size bits inference via existing loader-paths)
- Mini build converted end-to-end via the new flags; quality probes above; plain tq3 checkpoint regression-checked through the updated loader

Version 0.8.0; after merge, tagging `v0.8.0` fires the release.