### PR TITLE
0.12.4: stream_generate --no-think + sampling defaults; fix small-unsorted-MoE-batch dispatch (34x)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,10 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   satisfied the flat-routings dispatch (`n_tokens == k`) and misaligned its
   rows against the k*k routing indices; the flat path is now additionally
   guarded by `indices.size == k`.
+- **Pinned `transformers<5.13`**: transformers 5.13 dropped string keys in
+  `AutoTokenizer.register`, which mlx-lm <= 0.31.3 still uses — every
+  `import mlx_lm` fails. The cap will be lifted once a compatible mlx-lm
+  release exists.
 
 ## [0.12.3] - 2026-07-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.12.4] - 2026-07-04
+
+### Added
+
+- **`--no-think` and sampling defaults on the streaming CLI**
+  (`python -m turboquant_mlx.stream.stream_generate`), matching the 0.12.3
+  generate CLI: `--no-think` (disable thinking via the chat template),
+  `--multi-think`, and `--top-p` / `--top-k` / `--rep-penalty` / `--rep-ctx`
+  with defaults read from the model's `generation_config.json` (the neutral
+  1.0 repetition penalty is ignored; 0 or 1 on the CLI force-disables), plus
+  the single-`</think>` guard against re-emitted answers.
+
+### Fixed
+
+- **Small unsorted MoE batches no longer dequantize every expert.** mlx-lm's
+  `SwitchGLU` only sorts routings once `indices.size >= 64`, so 2-7-token
+  forwards (e.g. a short prompt extension on a warm prefix cache) arrive
+  unsorted and fell into the dequantize-all fallback — ~34x the cost of a
+  single-token forward (measured 1.17 s vs 34 ms per forward on the ternary
+  Qwen3.6-35B-A3B). Both unsorted row layouts (gate/up: one row per token;
+  down: one row per routing) now flatten into the fused per-routing kernel:
+  M=2 1177→233 ms (5.0x), M=4 1156→269 ms (4.3x); single-token decode and
+  sorted-batch paths are unchanged. Applies to both the resident and the
+  streaming expert layers.
+- **Top-k routing collision on unsorted batches**: a batch of exactly k
+  unsorted tokens on a top-k model (e.g. 4 tokens on GPT-OSS's top-4)
+  satisfied the flat-routings dispatch (`n_tokens == k`) and misaligned its
+  rows against the k*k routing indices; the flat path is now additionally
+  guarded by `indices.size == k`.
+
 ## [0.12.3] - 2026-07-03
 
 ### Added — thinking-mode ergonomics for low-bit builds

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.12.3"
+__version__ = "0.12.4"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/layers/polar_switch_linear.py
+++ b/layers/polar_switch_linear.py
@@ -159,7 +159,12 @@ class PolarQuantizedSwitchLinear(nn.Module):
                 y = y + mx.expand_dims(self["bias"][indices], -2)
             return y
 
-        if n_tokens == k:
+        # indices.size == k distinguishes the genuine flat forms (sorted
+        # routings / single-token down_proj) from an unsorted batch that
+        # merely happens to have as many tokens as experts-per-token
+        # (e.g. 4 tokens x top-4): there indices is (..., L, k) with
+        # L == k, and treating x rows as flat routings would misalign.
+        if n_tokens == k and indices.size == k:
             # Large batched routing (diffusion canvas / big prefill via
             # SwitchMLP's do_sort): the per-row gather kernel re-reads x per
             # output row, so past _GATHER_MM_MIN_ROUTINGS it loses badly.
@@ -210,6 +215,42 @@ class PolarQuantizedSwitchLinear(nn.Module):
             if "bias" in self:
                 y = y + mx.expand_dims(self["bias"][indices], -2)
             return y
+
+        # Small unsorted batch: mlx-lm's SwitchGLU only sorts at
+        # indices.size >= 64, so short forwards (e.g. a 2-7 token prompt
+        # extension on a warm prefix cache) land here. Dequantizing every
+        # expert for a handful of routings is ~34x slower than the fused
+        # per-routing kernel, so flatten (token, expert) pairs and reuse
+        # polar_multi_gather_qmv. Two unsorted row layouts arrive:
+        #   gate/up: one row per token          (..., 1, 1, in), idx (..., k)
+        #   down:    one row per (token,expert) (..., k, 1, in), idx (..., k)
+        # Also taken regardless of size when the materialized expert tensor
+        # would be OOM-large (issue #1).
+        n_routings = indices.size
+        if x.shape[-2] == 1 and (
+            n_routings < _GATHER_MM_MIN_ROUTINGS
+            or self._dequant_bytes() > _GATHER_MM_MAX_DEQUANT_BYTES
+        ):
+            if n_tokens * k == n_routings:
+                # one row per token: repeat each row for its k experts
+                x_rows = mx.repeat(
+                    x.reshape(n_tokens, self.input_dims), repeats=k, axis=0
+                )
+            elif n_tokens == n_routings:
+                # already one row per (token, expert) routing
+                x_rows = x.reshape(n_routings, self.input_dims)
+            else:
+                x_rows = None
+            if x_rows is not None:
+                y = polar_multi_gather_qmv(
+                    self.weight, self.scales, self.codebook,
+                    x_rows, indices.reshape(-1),
+                    self.bits, self.group_size, trit=self.trit,
+                )  # (n_routings, output_dims)
+                y = y.reshape(list(indices.shape) + [1, self.output_dims])
+                if "bias" in self:
+                    y = y + mx.expand_dims(self["bias"][indices], -2)
+                return y
 
         # Prefill path: vectorized dequant + gather_mm
         w_deq = self._dequantize_all()  # (num_experts, out, in)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,10 @@ classifiers = [
 dependencies = [
     "mlx>=0.20.0",
     "mlx-lm>=0.31.3",
+    # transformers 5.13 dropped string keys in AutoTokenizer.register, which
+    # mlx-lm <= 0.31.3 still uses (NewlineTokenizer) — import breaks. Lift the
+    # cap once an mlx-lm release is compatible.
+    "transformers<5.13",
     "numpy",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.12.3"
+version = "0.12.4"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -14,6 +14,7 @@ Example (Qwen3.6-35B-A3B, ~16 GB on disk, runs in ~5 GB RAM):
 from __future__ import annotations
 
 import argparse
+import json
 import os
 import subprocess
 import time
@@ -22,7 +23,13 @@ import mlx.core as mx
 
 import turboquant_mlx.compat  # noqa: F401
 from mlx_lm import generate as mlx_generate
-from mlx_lm.sample_utils import make_sampler
+from mlx_lm.sample_utils import make_logits_processors, make_sampler
+
+from turboquant_mlx.generate import resolve_model_path
+from turboquant_mlx.sampling import (
+    make_single_think_close_logits_processor,
+    think_close_token_id,
+)
 
 from .loader import load_streaming
 
@@ -66,6 +73,27 @@ def main():
                    help="Force F_NOCACHE (page cache off). Default: auto by model-size-vs-RAM.")
     p.add_argument("--fast", action="store_true", help="Disable QJL correction for faster decode.")
     p.add_argument("--no-chat-template", action="store_true")
+    p.add_argument("--top-p", type=float, default=None,
+                   help="Nucleus sampling threshold. Defaults to the model's "
+                        "generation_config.json value when present, else disabled. "
+                        "Pass 0 to force-disable.")
+    p.add_argument("--top-k", type=int, default=None,
+                   help="Top-k truncation. Defaults to the model's "
+                        "generation_config.json value when present, else disabled. "
+                        "Pass 0 to force-disable.")
+    p.add_argument("--rep-penalty", type=float, default=None,
+                   help="Repetition penalty (e.g. 1.05). Defaults to the model's "
+                        "generation_config.json value when present, else disabled. "
+                        "Pass 0 or 1 to force-disable.")
+    p.add_argument("--rep-ctx", type=int, default=256,
+                   help="Repetition penalty context window in tokens (default: 256).")
+    p.add_argument("--no-think", action="store_true",
+                   help="Disable thinking mode via the chat template "
+                        "(enable_thinking=False). Much faster and immune to "
+                        "think-block loops on thinking-capable models.")
+    p.add_argument("--multi-think", action="store_true",
+                   help="Allow more than one </think> token per generation. By default "
+                        "a second </think> is masked once one has been emitted.")
     args = p.parse_args()
 
     t0 = time.time()
@@ -79,15 +107,65 @@ def main():
 
     prompt = args.prompt
     if not args.no_chat_template and hasattr(tok, "apply_chat_template"):
+        template_kwargs = {"enable_thinking": False} if args.no_think else {}
         prompt = tok.apply_chat_template(
-            [{"role": "user", "content": args.prompt}], add_generation_prompt=True
+            [{"role": "user", "content": args.prompt}], add_generation_prompt=True,
+            **template_kwargs,
         )
 
-    sampler = make_sampler(temp=args.temp)
+    # Sampling defaults come from the model's own generation_config.json,
+    # mirroring turboquant_mlx.generate: top_p/top_k truncation (a stray
+    # '</think>' sampled where EOS belongs doubles the answer) and
+    # repetition_penalty for loop-prone low-bit thinking builds.
+    top_p, top_k, rep_penalty = args.top_p, args.top_k, args.rep_penalty
+    if top_p is None or top_k is None or rep_penalty is None:
+        try:
+            gen_cfg_file = resolve_model_path(args.model) / "generation_config.json"
+            if gen_cfg_file.exists():
+                with open(gen_cfg_file, encoding="utf-8") as f:
+                    gen_cfg = json.load(f)
+                if top_p is None:
+                    top_p = gen_cfg.get("top_p")
+                if top_k is None:
+                    top_k = gen_cfg.get("top_k")
+                if rep_penalty is None:
+                    cfg_rep = gen_cfg.get("repetition_penalty")
+                    # 1.0 is transformers' neutral default — not a real request
+                    if cfg_rep and cfg_rep != 1.0:
+                        rep_penalty = cfg_rep
+                        print(f"[INFO] repetition_penalty {cfg_rep} "
+                              f"(from generation_config.json)")
+        except Exception as e:
+            print(f"[INFO] Could not read generation_config.json for "
+                  f"{args.model}; sampling without truncation defaults ({e})")
+    # 0 or 1.0 on the CLI force-disables (1.0 is mathematically neutral)
+    if rep_penalty is not None and rep_penalty in (0.0, 1.0):
+        rep_penalty = None
+    sampler = make_sampler(
+        temp=args.temp,
+        top_p=top_p if top_p is not None else 0.0,
+        top_k=top_k if top_k is not None else 0,
+    )
+    logits_processors = []
+    if rep_penalty is not None:
+        logits_processors.extend(make_logits_processors(
+            repetition_penalty=rep_penalty,
+            repetition_context_size=args.rep_ctx,
+        ))
+    if not args.multi_think:
+        think_guard = make_single_think_close_logits_processor(
+            think_close_token_id(tok)
+        )
+        if think_guard is not None:
+            logits_processors.append(think_guard)
+    if not logits_processors:
+        logits_processors = None
+
     print("=" * 60)
     t = time.time()
     text = mlx_generate(model, tok, prompt=prompt, max_tokens=args.max_tokens,
-                        sampler=sampler, verbose=True)
+                        sampler=sampler, logits_processors=logits_processors,
+                        verbose=True)
     dt = time.time() - t
     print("=" * 60)
     # Count tokens actually generated (the model may stop at EOS before

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -456,7 +456,9 @@ class StreamingSwitchLinear(nn.Module):
             )
             return y.reshape(list(indices.shape) + [1, self.output_dims])
 
-        if n_tokens == k:
+        # indices.size == k distinguishes genuine flat forms from an
+        # unsorted batch with n_tokens == k (see PolarQuantizedSwitchLinear).
+        if n_tokens == k and indices.size == k:
             x_2d = x.reshape(k, self.input_dims)
             y = polar_multi_gather_qmv(
                 w_sel, s_sel, self.codebook,
@@ -464,6 +466,28 @@ class StreamingSwitchLinear(nn.Module):
                 trit=self.trit,
             )
             return y.reshape(list(indices.shape) + [1, self.output_dims])
+
+        # Small unsorted batch: flatten (token, expert) pairs into the fused
+        # per-routing kernel instead of dequantizing the selected experts
+        # through the Python unpack path. Both unsorted row layouts, as in
+        # PolarQuantizedSwitchLinear.__call__.
+        n_routings = indices.size
+        if x.shape[-2] == 1:
+            if n_tokens * k == n_routings:
+                x_rows = mx.repeat(
+                    x.reshape(n_tokens, self.input_dims), repeats=k, axis=0
+                )
+            elif n_tokens == n_routings:
+                x_rows = x.reshape(n_routings, self.input_dims)
+            else:
+                x_rows = None
+            if x_rows is not None:
+                y = polar_multi_gather_qmv(
+                    w_sel, s_sel, self.codebook,
+                    x_rows, idx_local_flat, self.bits, self.group_size,
+                    trit=self.trit,
+                )
+                return y.reshape(list(indices.shape) + [1, self.output_dims])
 
         # Prefill: dequantize only the selected experts, gather_mm locally.
         w_deq = self._dequantize_selected(w_sel, s_sel)

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -25,6 +25,7 @@ import mlx.nn as nn
 from turboquant_mlx.core.rotation import rotate_input
 from turboquant_mlx.kernels.polar_gather_qmv import polar_gather_qmv
 from turboquant_mlx.kernels.polar_multi_gather_qmv import polar_multi_gather_qmv
+from turboquant_mlx.layers.polar_switch_linear import _GATHER_MM_MIN_ROUTINGS
 
 
 class ExpertCache:
@@ -470,9 +471,12 @@ class StreamingSwitchLinear(nn.Module):
         # Small unsorted batch: flatten (token, expert) pairs into the fused
         # per-routing kernel instead of dequantizing the selected experts
         # through the Python unpack path. Both unsorted row layouts, as in
-        # PolarQuantizedSwitchLinear.__call__.
+        # PolarQuantizedSwitchLinear.__call__. Past _GATHER_MM_MIN_ROUTINGS
+        # the per-row kernel re-reads x per output row and loses; keep the
+        # dequant-selected + gather_mm fallback there (mlx-lm sorts those
+        # shapes anyway, so this only affects direct callers).
         n_routings = indices.size
-        if x.shape[-2] == 1:
+        if x.shape[-2] == 1 and n_routings < _GATHER_MM_MIN_ROUTINGS:
             if n_tokens * k == n_routings:
                 x_rows = mx.repeat(
                     x.reshape(n_tokens, self.input_dims), repeats=k, axis=0

--- a/tests/test_switch_unsorted_batch.py
+++ b/tests/test_switch_unsorted_batch.py
@@ -1,0 +1,152 @@
+"""Parity tests for the small-unsorted-batch dispatch in
+PolarQuantizedSwitchLinear.
+
+mlx-lm's SwitchGLU only sorts routings when indices.size >= 64, so short
+forwards (2-7 tokens at top-8) arrive unsorted. These used to fall into the
+dequantize-all-experts fallback (~34x a single-token forward); they must now
+take the fused per-routing kernel and match the dequant + mx.gather_mm
+reference in both unsorted row layouts:
+
+  gate/up: one row per token          (B, L, 1, 1, in), idx (B, L, k)
+  down:    one row per (token,expert) (B, L, k, 1, in), idx (B, L, k)
+
+Also pins the n_tokens == k collision: 4 unsorted tokens on a top-4 model
+used to be misread as flat per-expert rows (misaligned with its k*k indices).
+"""
+
+import mlx.core as mx
+import pytest
+
+import turboquant_mlx.layers.polar_switch_linear as psl
+from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
+
+
+def _make_layer(num_experts=8, output_dims=64, input_dims=128, bits=3,
+                group_size=32, ternary=False, bias=False):
+    mx.random.seed(0)
+    w = mx.random.normal((num_experts, output_dims, input_dims)).astype(mx.float16)
+    b = None
+    if bias:
+        b = mx.random.normal((num_experts, output_dims)).astype(mx.float16)
+    return PolarQuantizedSwitchLinear.from_switch_linear(
+        None, bits=bits, group_size=group_size, seed=7, float_weight=w,
+        bias=b, ternary=ternary,
+    )
+
+
+def _rel(a, b):
+    a = a.astype(mx.float32)
+    b = b.astype(mx.float32)
+    return float(mx.linalg.norm(a - b) / (mx.linalg.norm(b) + 1e-12))
+
+
+def _dequant_reference(layer, x, idx):
+    """Same inputs through the dequant + gather_mm fallback."""
+    saved = psl._GATHER_MM_MIN_ROUTINGS
+    psl._GATHER_MM_MIN_ROUTINGS = 0
+    try:
+        return layer(x, idx)
+    finally:
+        psl._GATHER_MM_MIN_ROUTINGS = saved
+
+
+def _fused_only(layer, x, idx):
+    """Layer call that fails the test if it falls back to dequant-all."""
+    def _boom(self):
+        raise AssertionError("small unsorted batch fell back to dequant-all")
+
+    saved = PolarQuantizedSwitchLinear._dequantize_all
+    PolarQuantizedSwitchLinear._dequantize_all = _boom
+    try:
+        y = layer(x, idx)
+        mx.eval(y)
+        return y
+    finally:
+        PolarQuantizedSwitchLinear._dequantize_all = saved
+
+
+@pytest.mark.parametrize("ternary", [False, True])
+@pytest.mark.parametrize("n_tokens", [2, 7])
+def test_gate_up_layout_parity(ternary, n_tokens):
+    layer = _make_layer(ternary=ternary)
+    mx.random.seed(1)
+    x = mx.random.normal((1, n_tokens, 1, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.random.randint(0, layer.num_experts, (1, n_tokens, 8)).astype(mx.uint32)
+    mx.eval(x, idx)
+
+    ref = _dequant_reference(layer, x, idx)
+    got = _fused_only(layer, x, idx)
+    mx.eval(got, ref)
+    assert got.shape == ref.shape
+    assert _rel(got, ref) < 1e-3
+
+
+@pytest.mark.parametrize("ternary", [False, True])
+def test_down_layout_parity(ternary):
+    layer = _make_layer(ternary=ternary)
+    n_tokens, k = 3, 8
+    mx.random.seed(2)
+    x = mx.random.normal((1, n_tokens, k, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.random.randint(0, layer.num_experts, (1, n_tokens, k)).astype(mx.uint32)
+    mx.eval(x, idx)
+
+    ref = _dequant_reference(layer, x, idx)
+    got = _fused_only(layer, x, idx)
+    mx.eval(got, ref)
+    assert got.shape == ref.shape
+    assert _rel(got, ref) < 1e-3
+
+
+def test_bias_applied_on_fused_path():
+    layer = _make_layer(bias=True)
+    n_tokens = 4
+    mx.random.seed(3)
+    x = mx.random.normal((1, n_tokens, 1, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.random.randint(0, layer.num_experts, (1, n_tokens, 8)).astype(mx.uint32)
+    mx.eval(x, idx)
+
+    ref = _dequant_reference(layer, x, idx)
+    got = _fused_only(layer, x, idx)
+    mx.eval(got, ref)
+    assert got.shape == ref.shape
+    assert _rel(got, ref) < 1e-3
+
+
+def test_top4_collision_n_tokens_equals_k():
+    """4 unsorted tokens on a top-4 model: n_tokens == k but indices.size is
+    k*k — must be dispatched as an unsorted batch, not as flat routings."""
+    layer = _make_layer(num_experts=4)
+    n_tokens = k = 4
+    mx.random.seed(4)
+    x = mx.random.normal((1, n_tokens, 1, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.random.randint(0, layer.num_experts, (1, n_tokens, k)).astype(mx.uint32)
+    mx.eval(x, idx)
+
+    ref = _dequant_reference(layer, x, idx)
+    got = _fused_only(layer, x, idx)
+    mx.eval(got, ref)
+    assert got.shape == ref.shape == (1, n_tokens, k, 1, layer.output_dims)
+    assert _rel(got, ref) < 1e-3
+
+
+def test_large_unsorted_batch_keeps_dequant_path():
+    """Past _GATHER_MM_MIN_ROUTINGS the per-row kernel loses; the dequant +
+    gather_mm path must still be chosen for large unsorted batches."""
+    layer = _make_layer()
+    n_tokens = 128  # 128 x top-8 = 1024 routings >= 512
+    mx.random.seed(5)
+    x = mx.random.normal((1, n_tokens, 1, 1, layer.input_dims)).astype(mx.float16)
+    idx = mx.random.randint(0, layer.num_experts, (1, n_tokens, 8)).astype(mx.uint32)
+    mx.eval(x, idx)
+
+    def _boom(*a, **kw):
+        raise AssertionError("large unsorted batch took the per-row kernel")
+
+    saved = psl.polar_multi_gather_qmv
+    psl.polar_multi_gather_qmv = _boom
+    try:
+        y = layer(x, idx)
+        mx.eval(y)
+    finally:
+        psl.polar_multi_gather_qmv = saved
+    assert y.shape == (1, n_tokens, 8, 1, layer.output_dims)


### PR DESCRIPTION
## Summary

Bundles two changes as v0.12.4:

### feat(stream): `--no-think` + sampling defaults in `stream.stream_generate`

Ports the 0.12.3 generate-CLI ergonomics to the streaming CLI: `--no-think` (chat-template `enable_thinking=False`), `--multi-think`, and `--top-p` / `--top-k` / `--rep-penalty` / `--rep-ctx` with defaults read from the model's `generation_config.json` (neutral 1.0 ignored; 0 or 1 force-disables), plus the single-`</think>` guard.

### fix(moe): small unsorted batches no longer dequantize every expert

mlx-lm's `SwitchGLU` only sorts routings once `indices.size >= 64`, so 2-7-token forwards (e.g. a short prompt extension on a warm prefix cache) arrive unsorted and fell into the dequantize-all fallback — ~34x a single-token forward. Both unsorted row layouts (gate/up: one row per token; down: one row per routing) now flatten into the fused `polar_multi_gather_qmv` kernel, in both the resident and streaming expert layers.

Measured on ternary Qwen3.6-35B-A3B (M4 Max):

| Batch | Before | After |
|---|---|---|
| M=1 (decode) | 34.7 ms | 34.2 ms (unchanged) |
| M=2 | 1177 ms | **233 ms** (5.0x) |
| M=4 | 1156 ms | **269 ms** (4.3x) |
| M=8 / M=16 (sorted) | 346 / 501 ms | unchanged |

Also fixes a latent top-k collision: exactly k unsorted tokens on a top-k model (e.g. 4 tokens on a top-4 MoE) matched the flat-routings dispatch (`n_tokens == k`) and misaligned rows against the k*k indices; the flat path is now guarded by `indices.size == k`.

## Test plan

- 9 new parity tests in `tests/test_switch_unsorted_batch.py`: both unsorted layouts x bit-packed/ternary experts, bias, the top-k collision, and large-batch threshold retention (>=512 routings keep the dequant + gather_mm path)
- Full suite: 155 passed
- E2e smoke on the real ternary 35B: coherent generation, 33.5 tok/s decode, 10.7 GB peak (unchanged)