### PR TITLE
chore: release 0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-17
+
 ### Added
 
 - **`turboquant-serve` KV-cache quantization** — the server now accepts the

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.8.0"
+__version__ = "0.9.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.8.0"
+version = "0.9.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release **0.9.0** — finalizes the `[Unreleased]` CHANGELOG section shipped in #30 (`turboquant-serve` KV-cache quantization) and bumps the version.

## Changes
- `pyproject.toml` + `__init__.py`: `0.8.0` → `0.9.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.9.0] - 2026-06-17`

New backward-compatible feature (server KV-quant flags) → semver **minor** bump.

## Release mechanics (after merge)
Push tag `v0.9.0` on `main` → `release.yml` creates the GitHub Release (auto notes), builds the sdist, and publishes to PyPI (`turboquant-mlx-full`) via OIDC — **gated on manual approval of the `pypi` environment**, so nothing uploads without your sign-off.

Test suite green (83 passed).