### PR TITLE
fix: ternary trit format on the streaming expert path (v0.12.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,20 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.1] - 2026-07-02
+
+### Fixed — ternary experts on the streaming path
+
+- **Streaming a ternary (trit) MoE now works.** `StreamingSwitchLinear` was
+  trit-blind: its prefill dequant (`_dequantize_selected`) unpacked the base-3
+  trit weights as bit-packed 2-bit indices (16 vs 20 values per uint32), which
+  crashed with a `reshape` size mismatch, and its decode/prefill kernel calls
+  never passed `trit=`. The streaming layer now detects the 3-entry codebook
+  (with an explicit `trit` flag from the loader), decodes with `unpack_trits`,
+  and threads `trit=` into `polar_gather_qmv` / `polar_multi_gather_qmv`. This
+  is the path a >RAM ternary MoE takes — e.g. the 53 GB `Qwen3-235B tq3a-tqTe`
+  streamed on a 16 GB Mac mini. The resident (fits-in-RAM) path was unaffected.
+
 ## [0.12.0] - 2026-07-01
 
 ### Added — ternary (1.58-bit) experts with base-3 trit packing

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.12.0"
+__version__ = "0.12.1"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.12.0"
+version = "0.12.1"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -171,6 +171,7 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
                 # one trigger per layer fires the next-layer prefetch; gate_proj
                 # is first in _PROJS so it fires with maximum lead time.
                 is_trigger=(proj == _PROJS[0]),
+                trit=res.trit,
             )
             setattr(sm, proj, st)
             proj_keys.append((wkey, skey))

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -366,6 +366,7 @@ class StreamingSwitchLinear(nn.Module):
         cache: ExpertCache,
         layer_idx: int = -1,
         is_trigger: bool = False,
+        trit: bool = False,
     ):
         super().__init__()
         self.input_dims = input_dims
@@ -373,6 +374,10 @@ class StreamingSwitchLinear(nn.Module):
         self.num_experts = num_experts
         self.bits = bits
         self.group_size = group_size
+        # Ternary (1.58-bit) experts pack 20 base-3 trits per uint32 instead of
+        # bit-packing; the kernels and dequant switch to base-3 decode off this.
+        # Detect from the 3-entry codebook if the caller didn't say (self-describing).
+        self.trit = bool(trit) or codebook.size == 3
         self._needs_rotation = needs_rotation
         # small resident tensors
         self.codebook = codebook
@@ -393,12 +398,15 @@ class StreamingSwitchLinear(nn.Module):
         Mirrors PolarQuantizedSwitchLinear._dequantize_all but on an
         (n_sel, out, packed) stack instead of all num_experts.
         """
-        from turboquant_mlx.core.packing import unpack_indices
+        from turboquant_mlx.core.packing import unpack_indices, unpack_trits
         from turboquant_mlx.core.codebook import dequantize_scalar
 
         n_sel = w_sel.shape[0]
         n_groups = self.input_dims // self.group_size
-        idx = unpack_indices(w_sel, self.bits, self.input_dims)
+        if self.trit:
+            idx = unpack_trits(w_sel, self.input_dims)
+        else:
+            idx = unpack_indices(w_sel, self.bits, self.input_dims)
         w_deq = dequantize_scalar(idx, self.codebook)
         w_deq = w_deq.reshape(n_sel, self.output_dims, n_groups, self.group_size)
         w_deq = w_deq * mx.expand_dims(s_sel, axis=-1)
@@ -433,6 +441,7 @@ class StreamingSwitchLinear(nn.Module):
             y = polar_gather_qmv(
                 w_sel, s_sel, self.codebook,
                 x_flat, idx_local_flat, self.bits, self.group_size,
+                trit=self.trit,
             )
             return y.reshape(list(indices.shape) + [1, self.output_dims])
 
@@ -441,6 +450,7 @@ class StreamingSwitchLinear(nn.Module):
             y = polar_multi_gather_qmv(
                 w_sel, s_sel, self.codebook,
                 x_2d, idx_local_flat, self.bits, self.group_size,
+                trit=self.trit,
             )
             return y.reshape(list(indices.shape) + [1, self.output_dims])
 

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -378,6 +378,17 @@ class StreamingSwitchLinear(nn.Module):
         # bit-packing; the kernels and dequant switch to base-3 decode off this.
         # Detect from the 3-entry codebook if the caller didn't say (self-describing).
         self.trit = bool(trit) or codebook.size == 3
+        if self.trit:
+            # The Metal kernels hardcode n_codes=3 under trit; a mismatched
+            # codebook would read out of bounds on the GPU. Fail loud instead.
+            if codebook.size != 3:
+                raise ValueError(
+                    "Ternary (trit) mode requires a 3-entry codebook, "
+                    f"got size {codebook.size}."
+                )
+            # Match the resident layer (ternary is always bit-width 2) so the
+            # (bits, group_size, trit) kernel-cache key stays consistent.
+            self.bits = 2
         self._needs_rotation = needs_rotation
         # small resident tensors
         self.codebook = codebook

--- a/tests/test_trit_packing.py
+++ b/tests/test_trit_packing.py
@@ -189,3 +189,42 @@ def test_switch_layer_trit_dispatch():
     refk = np.stack([w_deq[e] @ xkr[j] for j, e in enumerate(np.array(idxk))])
     yk = np.array(layer(xk, idxk))
     assert _rel(yk.reshape(k, out_dims).astype(np.float32), refk) < 3e-3
+
+
+# --------------------------------------------------------------------------- #
+# streaming layer (the disk-streamed path used on the mini / >RAM MoEs)
+# --------------------------------------------------------------------------- #
+
+def _make_streaming_layer(in_dims, out_dims, gs, *, trit_flag, codebook):
+    """Build a StreamingSwitchLinear without a cache/reader — enough to exercise
+    _dequantize_selected, the trit-blind prefill path that crashed on the mini."""
+    from turboquant_mlx.stream.streaming_switch import StreamingSwitchLinear
+    signs = mx.ones((in_dims,), dtype=mx.float16)
+    return StreamingSwitchLinear(
+        input_dims=in_dims, output_dims=out_dims, num_experts=8,
+        bits=2, group_size=gs, needs_rotation=False,
+        codebook=codebook, signs=signs,
+        weight_key="w", scales_key="s", cache=None, trit=trit_flag,
+    )
+
+
+def test_streaming_trit_autodetect_from_codebook():
+    """A 3-entry codebook must flip the streaming layer into trit mode even when
+    the caller forgets to pass trit=True (self-describing marker)."""
+    layer = _make_streaming_layer(96, 40, 32, trit_flag=False, codebook=_CB)
+    assert layer.trit is True
+
+
+def test_streaming_dequantize_selected_trit_matches_reference():
+    """Regression for the mini crash: _dequantize_selected must base-3 decode
+    trit-packed experts (reshape used the wrong 2-bit width before)."""
+    gs = 32
+    idx, scales, packed, w = _rand_expert_setup(6, 40, 96, gs, seed=7)
+    layer = _make_streaming_layer(96, 40, gs, trit_flag=True, codebook=_CB)
+    routed = np.array([4, 1, 5], dtype=np.int64)
+    w_sel = mx.array(np.array(packed)[routed])
+    s_sel = scales[mx.array(routed)]
+    deq = layer._dequantize_selected(w_sel, s_sel)   # (3, out, in) — no reshape crash
+    mx.eval(deq)
+    assert deq.shape == (3, 40, 96)
+    assert _rel(np.array(deq).astype(np.float32), w[routed]) < 2e-3

--- a/tests/test_trit_packing.py
+++ b/tests/test_trit_packing.py
@@ -210,9 +210,19 @@ def _make_streaming_layer(in_dims, out_dims, gs, *, trit_flag, codebook):
 
 def test_streaming_trit_autodetect_from_codebook():
     """A 3-entry codebook must flip the streaming layer into trit mode even when
-    the caller forgets to pass trit=True (self-describing marker)."""
+    the caller forgets to pass trit=True (self-describing marker), and force
+    bits=2 to match the resident layer + keep the kernel-cache key consistent."""
     layer = _make_streaming_layer(96, 40, 32, trit_flag=False, codebook=_CB)
     assert layer.trit is True
+    assert layer.bits == 2
+
+
+def test_streaming_trit_rejects_mismatched_codebook():
+    """trit=True with a non-3 codebook would make the kernels (n_codes=3) read
+    out of bounds on the GPU — must fail loud at construction instead."""
+    bad_cb = mx.zeros((4,), dtype=mx.float16)  # 2-bit codebook, not ternary
+    with pytest.raises(ValueError, match="3-entry codebook"):
+        _make_streaming_layer(96, 40, 32, trit_flag=True, codebook=bad_cb)
 
 
 def test_streaming_dequantize_selected_trit_matches_reference():


### PR DESCRIPTION
## Summary

The 1.58-bit **ternary trit** tier (shipped in v0.12.0) was wired through the four *resident* expert kernels and the resident switch layer, but **`StreamingSwitchLinear` was trit-blind**. Streaming is the path a >RAM ternary MoE takes — e.g. the 53 GB `Qwen3-235B-A22B tq3a-tqTe-g64` on a 16 GB Mac mini — so this broke every streaming-trit user. The resident (fits-in-RAM) path was unaffected, which is why the 64 GB validation never caught it.

### The bug
- `_dequantize_selected` (prefill) called `unpack_indices` with `bits=2`, unpacking **16 values/uint32** instead of the trit format's **20**, so the reshape failed:
  `ValueError: Cannot reshape array of size 201523200 into shape (40,1536,64,64)`.
- The `n_tokens==1` (decode) and `n_tokens==k` (per-expert prefill) kernel calls never passed `trit=`, so they'd decode the wrong packing too.

### The fix
- `StreamingSwitchLinear` now takes a `trit` flag (and auto-detects the 3-entry codebook as a fallback), `_dequantize_selected` uses `unpack_trits`, and both `polar_gather_qmv` / `polar_multi_gather_qmv` calls pass `trit=self.trit`.
- `stream/loader.py` passes `trit=res.trit` when swapping in the streaming layer.

## Validation
- Full suite: **138 pass** (+2 new streaming-trit regression tests: codebook auto-detect + `_dequantize_selected` vs reference dequant).
- Reproduced the reported command on the real `Qwen3-235B-A22B-Instruct-2507-tq3a-tqTe-g64` locally in the same regime (streaming, `--cache-budget-gb 3`, F_NOCACHE). It now runs and is coherent (Rayleigh-scattering explanation), **peak MLX memory 14.19 GB** — under the 16 GB mini's 17.2 GB RAM.

## Release
Patch release **v0.12.1** (version bumped in `pyproject.toml` + `__init__.py`, CHANGELOG entry added). Tag `v0.12.1` after merge to publish to PyPI.