### PR TITLE
feat(serve): TurboQuant KV-cache quantization for turboquant-serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`turboquant-serve` KV-cache quantization** — the server now accepts the
+  same KV-quant flags as `turboquant-generate` (`--kv-bits`, `--kv-k-bits` /
+  `--kv-v-bits`, `--kv-min-tokens`, `--kv-group-size`). `mlx_lm.server` has no
+  native KV-quant option, so these are parsed by the wrapper and stripped
+  before the remaining flags forward on; when set, every per-request prompt
+  cache has its standard `KVCache` layers swapped for `TurboQuantKVCache`
+  (other cache types — sliding-window / Mamba — pass through untouched, so
+  hybrid models like GPT-OSS and Nemotron-H keep working). This shrinks each
+  in-flight request's KV ~4x, which is the dominant memory lever for agentic
+  loops (Aider, Claude Code) on memory-constrained boxes — distinct from
+  `--prompt-cache-bytes`, which only bounds the cross-request reuse pool.
+  Enabling KV-quant forces single-stream serving (TurboQuant caches lack the
+  `merge` the batch generator needs).
+
 ## [0.8.0] - 2026-06-12
 
 ### Added — 16 GB Mac support for VLM/diffusion models

--- a/README.md
+++ b/README.md
@@ -326,6 +326,42 @@ Also close any other GPU users (Chrome/Electron apps, Final Cut, Xcode
 simulators) before launching — even an idle Chrome can be holding 1-2 GB
 of unified memory.
 
+#### Compress the KV cache while serving
+
+`--prompt-cache-bytes` caps how much the *reuse pool* across requests can
+grow, but each in-flight request still holds an **fp16** KV cache that
+scales with context length. On a memory-constrained box — e.g. a streaming
+120B on 16 GB driven by an agentic loop (Aider, Claude Code) whose prompts
+grow every turn — that per-request cache is usually what runs you out of
+memory first. `turboquant-serve` adds the same KV-quant flags as
+`turboquant-generate` to shrink it ~4x in place:
+
+```bash
+turboquant-serve \
+    --model manjunathshiva/Nemotron-3-Super-120B-A12B-tq3 \
+    --port 8080 \
+    --kv-k-bits 8 --kv-v-bits 3 \   # mixed-precision KV (recommended default)
+    --kv-min-tokens 128 \           # keep first 128 tokens fp16 (attention sinks)
+    --prompt-concurrency 1
+```
+
+| Flag | Meaning |
+| --- | --- |
+| `--kv-k-bits N` / `--kv-v-bits M` | Mixed-precision KV; K8/V3 is the recommended default |
+| `--kv-bits N` | Symmetric K=V=N (legacy; not recommended below 3) |
+| `--kv-min-tokens N` | Keep first N cached tokens in fp16 (sink protection) |
+| `--kv-group-size G` | Hadamard rotation group size (default 64) |
+
+These are processed by `turboquant-serve` and stripped before the remaining
+flags forward to `mlx_lm.server`. See [KV Cache Compression](#kv-cache-compression)
+below for how to choose bit-widths and the speed/quality trade-offs.
+
+> **Single-stream when KV-quant is on.** TurboQuant KV caches don't support
+> the cross-request `merge` that `mlx_lm.server`'s batch generator needs, so
+> enabling any `--kv-*` flag makes the server serve requests sequentially.
+> That's the right trade-off for a single-user setup; for a multi-client
+> server it means concurrent requests queue rather than batch.
+
 ---
 
 ## KV Cache Compression

--- a/serve.py
+++ b/serve.py
@@ -11,15 +11,36 @@ Non-TurboQuant models pass straight through to the standard mlx-lm
 loader, so this server works as a drop-in replacement for
 `mlx_lm.server` regardless of model type.
 
+TurboQuant KV-cache compression
+--------------------------------
+`mlx_lm.server` has no native KV-quantization flags, so this wrapper adds
+its own (`--kv-bits`, `--kv-k-bits`/`--kv-v-bits`, `--kv-min-tokens`,
+`--kv-group-size`) — the same set exposed by `turboquant-generate`. When
+enabled, every per-request prompt cache has its standard ``KVCache`` layers
+swapped for ``TurboQuantKVCache`` (other cache types — RotatingKVCache for
+sliding-window / Mamba layers — are left untouched, so hybrid models like
+GPT-OSS and Nemotron-H keep working). This shrinks each request's KV
+footprint ~4x, which is the real lever on memory-constrained boxes (e.g. a
+streaming 120B on 16 GB) where Aider-style agentic loops grow context fast.
+
+Note: enabling KV quantization forces single-stream (non-batched) serving,
+because TurboQuant caches do not support the cross-request ``merge`` the
+batch generator needs. That is the right trade-off for single-user setups;
+pair it with ``--prompt-concurrency 1`` for a multi-client server.
+
 Usage:
     turboquant-serve --model manjunathshiva/Nemotron-3-Super-120B-A12B-tq3
     turboquant-serve --model <path> --host 0.0.0.0 --port 8080
+    # K8/V3 mixed-precision KV (recommended default), sink-protect first 128:
+    turboquant-serve --model <tq-path> --kv-k-bits 8 --kv-v-bits 3 \
+        --kv-min-tokens 128 --prompt-concurrency 1
 
-All flags forward to `mlx_lm.server`; see `--help`.
+All other flags forward to `mlx_lm.server`; see `--help`.
 """
 
 from __future__ import annotations
 
+import argparse
 import sys
 
 _MIN_MLX_LM = (0, 31, 3)
@@ -114,9 +135,87 @@ def _patch_loader() -> None:
     _utils_mod.load = _tq_aware_load
 
 
+def _extract_kv_args(argv):
+    """Peel TurboQuant KV-cache flags off ``argv`` before mlx_lm.server sees it.
+
+    `mlx_lm.server`'s argparse would reject these as unknown, so we parse
+    them here with a permissive pre-parser and hand the *remaining* args back
+    to the server unchanged.
+
+    Returns ``(kv_config | None, remaining_argv)``. ``kv_config`` is ``None``
+    when no KV flag was given (KV quantization stays off), otherwise a kwargs
+    dict for ``convert_cache_to_turboquant``.
+    """
+    # add_help=False: let -h/--help fall through to mlx_lm.server's parser.
+    # allow_abbrev=False: never consume a server flag via prefix matching.
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--kv-bits", type=int, default=None)
+    parser.add_argument("--kv-k-bits", type=int, default=None)
+    parser.add_argument("--kv-v-bits", type=int, default=None)
+    parser.add_argument("--kv-min-tokens", type=int, default=0)
+    parser.add_argument("--kv-group-size", type=int, default=64)
+    ns, remaining = parser.parse_known_args(argv)
+
+    if ns.kv_bits is not None and (
+        ns.kv_k_bits is not None or ns.kv_v_bits is not None
+    ):
+        sys.stderr.write(
+            "ERROR: --kv-bits is mutually exclusive with "
+            "--kv-k-bits/--kv-v-bits\n"
+        )
+        sys.exit(2)
+    if (ns.kv_k_bits is None) != (ns.kv_v_bits is None):
+        sys.stderr.write(
+            "ERROR: --kv-k-bits and --kv-v-bits must be set together\n"
+        )
+        sys.exit(2)
+
+    if ns.kv_bits is None and ns.kv_k_bits is None:
+        return None, remaining
+
+    kv_config = dict(
+        tq_bits=ns.kv_bits,
+        k_bits=ns.kv_k_bits,
+        v_bits=ns.kv_v_bits,
+        group_size=ns.kv_group_size,
+        min_tokens_before_quant=ns.kv_min_tokens,
+    )
+    return kv_config, remaining
+
+
+def _patch_kv_cache(kv_config) -> None:
+    """Wrap `mlx_lm.server.make_prompt_cache` to emit TurboQuant KV caches.
+
+    Both the batchability probe and the per-request cache build call the bare
+    name `make_prompt_cache(model)` inside `mlx_lm.server`, so patching that
+    binding is sufficient. Standard ``KVCache`` layers become
+    ``TurboQuantKVCache``; other cache types are left as-is. Because the
+    converted caches lack ``merge``, the server's batchability probe sees them
+    and falls back to sequential serving automatically.
+    """
+    import mlx_lm.server as _server_mod
+    from turboquant_mlx.layers.polar_kv_cache import (
+        convert_cache_to_turboquant,
+    )
+
+    _orig_make = _server_mod.make_prompt_cache
+
+    def _tq_make_prompt_cache(model, *args, **kwargs):
+        cache = _orig_make(model, *args, **kwargs)
+        return convert_cache_to_turboquant(cache, **kv_config)
+
+    _server_mod.make_prompt_cache = _tq_make_prompt_cache
+
+
 def main() -> None:
     _check_mlx_lm_version()
     _patch_loader()
+
+    kv_config, remaining = _extract_kv_args(sys.argv[1:])
+    if kv_config is not None:
+        _patch_kv_cache(kv_config)
+    # Hand mlx_lm.server only the args it understands.
+    sys.argv = [sys.argv[0], *remaining]
 
     from mlx_lm.server import main as _mlx_lm_server_main
 
@@ -124,6 +223,17 @@ def main() -> None:
         "TurboQuant-MLX serve  ·  OpenAI-compatible HTTP server "
         "(backend: mlx_lm.server, TurboQuant-aware loader)\n"
     )
+    if kv_config is not None:
+        if kv_config["tq_bits"] is not None:
+            desc = f"K=V={kv_config['tq_bits']}-bit"
+        else:
+            desc = f"K={kv_config['k_bits']}-bit, V={kv_config['v_bits']}-bit"
+        sys.stderr.write(
+            f"[turboquant-serve] TurboQuant KV cache: {desc}, "
+            f"group={kv_config['group_size']}, "
+            f"sink={kv_config['min_tokens_before_quant']} "
+            "(forces single-stream serving)\n"
+        )
     _mlx_lm_server_main()
 
 

--- a/tests/test_serve_kv.py
+++ b/tests/test_serve_kv.py
@@ -1,0 +1,166 @@
+"""Tests for turboquant-serve TurboQuant KV-cache flags.
+
+Covers the wiring added so `turboquant-serve` (which wraps mlx_lm.server,
+whose argparse has no native KV-quant flags) can compress each request's KV
+cache:
+
+1. Flag extraction: `--kv-*` flags are peeled off argv, the rest forwarded.
+2. Flag validation: mutually-exclusive / paired flags are enforced.
+3. Cache patch: `make_prompt_cache` in mlx_lm.server emits TurboQuantKVCache.
+4. Integration: a TurboQuant cache survives the server's LRUPromptCache
+   reuse machinery (nbytes / deepcopy / insert / fetch) without crashing.
+"""
+
+import copy
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.serve import _extract_kv_args, _patch_kv_cache
+from turboquant_mlx.layers.polar_kv_cache import (
+    TurboQuantKVCache,
+    make_turboquant_cache,
+)
+
+
+class _DummyModel:
+    """Minimal stand-in: make_prompt_cache only needs `.layers` length."""
+
+    def __init__(self, n_layers):
+        self.layers = list(range(n_layers))
+
+
+def _random_kv(batch=1, n_heads=4, seq=8, head_dim=128, seed=0):
+    mx.random.seed(seed)
+    k = mx.random.normal((batch, n_heads, seq, head_dim)).astype(mx.float16)
+    v = mx.random.normal((batch, n_heads, seq, head_dim)).astype(mx.float16)
+    mx.eval(k, v)
+    return k, v
+
+
+# ── Flag extraction ───────────────────────────────────────────────────────
+
+
+def test_extract_no_kv_flags_returns_none():
+    kv, remaining = _extract_kv_args(["--model", "foo", "--port", "8080"])
+    assert kv is None
+    assert remaining == ["--model", "foo", "--port", "8080"]
+
+
+def test_extract_kv_bits_peeled_off():
+    kv, remaining = _extract_kv_args(
+        ["--model", "foo", "--kv-bits", "3", "--port", "8080"]
+    )
+    assert kv is not None
+    assert kv["tq_bits"] == 3
+    assert kv["k_bits"] is None and kv["v_bits"] is None
+    # KV flags removed; everything else forwarded untouched.
+    assert remaining == ["--model", "foo", "--port", "8080"]
+
+
+def test_extract_mixed_precision_and_extras():
+    kv, remaining = _extract_kv_args(
+        [
+            "--model", "foo",
+            "--kv-k-bits", "8", "--kv-v-bits", "3",
+            "--kv-min-tokens", "128", "--kv-group-size", "32",
+        ]
+    )
+    assert kv["tq_bits"] is None
+    assert kv["k_bits"] == 8 and kv["v_bits"] == 3
+    assert kv["min_tokens_before_quant"] == 128
+    assert kv["group_size"] == 32
+    assert remaining == ["--model", "foo"]
+
+
+def test_extract_defaults_when_only_bits_given():
+    kv, _ = _extract_kv_args(["--kv-bits", "2"])
+    assert kv["group_size"] == 64
+    assert kv["min_tokens_before_quant"] == 0
+
+
+def test_extract_does_not_eat_server_flags_by_prefix():
+    # allow_abbrev=False: a real server flag must never be consumed.
+    kv, remaining = _extract_kv_args(["--kv-bits", "3", "--max-tokens", "512"])
+    assert kv is not None
+    assert "--max-tokens" in remaining and "512" in remaining
+
+
+def test_extract_rejects_bits_with_split():
+    with pytest.raises(SystemExit):
+        _extract_kv_args(["--kv-bits", "3", "--kv-k-bits", "8", "--kv-v-bits", "3"])
+
+
+def test_extract_rejects_unpaired_split():
+    with pytest.raises(SystemExit):
+        _extract_kv_args(["--kv-k-bits", "8"])
+
+
+# ── Cache patch ─────────────────────────────────────────────────────────────
+
+
+def test_patch_make_prompt_cache_emits_turboquant():
+    import mlx_lm.server as server_mod
+
+    kv_config, _ = _extract_kv_args(["--kv-bits", "3"])
+    orig = server_mod.make_prompt_cache
+    try:
+        _patch_kv_cache(kv_config)
+        cache = server_mod.make_prompt_cache(_DummyModel(4))
+        assert len(cache) == 4
+        assert all(isinstance(c, TurboQuantKVCache) for c in cache)
+        assert all(c._k_bits == 3 and c._v_bits == 3 for c in cache)
+    finally:
+        server_mod.make_prompt_cache = orig
+
+
+def test_patch_make_prompt_cache_mixed_precision():
+    import mlx_lm.server as server_mod
+
+    kv_config, _ = _extract_kv_args(["--kv-k-bits", "8", "--kv-v-bits", "3"])
+    orig = server_mod.make_prompt_cache
+    try:
+        _patch_kv_cache(kv_config)
+        cache = server_mod.make_prompt_cache(_DummyModel(2))
+        assert all(c._k_bits == 8 and c._v_bits == 3 for c in cache)
+    finally:
+        server_mod.make_prompt_cache = orig
+
+
+def test_turboquant_cache_has_no_merge_so_server_serves_sequentially():
+    # The batchability probe is `all(hasattr(c, "merge") ...)`; TurboQuant
+    # caches must NOT have merge so the server falls back to single-stream.
+    cache = make_turboquant_cache(_DummyModel(2), tq_bits=3)
+    assert not any(hasattr(c, "merge") for c in cache)
+
+
+# ── Integration with the server's LRUPromptCache ────────────────────────────
+
+
+def test_turboquant_cache_survives_lru_prompt_cache():
+    from mlx_lm.models.cache import LRUPromptCache
+
+    cache = make_turboquant_cache(_DummyModel(2), tq_bits=3)
+    k, v = _random_kv(seq=8)
+    for c in cache:
+        c.update_and_fetch(k, v)
+
+    # nbytes must be defined (LRUPromptCache.insert_cache sums it) and > 0.
+    total = sum(c.nbytes for c in cache)
+    assert total > 0
+
+    # fetch_nearest_cache deepcopies the stored cache — must not crash and
+    # must preserve size.
+    cp = copy.deepcopy(cache)
+    assert sum(c.nbytes for c in cp) == total
+
+    lru = LRUPromptCache(max_size=2)
+    tokens = list(range(1, 9))
+    lru.insert_cache("model-key", tokens, cache)
+    assert len(lru) == 1
+    assert lru.nbytes > 0
+
+    got, rest = lru.fetch_nearest_cache("model-key", tokens)
+    assert got is not None
+    assert rest == []  # exact hit → whole prompt is cached
+    assert all(isinstance(c, TurboQuantKVCache) for c in got)


### PR DESCRIPTION
## Summary

`mlx_lm.server` has no native KV-quant flags, so a served model's per-request KV cache stays **fp16 and grows with context**. On memory-constrained setups — e.g. a streaming 120B on 16 GB driven by an agentic loop (Aider, Claude Code) whose prompts grow every turn — that per-request cache is what runs you out of memory first. `--prompt-cache-bytes` only bounds the cross-request *reuse pool*; it doesn't touch the in-flight request's KV.

This adds the same KV-quant flags `turboquant-generate` already exposes, now on the server:

- `--kv-bits N` — symmetric K=V (legacy)
- `--kv-k-bits N` / `--kv-v-bits M` — mixed precision (K8/V3 recommended)
- `--kv-min-tokens N` — keep first N tokens fp16 (attention-sink protection)
- `--kv-group-size G` — Hadamard rotation group size (default 64)

```bash
turboquant-serve --model <tq-model> --port 8080 \
  --kv-k-bits 8 --kv-v-bits 3 --kv-min-tokens 128 --prompt-concurrency 1
```

## How it works

- Flags are pre-parsed with `parse_known_args(allow_abbrev=False)` and **stripped from `argv`** before the rest forward to `mlx_lm.server` (which would otherwise reject them).
- When set, `mlx_lm.server.make_prompt_cache` is patched to run `convert_cache_to_turboquant` on every per-request cache → shrinks each in-flight request's KV ~4×.
- Standard `KVCache` layers become `TurboQuantKVCache`; other cache types (sliding-window / GatedDeltaNet `ArraysCache`) pass through untouched, so hybrid models keep working.
- `TurboQuantKVCache` has no `merge()`, so the server's batchability probe falls back to **single-stream serving** — the right trade-off for single-user setups. It retains `nbytes`/`is_trimmable`/`trim`, so the `LRUPromptCache` reuse machinery (insert/deepcopy/fetch) works unchanged.

## Validation

- **11 new unit tests** (`tests/test_serve_kv.py`): flag extraction/validation, prefix-safety, the `make_prompt_cache` patch, the no-`merge`→sequential property, and full `LRUPromptCache` integration (deepcopy → nbytes → insert → fetch).
- **End-to-end on two real TQ checkpoints** over the live OpenAI endpoint with `--kv-k-bits 8 --kv-v-bits 3`:
  - `qwen3.6-27b-tq3-g32` (`qwen3_5`, 48 GDN `ArraysCache` + 16 `KVCache`→TQ) — coherent code + math.
  - `Qwen3.6-35B-A3B-tq3-g32` (`qwen3_5_moe`, 30 `ArraysCache` + 10 `KVCache`→TQ) — `17×23 → 391`, valid `is_prime`.
  - Both: smaller KV, clean cache insert/fetch, zero errors.

### Note on prompt-cache reuse
On these Qwen3.6 hybrids, `can_trim_prompt_cache` is `False` for **both** stock and KV-quant (the GatedDeltaNet `ArraysCache` layers are non-trimmable), so the trim-based reuse path is off either way — KV-quant is reuse-neutral. Only the full-attention layers have a KV cache that grows with context, which is exactly what KV-quant shrinks.

## Docs
README serve section gains a "Compress the KV cache while serving" subsection (flag table + single-stream caveat); CHANGELOG `[Unreleased]` updated.