### PR TITLE
chore: release 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-07-01
+
 ### Added — ternary (1.58-bit) experts with base-3 trit packing
 
 - **`convert --ternary-experts`** quantizes routed MoE experts to the data-free

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.11.0"
+__version__ = "0.12.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.11.0"
+version = "0.12.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release **0.12.0** — ternary (1.58-bit) experts with base-3 trit packing (#35).

- `pyproject.toml` + `__init__.py`: `0.11.0` → `0.12.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.12.0] - 2026-07-01`

No code changes — version/changelog only. After merge, push tag `v0.12.0` to
trigger `release.yml` (GitHub Release + sdist + PyPI publish via OIDC, gated on
the manual `pypi` environment approval).