### PR TITLE
feat: thinking-mode ergonomics — --no-think, rep-penalty defaults, single-think guard (v0.12.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.3] - 2026-07-03
+
+### Added — thinking-mode ergonomics for low-bit builds
+
+- **`--no-think` on the generate CLI**: disables thinking via the chat
+  template (`enable_thinking=False`). On loop-prone low-bit thinking builds
+  this answers instantly instead of deliberating for minutes. (The server
+  equivalent already exists: `--chat-template-args '{"enable_thinking": false}'`.)
+- **`--rep-penalty` now defaults from the model's `generation_config.json`**
+  (ignoring the neutral 1.0), so a build that ships `repetition_penalty: 1.05`
+  gets it automatically; `--rep-penalty 0` (or 1) force-disables. A 12-trial
+  A/B/C/D sweep on the ternary 35B showed a light repetition penalty is the
+  only sampling change that reliably exits `<think>` (3/3 vs 2/3 for every
+  other config, including the pre-0.12.2 sampler).
+- **`turboquant-serve --rep-penalty` / `--rep-ctx`**: server-side default
+  `repetition_penalty` for OpenAI clients that never send the field
+  (mlx_lm.server hardcodes the request default to 0.0 with no flag). When the
+  flag is omitted, the default is read from the model's
+  `generation_config.json`, resolved once on the first request.
+
+### Fixed — doubled answers from a second `</think>`
+
+- **Single-think-block guard** in the generate CLI: once `</think>` has been
+  emitted, its logit is masked, so the model can't "reopen" the answer and
+  emit it twice (observed sporadically on ternary builds even with top-k/top-p
+  truncation). Disable with `--multi-think` for models that legitimately emit
+  several think blocks.
+
 ## [0.12.2] - 2026-07-03
 
 ### Fixed — generate CLI sampler now honors the model's generation_config

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.12.2"
+__version__ = "0.12.3"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/generate.py
+++ b/generate.py
@@ -237,9 +237,23 @@ def main():
     )
     parser.add_argument(
         "--rep-penalty", type=float, default=None,
-        help="Repetition penalty (e.g. 1.04). Disabled when omitted. "
-             "Recommended for hybrid Nemotron-3 to avoid long-gen tail "
-             "loops; omit for numeric/math prompts.",
+        help="Repetition penalty (e.g. 1.05). Defaults to the model's "
+             "generation_config.json value when present, else disabled. "
+             "Pass 0 or 1 to force-disable. Recommended for thinking-mode "
+             "models on low-bit builds (breaks think-block loops); omit for "
+             "numeric/math prompts.",
+    )
+    parser.add_argument(
+        "--no-think", action="store_true",
+        help="Disable thinking mode via the chat template "
+             "(enable_thinking=False). Much faster and immune to "
+             "think-block loops on thinking-capable models.",
+    )
+    parser.add_argument(
+        "--multi-think", action="store_true",
+        help="Allow more than one </think> token per generation. By default "
+             "a second </think> is masked once one has been emitted, which "
+             "prevents low-bit thinking models from re-emitting their answer.",
     )
     parser.add_argument(
         "--rep-ctx", type=int, default=256,
@@ -298,10 +312,13 @@ def main():
     if hasattr(tokenizer, 'apply_chat_template'):
         try:
             messages = [{"role": "user", "content": args.prompt}]
+            template_kwargs = {"enable_thinking": False} if args.no_think else {}
             prompt = tokenizer.apply_chat_template(
                 messages, tokenize=False, add_generation_prompt=True,
+                **template_kwargs,
             )
-            print("[INFO] Applied chat template")
+            print("[INFO] Applied chat template"
+                  + (" (thinking disabled)" if args.no_think else ""))
         except Exception:
             pass  # Fall back to raw prompt
 
@@ -311,14 +328,17 @@ def main():
     from turboquant_mlx.sampling import (
         eos_token_ids,
         make_min_tokens_logits_processor,
+        make_single_think_close_logits_processor,
+        think_close_token_id,
     )
 
-    # Truncation defaults come from the model's own generation_config.json
-    # (e.g. Qwen ships top_k=20/top_p=0.95). Untruncated temperature sampling
-    # over a 250K vocab occasionally picks a stray special token — seen as a
-    # doubled answer when '</think>' is sampled where '<|im_end|>' belongs.
-    top_p, top_k = args.top_p, args.top_k
-    if top_p is None or top_k is None:
+    # Sampling defaults come from the model's own generation_config.json
+    # (e.g. Qwen ships top_k=20/top_p=0.95; loop-prone low-bit builds can ship
+    # repetition_penalty). Untruncated temperature sampling over a 250K vocab
+    # occasionally picks a stray special token — seen as a doubled answer when
+    # '</think>' is sampled where '<|im_end|>' belongs.
+    top_p, top_k, rep_penalty = args.top_p, args.top_k, args.rep_penalty
+    if top_p is None or top_k is None or rep_penalty is None:
         # load_turboquant already resolved/downloaded the model, so this is a
         # cache hit; read the json directly rather than pulling in transformers
         # (only an optional [eval] dependency).
@@ -331,11 +351,21 @@ def main():
                     top_p = gen_cfg.get("top_p")
                 if top_k is None:
                     top_k = gen_cfg.get("top_k")
+                if rep_penalty is None:
+                    cfg_rep = gen_cfg.get("repetition_penalty")
+                    # 1.0 is transformers' neutral default — not a real request
+                    if cfg_rep and cfg_rep != 1.0:
+                        rep_penalty = cfg_rep
+                        print(f"[INFO] repetition_penalty {cfg_rep} "
+                              f"(from generation_config.json)")
         except Exception as e:
             print(
                 f"[INFO] Could not read generation_config.json for "
                 f"{args.model}; sampling without truncation defaults ({e})"
             )
+    # 0 or 1.0 on the CLI force-disables (1.0 is mathematically neutral)
+    if rep_penalty is not None and rep_penalty in (0.0, 1.0):
+        rep_penalty = None
     sampler = make_sampler(
         temp=args.temp,
         top_p=top_p if top_p is not None else 0.0,
@@ -345,11 +375,17 @@ def main():
         args.min_tokens, eos_token_ids(tokenizer)
     )
     logits_processors = []
-    if args.rep_penalty is not None:
+    if rep_penalty is not None:
         logits_processors.extend(make_logits_processors(
-            repetition_penalty=args.rep_penalty,
+            repetition_penalty=rep_penalty,
             repetition_context_size=args.rep_ctx,
         ))
+    if not args.multi_think:
+        think_guard = make_single_think_close_logits_processor(
+            think_close_token_id(tokenizer)
+        )
+        if think_guard is not None:
+            logits_processors.append(think_guard)
     if min_tokens_proc is not None:
         logits_processors.append(min_tokens_proc)
     if not logits_processors:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.12.2"
+version = "0.12.3"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sampling.py
+++ b/sampling.py
@@ -45,6 +45,51 @@ def make_min_tokens_logits_processor(
     return processor
 
 
+def make_single_think_close_logits_processor(
+    think_close_id: Optional[int],
+) -> Optional[Callable[[mx.array, mx.array], mx.array]]:
+    """Build a logits processor that allows at most one ``</think>`` token.
+
+    Low-bit thinking models occasionally sample a second ``</think>`` where
+    ``<|im_end|>`` belongs — the model then "reopens" its answer and emits it
+    again verbatim (observed on ternary-expert builds). After the first
+    ``</think>`` appears in the generated tokens, this processor masks it,
+    so the only sensible continuation after the answer is EOS.
+
+    Args:
+        think_close_id: Token id of ``</think>``. Pass ``None`` (or a
+            negative id) when the tokenizer has no such single token —
+            the processor is disabled and ``None`` is returned.
+
+    Returns:
+        A ``(tokens, logits) -> logits`` callable for mlx-lm's
+        ``logits_processors`` kwarg, or ``None`` if no-op.
+    """
+    if think_close_id is None or think_close_id < 0:
+        return None
+    neg_inf = -float("inf")
+    seen = False
+
+    def processor(tokens: mx.array, logits: mx.array) -> mx.array:
+        nonlocal seen
+        if not seen and tokens is not None and tokens.size:
+            seen = bool(mx.any(tokens == think_close_id).item())
+        if seen:
+            logits[..., think_close_id] = neg_inf
+        return logits
+
+    return processor
+
+
+def think_close_token_id(tokenizer) -> Optional[int]:
+    """Return the id of ``</think>`` when it encodes to a single token."""
+    try:
+        ids = tokenizer.encode("</think>", add_special_tokens=False)
+    except Exception:
+        return None
+    return ids[0] if len(ids) == 1 else None
+
+
 def eos_token_ids(tokenizer) -> set:
     """Return the full set of EOS token ids a tokenizer considers terminal.
 

--- a/sampling.py
+++ b/sampling.py
@@ -68,14 +68,17 @@ def make_single_think_close_logits_processor(
     if think_close_id is None or think_close_id < 0:
         return None
     neg_inf = -float("inf")
-    seen = False
+    # Kept as an mx.array so the guard never forces a CPU-GPU sync inside
+    # the decode loop; it latches True once </think> appears.
+    seen = mx.array(False)
 
     def processor(tokens: mx.array, logits: mx.array) -> mx.array:
         nonlocal seen
-        if not seen and tokens is not None and tokens.size:
-            seen = bool(mx.any(tokens == think_close_id).item())
-        if seen:
-            logits[..., think_close_id] = neg_inf
+        if tokens is not None and tokens.size:
+            seen = mx.logical_or(seen, mx.any(tokens == think_close_id))
+        logits[..., think_close_id] = mx.where(
+            seen, neg_inf, logits[..., think_close_id]
+        )
         return logits
 
     return processor

--- a/serve.py
+++ b/serve.py
@@ -430,7 +430,12 @@ def _patch_default_rep_penalty(rep_config) -> None:
             try:
                 from turboquant_mlx.generate import resolve_model_path
 
-                model = handler.response_generator.cli_args.model
+                # APIHandler exposes cli_args via response_generator in
+                # mlx-lm 0.31.x; fall back to model_provider for other
+                # versions rather than pinning one attribute name.
+                provider = getattr(handler, "response_generator", None) \
+                    or getattr(handler, "model_provider", None)
+                model = provider.cli_args.model
                 cfg_file = resolve_model_path(model) / "generation_config.json"
                 if cfg_file.exists():
                     with open(cfg_file, encoding="utf-8") as f:

--- a/serve.py
+++ b/serve.py
@@ -384,6 +384,84 @@ class _KeepaliveSSEWriter:
         return getattr(self._wfile, name)
 
 
+def _extract_rep_penalty_args(argv):
+    """Peel the server-side repetition-penalty default flags off ``argv``.
+
+    ``--rep-penalty`` sets a default ``repetition_penalty`` for requests that
+    don't specify one (OpenAI clients rarely do); ``--rep-ctx`` sets the
+    matching default context window. When ``--rep-penalty`` is omitted the
+    default is looked up lazily from the model's ``generation_config.json``
+    (loop-prone low-bit thinking builds ship one). ``--rep-penalty 0`` (or 1)
+    disables the fallback entirely.
+
+    Returns ``(rep_config | None, remaining_argv)``.
+    """
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument("--rep-penalty", type=float, default=None)
+    parser.add_argument("--rep-ctx", type=int, default=256)
+    ns, remaining = parser.parse_known_args(argv)
+    if ns.rep_penalty is not None and ns.rep_penalty in (0.0, 1.0):
+        return None, remaining
+    return {"penalty": ns.rep_penalty, "context_size": ns.rep_ctx}, remaining
+
+
+def _patch_default_rep_penalty(rep_config) -> None:
+    """Give requests without a ``repetition_penalty`` a server-side default.
+
+    mlx_lm.server hardcodes the request default to 0.0 (disabled) with no CLI
+    flag, so OpenAI clients that never send the field can't benefit. Wraps
+    ``APIHandler.validate_model_parameters`` (which runs right after the body
+    fields are read) and fills in the default only when the client did not
+    send the field. The default is ``--rep-penalty`` when given, else the
+    model's ``generation_config.json`` ``repetition_penalty`` (ignoring the
+    neutral 1.0), resolved once on the first request.
+    """
+    import mlx_lm.server as _server_mod
+
+    APIHandler = _server_mod.APIHandler
+    _orig = APIHandler.validate_model_parameters
+    resolved: dict = {}
+
+    def _default_penalty(handler):
+        if "penalty" in resolved:
+            return resolved["penalty"]
+        penalty = rep_config["penalty"]
+        if penalty is None:
+            try:
+                from turboquant_mlx.generate import resolve_model_path
+
+                model = handler.response_generator.cli_args.model
+                cfg_file = resolve_model_path(model) / "generation_config.json"
+                if cfg_file.exists():
+                    with open(cfg_file, encoding="utf-8") as f:
+                        cfg_rep = json.load(f).get("repetition_penalty")
+                    if cfg_rep and cfg_rep != 1.0:
+                        penalty = cfg_rep
+            except Exception as e:
+                sys.stderr.write(
+                    f"[turboquant-serve] Could not read generation_config "
+                    f"repetition_penalty ({e})\n"
+                )
+        if penalty is not None:
+            sys.stderr.write(
+                f"[turboquant-serve] Default repetition_penalty={penalty} "
+                f"(ctx={rep_config['context_size']}) for requests that don't "
+                "set one\n"
+            )
+        resolved["penalty"] = penalty
+        return penalty
+
+    def validate_model_parameters(self):
+        penalty = _default_penalty(self)
+        if penalty is not None and "repetition_penalty" not in self.body:
+            self.repetition_penalty = penalty
+            if "repetition_context_size" not in self.body:
+                self.repetition_context_size = rep_config["context_size"]
+        return _orig(self)
+
+    APIHandler.validate_model_parameters = validate_model_parameters
+
+
 def _patch_prefill_keepalive(interval: float = 10.0) -> None:
     """Mirror mlx_lm's prefill keepalive *comments* as real SSE ``data:`` chunks.
 
@@ -422,7 +500,10 @@ def main() -> None:
     stream_config, remaining = _extract_stream_args(remaining)
     prefill_stats_config, remaining = _extract_prefill_stats_args(remaining)
     prefill_keepalive_config, remaining = _extract_prefill_keepalive_args(remaining)
+    rep_config, remaining = _extract_rep_penalty_args(remaining)
     _patch_loader(stream_config)
+    if rep_config is not None:
+        _patch_default_rep_penalty(rep_config)
     if kv_config is not None:
         _patch_kv_cache(kv_config)
     if prefill_stats_config is not None:

--- a/tests/test_think_guard.py
+++ b/tests/test_think_guard.py
@@ -1,0 +1,68 @@
+"""Tests for the single-think-block guard and sampling default plumbing."""
+
+import mlx.core as mx
+
+from turboquant_mlx.sampling import (
+    make_single_think_close_logits_processor,
+    think_close_token_id,
+)
+
+CLOSE = 42  # stand-in for the </think> token id
+VOCAB = 100
+
+
+def _logits():
+    return mx.zeros((1, VOCAB))
+
+
+def test_guard_disabled_without_token_id():
+    assert make_single_think_close_logits_processor(None) is None
+    assert make_single_think_close_logits_processor(-1) is None
+
+
+def test_guard_allows_first_close():
+    proc = make_single_think_close_logits_processor(CLOSE)
+    tokens = mx.array([1, 2, 3])  # no </think> yet
+    out = proc(tokens, _logits())
+    assert out[0, CLOSE].item() == 0.0  # untouched
+
+
+def test_guard_masks_after_first_close():
+    proc = make_single_think_close_logits_processor(CLOSE)
+    tokens = mx.array([1, 2, CLOSE, 4])
+    out = proc(tokens, _logits())
+    assert out[0, CLOSE].item() == -float("inf")
+    # other logits untouched
+    assert out[0, CLOSE - 1].item() == 0.0
+
+
+def test_guard_stays_latched_once_seen():
+    proc = make_single_think_close_logits_processor(CLOSE)
+    proc(mx.array([CLOSE]), _logits())  # latch
+    # later steps mask even if the (hypothetical) window no longer shows it
+    out = proc(mx.array([7, 8, 9]), _logits())
+    assert out[0, CLOSE].item() == -float("inf")
+
+
+def test_guard_handles_empty_tokens():
+    proc = make_single_think_close_logits_processor(CLOSE)
+    out = proc(mx.array([], dtype=mx.int32), _logits())
+    assert out[0, CLOSE].item() == 0.0
+
+
+class _FakeTokenizer:
+    def __init__(self, mapping):
+        self._mapping = mapping
+
+    def encode(self, text, add_special_tokens=False):
+        return self._mapping[text]
+
+
+def test_think_close_token_id_single_token():
+    tok = _FakeTokenizer({"</think>": [248069]})
+    assert think_close_token_id(tok) == 248069
+
+
+def test_think_close_token_id_multi_token_returns_none():
+    tok = _FakeTokenizer({"</think>": [12, 13, 14]})
+    assert think_close_token_id(tok) is None


### PR DESCRIPTION
## Summary

Low-bit **thinking** builds (e.g. the ternary `Qwen3.6-35B-A3B-tq3a-tqTe-g64`) have two failure modes observed on a real 16 GB mini: (1) getting stuck **inside** `<think>` cycling redrafts, and (2) sampling a second `</think>` where `<|im_end|>` belongs, re-emitting the whole answer. A 12-trial sweep (4 configs × 3 seeds) showed the loops are inherent to the build (the pre-0.12.2 sampler loops identically) and that a **light repetition penalty is the only sampling change that reliably exits `<think>`** (3/3 vs 2/3 for every other config).

## Changes

**generate CLI**
- `--no-think`: disables thinking via the chat template (`enable_thinking=False`). Instant, loop-immune answers; also the recommended mode for math on ternary builds.
- `--rep-penalty` now defaults from the model's `generation_config.json` (ignoring the neutral 1.0), same principle as the 0.12.2 top-p/top-k fix. `0`/`1` force-disables. Logs an `[INFO]` line when a config default is applied.
- **Single-think-block guard** (new `make_single_think_close_logits_processor` in sampling.py): once `</think>` has been emitted, its logit is masked — deterministically kills the doubled-answer artifact. `--multi-think` opts out. No-op for tokenizers where `</think>` isn't a single token.

**turboquant-serve**
- `--rep-penalty` / `--rep-ctx`: server-side default `repetition_penalty` for requests that don't send one (mlx_lm.server hardcodes the request default to 0.0 with no flag, so OpenAI clients could never benefit). Falls back to the model's `generation_config.json`, resolved once on the first request; only fills fields the client did not send.
- (Thinking-off server-side already works via the passthrough `--chat-template-args '{"enable_thinking": false}'` or per-request `chat_template_kwargs` — documented, no code needed.)

## Validation (real ternary 35B, M4 Max)

- Default run picks up `repetition_penalty 1.05` from generation_config, exits think, ends naturally (1268 tok).
- `--no-think`: perfect 2-sentence answer, 36 tokens, 33 tok/s.
- Two-trains math: correct answer (112.22 mi) under `--no-think`; thinking-mode math loops with *and* without rep-penalty (inherent to the build, not a regression — documented guidance: use `--no-think` for math).
- Serve smoke test: request without `repetition_penalty` → log shows `Default repetition_penalty=1.05 (ctx=256)`; `chat_template_kwargs {"enable_thinking": false}` → clean instant completion.
- 7 new unit tests (think-guard + token-id helper); suite: **146 passed**.