### PR TITLE
fix: generate CLI sampler defaults from generation_config (v0.12.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.2] - 2026-07-03
+
+### Fixed — generate CLI sampler now honors the model's generation_config
+
+- **`python -m turboquant_mlx.generate` sampled with temperature only** — no
+  top-p/top-k truncation — so every token in the vocabulary kept nonzero
+  probability at each step. Over long generations this occasionally sampled a
+  stray special token; the visible symptom was a **doubled answer** when
+  `</think>` was drawn where `<|im_end|>` belonged (seen on
+  `Qwen3.6-35B-A3B-tq3a-tqTe-g64`). Low-bit builds are the most exposed since
+  their logits are the noisiest. New `--top-p` / `--top-k` flags now default
+  from the model's own `generation_config.json` (e.g. Qwen ships
+  `top_k=20, top_p=0.95`), can be overridden per run, and `0` force-disables.
+  Models without a `generation_config.json` keep the previous behavior.
+
 ## [0.12.1] - 2026-07-02
 
 ### Fixed — ternary experts on the streaming path

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.12.1"
+__version__ = "0.12.2"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/generate.py
+++ b/generate.py
@@ -16,6 +16,7 @@ Usage:
 
 import argparse
 import glob
+import json
 import sys
 from pathlib import Path
 
@@ -318,15 +319,23 @@ def main():
     # doubled answer when '</think>' is sampled where '<|im_end|>' belongs.
     top_p, top_k = args.top_p, args.top_k
     if top_p is None or top_k is None:
+        # load_turboquant already resolved/downloaded the model, so this is a
+        # cache hit; read the json directly rather than pulling in transformers
+        # (only an optional [eval] dependency).
         try:
-            from transformers import GenerationConfig
-            gen_cfg = GenerationConfig.from_pretrained(args.model)
-            if top_p is None:
-                top_p = getattr(gen_cfg, "top_p", None)
-            if top_k is None:
-                top_k = getattr(gen_cfg, "top_k", None)
-        except Exception:
-            pass
+            gen_cfg_file = resolve_model_path(args.model) / "generation_config.json"
+            if gen_cfg_file.exists():
+                with open(gen_cfg_file, encoding="utf-8") as f:
+                    gen_cfg = json.load(f)
+                if top_p is None:
+                    top_p = gen_cfg.get("top_p")
+                if top_k is None:
+                    top_k = gen_cfg.get("top_k")
+        except Exception as e:
+            print(
+                f"[INFO] Could not read generation_config.json for "
+                f"{args.model}; sampling without truncation defaults ({e})"
+            )
     sampler = make_sampler(
         temp=args.temp,
         top_p=top_p if top_p is not None else 0.0,

--- a/generate.py
+++ b/generate.py
@@ -222,6 +222,19 @@ def main():
         help="Sampling temperature (default: 0.7)",
     )
     parser.add_argument(
+        "--top-p", type=float, default=None,
+        help="Nucleus sampling threshold. Defaults to the model's "
+             "generation_config.json value when present, else disabled. "
+             "Pass 0 to force-disable.",
+    )
+    parser.add_argument(
+        "--top-k", type=int, default=None,
+        help="Top-k truncation. Defaults to the model's "
+             "generation_config.json value when present, else disabled. "
+             "Pass 0 to force-disable. Without truncation, rare tokens like "
+             "a stray '</think>' can be sampled in place of EOS.",
+    )
+    parser.add_argument(
         "--rep-penalty", type=float, default=None,
         help="Repetition penalty (e.g. 1.04). Disabled when omitted. "
              "Recommended for hybrid Nemotron-3 to avoid long-gen tail "
@@ -299,7 +312,26 @@ def main():
         make_min_tokens_logits_processor,
     )
 
-    sampler = make_sampler(temp=args.temp)
+    # Truncation defaults come from the model's own generation_config.json
+    # (e.g. Qwen ships top_k=20/top_p=0.95). Untruncated temperature sampling
+    # over a 250K vocab occasionally picks a stray special token — seen as a
+    # doubled answer when '</think>' is sampled where '<|im_end|>' belongs.
+    top_p, top_k = args.top_p, args.top_k
+    if top_p is None or top_k is None:
+        try:
+            from transformers import GenerationConfig
+            gen_cfg = GenerationConfig.from_pretrained(args.model)
+            if top_p is None:
+                top_p = getattr(gen_cfg, "top_p", None)
+            if top_k is None:
+                top_k = getattr(gen_cfg, "top_k", None)
+        except Exception:
+            pass
+    sampler = make_sampler(
+        temp=args.temp,
+        top_p=top_p if top_p is not None else 0.0,
+        top_k=top_k if top_k is not None else 0,
+    )
     min_tokens_proc = make_min_tokens_logits_processor(
         args.min_tokens, eos_token_ids(tokenizer)
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.12.1"
+version = "0.12.2"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
## Summary

`python -m turboquant_mlx.generate` built its sampler as `make_sampler(temp=0.7)` — **no top-p/top-k truncation** — so all ~248K vocab tokens kept nonzero probability at every step. Over long generations this occasionally samples a stray special token; the observed symptom (real 16 GB mini run on `Qwen3.6-35B-A3B-tq3a-tqTe-g64`, 1800-token generation) was a **doubled answer**: the model sampled `</think>` where `<|im_end|>` belonged, then re-emitted the entire answer. Low-bit builds are the most exposed since their logits are the noisiest.

EOS wiring was verified correct (`eos_token_id=[248046 <|im_end|>, 248044 <|endoftext|>]` matches the tokenizer) — the fix is purely sampler-side.

## Changes

- New `--top-p` / `--top-k` CLI flags that **default from the model's own `generation_config.json`** when present (e.g. Qwen ships `top_k=20, top_p=0.95`), overridable per run, `0` force-disables.
- Models without a `generation_config.json` keep the previous behavior (temperature-only).
- Version bump 0.12.1 → 0.12.2 (pyproject.toml + __init__.py), CHANGELOG entry.

## Validation

- Repro prompt re-run at `--max-tokens 4096` on the 35B ternary build: config resolved (`top_p=0.95, top_k=20`), exactly one `</think>`, no duplicated answer, clean EOS stop at 1393 tokens.
- Full test suite: **139 passed**.