### PR TITLE
feat(serve): expert streaming in turboquant-serve (0.11.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-06-20
+
+### Added — expert streaming in `turboquant-serve`
+
+- **`turboquant-serve --cache-budget-gb N`** routes the OpenAI-compatible server
+  through `load_streaming`, so a MoE whose weights exceed RAM can be *served*
+  over the API — only router-selected experts are paged from disk per token.
+  This puts a ~50 GB **122B on a 16 GB Mac mini** behind Claude Code / Aider.
+  The Flash-MoE levers from 0.10.0 ride along: **`--max-active-experts`**
+  (K-reduction, default 4) and **`--use-page-cache` / `--no-page-cache`**
+  (auto by model-size-vs-RAM). Composes with the `--kv-*` KV-quant flags;
+  streaming is single-user, so pair with `--prompt-concurrency 1`. Verified
+  end-to-end: the streamed model serves coherent completions over
+  `/v1/chat/completions`.
+
 ## [0.10.0] - 2026-06-20
 
 ### Added — Flash-MoE streaming levers

--- a/README.md
+++ b/README.md
@@ -262,6 +262,28 @@ for chunk in resp:
 All `mlx_lm.server` flags forward unchanged — see `turboquant-serve --help`
 for `--host`, `--temp`, `--top-p`, `--prompt-cache-size`, etc.
 
+#### Serve a model bigger than RAM (expert streaming)
+
+Passing `--cache-budget-gb` routes the loader through the streaming path, so a
+MoE whose weights exceed RAM can be **served** over the OpenAI API — only the
+router-selected experts are paged from disk per token. This is how you put a
+~50 GB **122B on a 16 GB Mac mini** behind Claude Code / Aider:
+
+```bash
+turboquant-serve \
+    --model manjunathshiva/qwen3.5-122b-tq3 \
+    --cache-budget-gb 4 \
+    --kv-k-bits 8 --kv-v-bits 3 --kv-min-tokens 128 \
+    --prompt-concurrency 1 --port 8080
+```
+
+The [Flash-MoE streaming levers](#tuning-the-streaming-reader-v061) ride along:
+`--max-active-experts` (K-reduction, default `4` → ~2× less disk I/O) and
+`--use-page-cache` / `--no-page-cache` (auto by model-size-vs-RAM — trust-OS is
+~2.4× faster decode when the model fits free RAM, `F_NOCACHE` otherwise). Pair
+with `--kv-*` to compress the growing KV cache of long agentic loops, and
+`--prompt-concurrency 1` since streaming is a single-user path.
+
 > **Note**: `mlx_lm.server` is intended for development and local use, not
 > production. It does not implement authentication or rate limiting.
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.10.0"
+__version__ = "0.11.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.10.0"
+version = "0.11.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/serve.py
+++ b/serve.py
@@ -28,12 +28,27 @@ because TurboQuant caches do not support the cross-request ``merge`` the
 batch generator needs. That is the right trade-off for single-user setups;
 pair it with ``--prompt-concurrency 1`` for a multi-client server.
 
+Expert streaming
+----------------
+Passing ``--cache-budget-gb`` routes the loader through
+``turboquant_mlx.stream.load_streaming`` instead of the resident loader, so a
+MoE whose weights exceed RAM (e.g. a 122B on a 16 GB Mac mini) can be *served*
+over the OpenAI API — only the router-selected experts are paged from disk per
+token. The Flash-MoE streaming levers come with it: ``--max-active-experts``
+(K-reduction, default 4 → ~2x less disk I/O) and ``--use-page-cache`` /
+``--no-page-cache`` (auto by model-size-vs-RAM; trust-OS is ~2.4x faster decode
+when the model fits free RAM, F_NOCACHE otherwise). Streaming is a single-user
+path — pair with ``--prompt-concurrency 1``.
+
 Usage:
     turboquant-serve --model manjunathshiva/Nemotron-3-Super-120B-A12B-tq3
     turboquant-serve --model <path> --host 0.0.0.0 --port 8080
     # K8/V3 mixed-precision KV (recommended default), sink-protect first 128:
     turboquant-serve --model <tq-path> --kv-k-bits 8 --kv-v-bits 3 \
         --kv-min-tokens 128 --prompt-concurrency 1
+    # Stream a 122B on a 16 GB mini (+ KV-quant for long agentic context):
+    turboquant-serve --model manjunathshiva/qwen3.5-122b-tq3 \
+        --cache-budget-gb 4 --kv-k-bits 8 --kv-v-bits 3 --prompt-concurrency 1
 
 All other flags forward to `mlx_lm.server`; see `--help`.
 """
@@ -74,13 +89,17 @@ def _check_mlx_lm_version() -> None:
         sys.exit(1)
 
 
-def _patch_loader() -> None:
+def _patch_loader(stream_config=None) -> None:
     """Replace `mlx_lm.server.load` with a TurboQuant-aware wrapper.
 
     The server calls the bare name `load(...)` after `from .utils import
     load`, so patching the binding inside `mlx_lm.server` is what we need.
     We also patch `mlx_lm.utils.load` for any other callers that import
     from utils directly.
+
+    When ``stream_config`` is given, TurboQuant models are loaded through
+    ``load_streaming`` (experts paged from disk) instead of the resident
+    ``load_turboquant``; non-TurboQuant models always pass through to mlx-lm.
     """
     import mlx_lm.server as _server_mod
     import mlx_lm.utils as _utils_mod
@@ -92,6 +111,8 @@ def _patch_loader() -> None:
     # NemotronHConfig MLP-block-type patch) before any model loads.
     import turboquant_mlx.compat  # noqa: F401
     from turboquant_mlx.generate import load_turboquant
+    if stream_config is not None:
+        from turboquant_mlx.stream.loader import load_streaming
 
     def _tq_aware_load(
         path_or_hf_repo,
@@ -123,10 +144,19 @@ def _patch_loader() -> None:
                 "models; ignoring.\n"
             )
 
-        sys.stderr.write(
-            f"[turboquant-serve] Loading TurboQuant model from {model_path}\n"
-        )
-        model, tokenizer = load_turboquant(model_path, lazy=lazy)
+        if stream_config is not None:
+            sys.stderr.write(
+                f"[turboquant-serve] Streaming TurboQuant model from {model_path} "
+                f"(cache_budget={stream_config['cache_budget_gb']} GB)\n"
+            )
+            # load_streaming returns (model, tok, cache); the cache stays alive
+            # via the StreamingSwitchLinear modules that reference it.
+            model, tokenizer, _cache = load_streaming(model_path, **stream_config)
+        else:
+            sys.stderr.write(
+                f"[turboquant-serve] Loading TurboQuant model from {model_path}\n"
+            )
+            model, tokenizer = load_turboquant(model_path, lazy=lazy)
         if return_config:
             return model, tokenizer, cfg
         return model, tokenizer
@@ -183,6 +213,40 @@ def _extract_kv_args(argv):
     return kv_config, remaining
 
 
+def _extract_stream_args(argv):
+    """Peel expert-streaming flags off ``argv`` before mlx_lm.server sees them.
+
+    ``--cache-budget-gb`` is the trigger: when present, TurboQuant models load
+    through ``load_streaming`` with the given budget and Flash-MoE levers.
+    Returns ``(stream_config | None, remaining_argv)``. The other streaming
+    flags are no-ops without a budget (and are documented as such).
+    """
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--cache-budget-gb", type=float, default=None)
+    parser.add_argument("--max-active-experts", type=int, default=4)
+    parser.add_argument("--prefetch-workers", type=int, default=8)
+    parser.add_argument("--prefetch-ahead", type=int, default=0)
+    parser.add_argument("--pin-file", default=None)
+    parser.add_argument("--use-page-cache", dest="use_page_cache",
+                        action="store_true", default=None)
+    parser.add_argument("--no-page-cache", dest="use_page_cache",
+                        action="store_false")
+    ns, remaining = parser.parse_known_args(argv)
+
+    if ns.cache_budget_gb is None:
+        return None, remaining
+
+    stream_config = dict(
+        cache_budget_gb=ns.cache_budget_gb,
+        max_active_experts=ns.max_active_experts,
+        use_page_cache=ns.use_page_cache,
+        prefetch_workers=ns.prefetch_workers,
+        prefetch_ahead=ns.prefetch_ahead,
+        pin_file=ns.pin_file,
+    )
+    return stream_config, remaining
+
+
 def _patch_kv_cache(kv_config) -> None:
     """Wrap `mlx_lm.server.make_prompt_cache` to emit TurboQuant KV caches.
 
@@ -209,9 +273,10 @@ def _patch_kv_cache(kv_config) -> None:
 
 def main() -> None:
     _check_mlx_lm_version()
-    _patch_loader()
 
     kv_config, remaining = _extract_kv_args(sys.argv[1:])
+    stream_config, remaining = _extract_stream_args(remaining)
+    _patch_loader(stream_config)
     if kv_config is not None:
         _patch_kv_cache(kv_config)
     # Hand mlx_lm.server only the args it understands.
@@ -223,6 +288,15 @@ def main() -> None:
         "TurboQuant-MLX serve  ·  OpenAI-compatible HTTP server "
         "(backend: mlx_lm.server, TurboQuant-aware loader)\n"
     )
+    if stream_config is not None:
+        pc = "auto" if stream_config["use_page_cache"] is None else (
+            "on" if stream_config["use_page_cache"] else "off")
+        sys.stderr.write(
+            f"[turboquant-serve] Expert streaming: cache_budget="
+            f"{stream_config['cache_budget_gb']} GB, "
+            f"max_active_experts={stream_config['max_active_experts']}, "
+            f"page_cache={pc} (single-user; use --prompt-concurrency 1)\n"
+        )
     if kv_config is not None:
         if kv_config["tq_bits"] is not None:
             desc = f"K=V={kv_config['tq_bits']}-bit"

--- a/tests/test_serve_stream.py
+++ b/tests/test_serve_stream.py
@@ -1,0 +1,57 @@
+"""Tests for turboquant-serve expert-streaming flags.
+
+Covers `_extract_stream_args`: `--cache-budget-gb` is the trigger that turns on
+streaming; the Flash-MoE levers (`--max-active-experts`, `--use-page-cache` /
+`--no-page-cache`) ride along; everything else forwards to mlx_lm.server
+untouched. Also checks streaming + KV flags coexist (both off the same argv).
+"""
+
+from turboquant_mlx.serve import _extract_stream_args, _extract_kv_args
+
+
+def test_no_budget_returns_none():
+    sc, remaining = _extract_stream_args(["--model", "foo", "--port", "8080"])
+    assert sc is None
+    assert remaining == ["--model", "foo", "--port", "8080"]
+
+
+def test_budget_triggers_streaming_with_defaults():
+    sc, remaining = _extract_stream_args(
+        ["--model", "foo", "--cache-budget-gb", "4", "--port", "8080"])
+    assert sc is not None
+    assert sc["cache_budget_gb"] == 4.0
+    assert sc["max_active_experts"] == 4       # K-reduction default
+    assert sc["use_page_cache"] is None        # auto by model-size-vs-RAM
+    assert remaining == ["--model", "foo", "--port", "8080"]
+
+
+def test_levers_peeled_and_forwarded():
+    sc, remaining = _extract_stream_args(
+        ["--model", "foo", "--cache-budget-gb", "8",
+         "--max-active-experts", "6", "--no-page-cache"])
+    assert sc["max_active_experts"] == 6
+    assert sc["use_page_cache"] is False
+    assert remaining == ["--model", "foo"]
+
+
+def test_use_page_cache_forces_on():
+    sc, _ = _extract_stream_args(["--cache-budget-gb", "4", "--use-page-cache"])
+    assert sc["use_page_cache"] is True
+
+
+def test_does_not_eat_server_flags_by_prefix():
+    sc, remaining = _extract_stream_args(
+        ["--cache-budget-gb", "4", "--max-tokens", "512"])
+    assert sc is not None
+    assert "--max-tokens" in remaining and "512" in remaining
+
+
+def test_streaming_and_kv_flags_coexist():
+    # main() peels KV first, then streaming off the remainder.
+    kv, remaining = _extract_kv_args(
+        ["--model", "foo", "--cache-budget-gb", "4",
+         "--kv-k-bits", "8", "--kv-v-bits", "3", "--prompt-concurrency", "1"])
+    sc, remaining = _extract_stream_args(remaining)
+    assert kv["k_bits"] == 8 and kv["v_bits"] == 3
+    assert sc["cache_budget_gb"] == 4.0
+    assert remaining == ["--model", "foo", "--prompt-concurrency", "1"]


### PR DESCRIPTION
Adds expert streaming to the OpenAI-compatible server so a MoE whose weights exceed RAM can be **served** (not just `generate`d) — the missing piece for running a big model behind Claude Code / Aider on a small machine. Follow-up to #33 (the streaming levers themselves).

## What

`turboquant-serve --cache-budget-gb N` routes the loader through `load_streaming` instead of the resident `load_turboquant`, so only the router-selected experts are paged from disk per token. The Flash-MoE levers from 0.10.0 ride along:

- `--max-active-experts` (K-reduction, default `4` → ~2× less streamed disk I/O)
- `--use-page-cache` / `--no-page-cache` (auto by model-size-vs-RAM; trust-OS ~2.4× when the model fits free RAM, `F_NOCACHE` otherwise)

Composes with the existing `--kv-*` KV-quant flags. Streaming is single-user → pair with `--prompt-concurrency 1`.

### The target use case — 122B on a 16 GB Mac mini
```bash
turboquant-serve --model manjunathshiva/qwen3.5-122b-tq3 \
  --cache-budget-gb 4 --kv-k-bits 8 --kv-v-bits 3 --kv-min-tokens 128 \
  --prompt-concurrency 1 --port 8080
```
(On the 16 GB mini the 50 GB model is ≫ RAM, so trust-OS correctly auto-stays on `F_NOCACHE`; K-reduction + streaming are what make it fit and serve.)

## Implementation
- `_extract_stream_args(argv)` peels the streaming flags off argv (mirrors `_extract_kv_args`); `--cache-budget-gb` is the trigger.
- `_patch_loader(stream_config)` swaps `load_turboquant` → `load_streaming` for TurboQuant models when streaming is on; non-TurboQuant models still pass through to mlx-lm.
- `main()` peels KV flags, then streaming flags, then patches both; prints a streaming banner.

## Verification
- `tests/test_serve_stream.py` — trigger, lever pass-through, `allow_abbrev=False` prefix safety, KV+streaming coexistence (6 tests; 26 green across serve/streaming suites).
- **End-to-end**: started the server on a streamed 35B-A3B (banner confirmed `cache_budget=4 GB, max_active_experts=4, page_cache=auto → trust-OS`, experts swapped, K-reduction 8→4) and hit `/v1/chat/completions` — coherent generation, correct JSON composed. Empty `content` on short `max_tokens` is the Qwen3.6 thinking-mode artifact (already documented in the serve README), not a serve bug.

Folds the `0.11.0` bump (`__init__.py` + `pyproject.toml` + `CHANGELOG.md`) so merge + `v0.11.0` tag releases it.