### PR TITLE
feat: disk-persistent prompt cache on turboquant-serve (--disk-cache)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,26 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Disk-persistent prompt cache on `turboquant-serve`** (`--disk-cache
+  [DIR]`, plus `--disk-cache-budget-gb` / `--disk-cache-min-tokens` /
+  `--disk-cache-save-every`): each completed request's KV cache is
+  checkpointed to disk (background writer, LRU byte-budget eviction) and
+  restored on a prompt-cache miss — most importantly the first request after
+  a server restart, which resumes from the longest saved token prefix
+  instead of re-prefilling the whole conversation (a ~13-minute cold 22K
+  prefill on a streaming 122B on a 16 GB mini becomes a checkpoint load plus
+  a short suffix prefill). Token-level longest-common-prefix matching keeps
+  the exact semantics of the in-memory cache: strict-prefix checkpoints
+  extend any cache type, longer/divergent checkpoints are used only for
+  trimmable caches. TurboQuant-quantized KV caches serialize too
+  (`TurboQuantKVCache.from_state` added). Measured on a 64 GB M4 with
+  Qwen3.6-35B-A3B-tq3-g32 and a 16.3K-token conversation: the first turn
+  after a restart drops 21.1 s → 3.0 s (6.9x; 99.9% of the prompt served
+  from the 700 MB checkpoint, 22 tokens freshly prefilled, greedy output
+  byte-identical to the never-restarted server).
+
 ## [0.12.4] - 2026-07-04
 
 ### Added

--- a/disk_prompt_cache.py
+++ b/disk_prompt_cache.py
@@ -1,0 +1,581 @@
+"""Disk-persistent prompt cache for turboquant-serve.
+
+Makes the server's prompt-prefix cache a *disk* citizen, not just an
+in-memory one: every completed request's KV cache is checkpointed to a
+cache directory, and on a cache miss (most importantly: the first request
+after a server restart) the best on-disk checkpoint is loaded back and
+reused, so only the token suffix is prefilled. This turns the killer cold
+start on slow boxes (a ~13-minute 22K-token prefill on a streaming 122B on
+a 16 GB mini) into a file load plus a short suffix prefill.
+
+Design (inspired by DwarfStar's "the KV cache is a first-class disk
+citizen", adapted to mlx_lm's token-level prompt trie):
+
+- ``mlx_lm.server`` routes all prompt-cache traffic through
+  ``LRUPromptCache.fetch_nearest_cache`` / ``insert_cache`` with the full
+  token list. We wrap both (same pattern as ``prefill_stats``): inserts are
+  mirrored to disk, and a fetch that reuses little consults the disk index
+  for a checkpoint with a longer usable prefix, loads it into the in-memory
+  LRU, and re-runs the fetch.
+- Matching is token-level longest-common-prefix, exactly like the in-memory
+  trie — so there is no byte/retokenization keying problem: a checkpoint
+  whose tokens are a strict prefix of the request extends any cache type,
+  and a *longer/divergent* checkpoint is usable only when the cache is
+  trimmable (full-attention KV; hybrid GDN/Mamba states are not).
+- Save policy: only prompts of at least ``min_tokens``; at most one
+  checkpoint per ``save_every`` new tokens along a conversation lineage;
+  when the new checkpoint is trimmable, stored strict-prefix checkpoints
+  are superseded (deleted) — mirroring the trie's ``pop_prefixes``.
+- Storage: one ``.safetensors`` per checkpoint via the same state/meta_state
+  protocol as ``mlx_lm.models.cache.save_prompt_cache``, plus an
+  ``index.json`` holding the token lists. ``None`` entries inside a cache's
+  ``state`` (e.g. an absent fp16 tier in ``TurboQuantKVCache``) are stored
+  as placeholder arrays whose key paths are recorded in the file metadata
+  and put back to ``None`` on load.
+- Eviction: least-recently-used by total bytes (``budget_gb``).
+- Writes happen on a background thread so the next request is never blocked
+  behind a multi-GB checkpoint write; a flush runs at exit (the "shutdown
+  save"). Single-server-process per cache directory is assumed.
+
+Enable with ``turboquant-serve --disk-cache [DIR]``.
+"""
+
+from __future__ import annotations
+
+import atexit
+import hashlib
+import json
+import os
+import queue
+import sys
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, TextIO
+
+import numpy as np
+
+_FORMAT_VERSION = 1
+_INDEX_NAME = "index.json"
+# Loading a checkpoint must win at least this many tokens over what the
+# in-memory cache already covers — below that the file I/O isn't worth it.
+_MIN_GAIN_TOKENS = 256
+
+
+def _model_key_str(model: Any) -> str:
+    """Stable string form of the server's model key (a tuple of paths)."""
+    if isinstance(model, (tuple, list)):
+        return json.dumps([None if x is None else str(x) for x in model])
+    return str(model)
+
+
+def _digest(model_key: str, tokens: np.ndarray) -> str:
+    h = hashlib.sha256()
+    h.update(model_key.encode())
+    h.update(b"|")
+    h.update(np.ascontiguousarray(tokens, dtype=np.int64).tobytes())
+    return h.hexdigest()[:32]
+
+
+def _lcp(a: np.ndarray, b: np.ndarray) -> int:
+    n = min(a.size, b.size)
+    if n == 0:
+        return 0
+    neq = np.nonzero(a[:n] != b[:n])[0]
+    return int(neq[0]) if neq.size else n
+
+
+# ---------------------------------------------------------------------------
+# Checkpoint file format (mlx_lm save_prompt_cache layout + None sentinels)
+# ---------------------------------------------------------------------------
+
+_NONE_KEYS_META = "__tq_none_state_keys__"
+
+
+def _replace_nones(flat):
+    """Swap ``None`` state leaves for placeholder arrays (safetensors can
+    store neither None nor zero-size arrays); returns the affected key paths
+    so load can put the Nones back."""
+    import mlx.core as mx
+
+    none_keys = [k for k, v in flat if v is None]
+    flat = [
+        (k, mx.zeros((1,), dtype=mx.float32) if v is None else v)
+        for k, v in flat
+    ]
+    return flat, none_keys
+
+
+def _set_none_at(tree, dotted_key: str) -> None:
+    """Set the leaf at a tree_flatten-style dotted index path to ``None``."""
+    parts = dotted_key.split(".")
+    node = tree
+    for p in parts[:-1]:
+        node = node[int(p)]
+    node[int(parts[-1])] = None
+
+
+def _cache_class(name: str):
+    """Resolve a cache class by name: mlx_lm's registry plus TurboQuant's."""
+    import mlx_lm.models.cache as _cache_mod
+
+    if name == "TurboQuantKVCache":
+        from turboquant_mlx.layers.polar_kv_cache import TurboQuantKVCache
+
+        return TurboQuantKVCache
+    cls = getattr(_cache_mod, name, None)
+    if cls is None or not hasattr(cls, "from_state"):
+        raise ValueError(f"Unknown prompt-cache class in checkpoint: {name!r}")
+    return cls
+
+
+def prepare_cache_payload(prompt_cache: List[Any], metadata: Dict[str, str]):
+    """Extract and *evaluate* a cache's serializable payload.
+
+    Must run on the thread that owns the cache's MLX graph (the generation
+    thread): lazy arrays built on one thread cannot be evaluated from
+    another ("There is no Stream(gpu, 0) in current thread"). The returned
+    payload is fully materialized, so the background writer only does file
+    I/O. Returns ``(data_dict, meta_dict)`` for ``mx.save_safetensors``.
+    """
+    import mlx.core as mx
+    from mlx.utils import tree_flatten
+
+    cache_data = [c.state for c in prompt_cache]
+    cache_info = [c.meta_state for c in prompt_cache]
+    cache_classes = [type(c).__name__ for c in prompt_cache]
+    flat_data, none_keys = _replace_nones(tree_flatten(cache_data))
+    metadata = {**metadata, _NONE_KEYS_META: json.dumps(none_keys)}
+    flat_meta = dict(tree_flatten([cache_info, metadata, cache_classes]))
+    data = dict(flat_data)
+    mx.eval(list(data.values()))
+    return data, flat_meta
+
+
+def save_cache_file(path, prompt_cache: List[Any],
+                    metadata: Dict[str, str]) -> None:
+    """``save_prompt_cache``-compatible writer that tolerates None state leaves."""
+    import mlx.core as mx
+
+    data, meta = prepare_cache_payload(prompt_cache, metadata)
+    mx.save_safetensors(str(path), data, meta)
+
+
+def load_cache_file(path):
+    """Load a checkpoint written by ``save_cache_file``.
+
+    Returns ``(prompt_cache, metadata)``.
+    """
+    import mlx.core as mx
+    from mlx.utils import tree_unflatten
+
+    arrays, meta = mx.load(str(path), return_metadata=True)
+    arrays = tree_unflatten(list(arrays.items()))
+    meta = tree_unflatten(list(meta.items()))
+    info, metadata, classes = meta
+    for key in json.loads(metadata.pop(_NONE_KEYS_META, "[]")):
+        _set_none_at(arrays, key)
+    cache = [
+        _cache_class(name).from_state(state, meta_state)
+        for name, state, meta_state in zip(classes, arrays, info)
+    ]
+    return cache, metadata
+
+
+# ---------------------------------------------------------------------------
+# Store
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _Entry:
+    digest: str
+    model_key: str
+    tokens: np.ndarray
+    nbytes: int
+    trimmable: bool
+    created: float
+    last_used: float
+
+    def to_json(self) -> dict:
+        return dict(
+            digest=self.digest,
+            model_key=self.model_key,
+            tokens=self.tokens.tolist(),
+            nbytes=self.nbytes,
+            trimmable=self.trimmable,
+            created=self.created,
+            last_used=self.last_used,
+        )
+
+    @classmethod
+    def from_json(cls, d: dict) -> "_Entry":
+        return cls(
+            digest=d["digest"],
+            model_key=d["model_key"],
+            tokens=np.asarray(d["tokens"], dtype=np.int64),
+            nbytes=int(d["nbytes"]),
+            trimmable=bool(d["trimmable"]),
+            created=float(d["created"]),
+            last_used=float(d["last_used"]),
+        )
+
+
+class DiskPromptCache:
+    """Persist prompt-cache checkpoints under ``cache_dir`` and restore on miss.
+
+    Parameters
+    ----------
+    cache_dir : str | Path
+        Directory for ``index.json`` + per-checkpoint ``.safetensors`` files.
+    budget_gb : float
+        Max total checkpoint bytes; least-recently-used entries are evicted.
+    min_tokens : int
+        Never checkpoint prompts shorter than this.
+    save_every : int
+        Along one conversation lineage, only checkpoint after at least this
+        many new tokens since the stored prefix (a restart loses at most this
+        much prefill).
+    sync : bool
+        Write checkpoints synchronously instead of on the background thread
+        (used by tests).
+    """
+
+    def __init__(self, cache_dir, budget_gb: float = 10.0,
+                 min_tokens: int = 512, save_every: int = 1024,
+                 sync: bool = False, log: TextIO = sys.stderr):
+        self.dir = Path(cache_dir).expanduser()
+        self.dir.mkdir(parents=True, exist_ok=True)
+        self.budget_bytes = int(budget_gb * (1 << 30))
+        self.min_tokens = int(min_tokens)
+        self.save_every = int(save_every)
+        self.log = log
+        self._lock = threading.Lock()
+        self._entries: Dict[str, _Entry] = {}
+        # Enqueued-but-unwritten checkpoints, keyed like _entries. The save
+        # policy must see these too, or rapid-fire inserts (the server
+        # checkpoints each prompt segment) race past the stride throttle and
+        # write near-duplicate multi-GB files.
+        self._pending: Dict[str, tuple] = {}
+        self._load_index()
+
+        self._sync = sync
+        self._queue: Optional[queue.Queue] = None
+        if not sync:
+            self._queue = queue.Queue(maxsize=4)
+            worker = threading.Thread(
+                target=self._worker, daemon=True, name="tq-disk-cache"
+            )
+            worker.start()
+
+        self._orig_fetch = None
+        self._orig_insert = None
+
+    # -- index ------------------------------------------------------------
+
+    def _file(self, digest: str) -> Path:
+        return self.dir / f"{digest}.safetensors"
+
+    def _load_index(self) -> None:
+        index_path = self.dir / _INDEX_NAME
+        entries: Dict[str, _Entry] = {}
+        try:
+            with open(index_path, encoding="utf-8") as f:
+                data = json.load(f)
+            for d in data.get("entries", []):
+                entry = _Entry.from_json(d)
+                if self._file(entry.digest).exists():
+                    entries[entry.digest] = entry
+        except FileNotFoundError:
+            pass
+        except Exception as e:
+            self.log.write(
+                f"[disk-cache] index unreadable ({e}); starting empty\n"
+            )
+        self._entries = entries
+        # Prune checkpoint files the index doesn't know about (e.g. a write
+        # that crashed before the index update).
+        for f in self.dir.glob("*.safetensors"):
+            if f.stem not in self._entries:
+                try:
+                    f.unlink()
+                except OSError:
+                    pass
+
+    def _save_index(self) -> None:
+        # Called with self._lock held. Atomic via tmp + rename.
+        tmp = self.dir / (_INDEX_NAME + ".tmp")
+        data = dict(
+            version=_FORMAT_VERSION,
+            entries=[e.to_json() for e in self._entries.values()],
+        )
+        with open(tmp, "w", encoding="utf-8") as f:
+            json.dump(data, f)
+        os.replace(tmp, self.dir / _INDEX_NAME)
+
+    def _remove_entry(self, digest: str) -> None:
+        # Called with self._lock held.
+        self._entries.pop(digest, None)
+        try:
+            self._file(digest).unlink()
+        except OSError:
+            pass
+
+    def _evict_over_budget(self, protect: str) -> None:
+        # Called with self._lock held.
+        total = sum(e.nbytes for e in self._entries.values())
+        victims = sorted(self._entries.values(), key=lambda e: e.last_used)
+        for e in victims:
+            if total <= self.budget_bytes:
+                break
+            if e.digest == protect:
+                continue
+            total -= e.nbytes
+            self._remove_entry(e.digest)
+            self.log.write(
+                f"[disk-cache] evicted {e.tokens.size}-token checkpoint "
+                f"({e.nbytes / (1 << 20):.0f} MB, LRU)\n"
+            )
+
+    @property
+    def total_bytes(self) -> int:
+        with self._lock:
+            return sum(e.nbytes for e in self._entries.values())
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._entries)
+
+    # -- save path ----------------------------------------------------------
+
+    def maybe_save(self, model: Any, tokens: List[int],
+                   prompt_cache: List[Any]) -> None:
+        """Checkpoint ``prompt_cache`` if the save policy says it's worth it."""
+        toks = np.asarray(tokens, dtype=np.int64)
+        n = int(toks.size)
+        if n < self.min_tokens:
+            return
+        mk = _model_key_str(model)
+        digest = _digest(mk, toks)
+        with self._lock:
+            best_prefix = 0
+            known = list(self._entries.values()) + [
+                _e for _e in self._pending.values()
+            ]
+            for e in known:
+                if e.model_key != mk:
+                    continue
+                lcp = _lcp(e.tokens, toks)
+                if lcp == n:
+                    return  # a stored checkpoint already covers these tokens
+                if lcp == e.tokens.size:
+                    best_prefix = max(best_prefix, lcp)
+            if best_prefix and n - best_prefix < self.save_every:
+                return
+
+        from mlx_lm.models.cache import can_trim_prompt_cache
+
+        try:
+            trimmable = bool(can_trim_prompt_cache(prompt_cache))
+        except Exception:
+            trimmable = False
+
+        # Extract + evaluate the payload here, on the thread that owns the
+        # cache's MLX graph (lazy arrays cannot be evaluated cross-thread);
+        # the background writer is left with pure file I/O — the slow part.
+        metadata = dict(
+            version=str(_FORMAT_VERSION),
+            model_key=mk,
+            tokens=json.dumps(toks.tolist()),
+        )
+        try:
+            data, meta = prepare_cache_payload(prompt_cache, metadata)
+        except Exception as e:
+            self.log.write(f"[disk-cache] save skipped (serialize: {e})\n")
+            return
+
+        now = time.time()
+        placeholder = _Entry(
+            digest=digest, model_key=mk, tokens=toks, nbytes=0,
+            trimmable=trimmable, created=now, last_used=now,
+        )
+        job = (mk, toks, data, meta, trimmable)
+        if self._sync:
+            self._do_save(*job)
+        else:
+            with self._lock:
+                self._pending[digest] = placeholder
+            try:
+                self._queue.put_nowait(job)
+            except queue.Full:
+                with self._lock:
+                    self._pending.pop(digest, None)
+                self.log.write(
+                    "[disk-cache] save skipped (writer busy)\n"
+                )
+
+    def _worker(self) -> None:
+        while True:
+            job = self._queue.get()
+            try:
+                self._do_save(*job)
+            except Exception as e:
+                self.log.write(f"[disk-cache] save failed: {e}\n")
+            finally:
+                self._queue.task_done()
+
+    def _do_save(self, mk: str, toks: np.ndarray, data: dict, meta: dict,
+                 trimmable: bool) -> None:
+        import mlx.core as mx
+
+        digest = _digest(mk, toks)
+        path = self._file(digest)
+        t0 = time.time()
+        try:
+            mx.save_safetensors(str(path), data, meta)
+        except Exception as e:
+            try:
+                path.unlink()
+            except OSError:
+                pass
+            with self._lock:
+                self._pending.pop(digest, None)
+            self.log.write(f"[disk-cache] save failed: {e}\n")
+            return
+
+        nbytes = path.stat().st_size
+        now = time.time()
+        n = int(toks.size)
+        with self._lock:
+            self._pending.pop(digest, None)
+            self._entries[digest] = _Entry(
+                digest=digest, model_key=mk, tokens=toks, nbytes=nbytes,
+                trimmable=trimmable, created=now, last_used=now,
+            )
+            if trimmable:
+                # A trimmable checkpoint can always be cut back, so shorter
+                # strict-prefix checkpoints of the same lineage are redundant
+                # (mirrors the in-memory trie's pop_prefixes).
+                for e in list(self._entries.values()):
+                    if e.digest == digest or e.model_key != mk:
+                        continue
+                    if e.tokens.size < n and _lcp(e.tokens, toks) == e.tokens.size:
+                        self._remove_entry(e.digest)
+            self._evict_over_budget(protect=digest)
+            self._save_index()
+        self.log.write(
+            f"[disk-cache] saved {n}-token checkpoint "
+            f"({nbytes / (1 << 20):.0f} MB in {time.time() - t0:.1f}s)\n"
+        )
+
+    def flush(self) -> None:
+        """Wait for queued checkpoint writes to hit disk (the shutdown save)."""
+        if self._queue is not None:
+            self._queue.join()
+
+    # -- restore path -------------------------------------------------------
+
+    def restore_into(self, lru, model: Any, tokens: List[int],
+                     reused: int) -> bool:
+        """Load the best on-disk checkpoint into ``lru`` if it beats ``reused``.
+
+        Returns True when a checkpoint was inserted (caller should re-run the
+        LRU fetch to pick it up).
+        """
+        toks = np.asarray(tokens, dtype=np.int64)
+        n = int(toks.size)
+        mk = _model_key_str(model)
+        with self._lock:
+            best = None
+            best_usable = reused + _MIN_GAIN_TOKENS
+            for e in self._entries.values():
+                if e.model_key != mk:
+                    continue
+                lcp = _lcp(e.tokens, toks)
+                if lcp == e.tokens.size:
+                    usable = lcp  # checkpoint is a (weak) prefix of the request
+                elif e.trimmable:
+                    usable = min(lcp, n - 1)  # divergent/longer: trim after load
+                else:
+                    continue
+                if usable >= best_usable:
+                    best, best_usable = e, usable
+            if best is None:
+                return False
+            path = self._file(best.digest)
+
+        t0 = time.time()
+        try:
+            cache, _meta = load_cache_file(path)
+        except Exception as e:
+            self.log.write(
+                f"[disk-cache] checkpoint unreadable ({e}); dropping it\n"
+            )
+            with self._lock:
+                self._remove_entry(best.digest)
+                self._save_index()
+            return False
+
+        with self._lock:
+            if best.digest in self._entries:
+                self._entries[best.digest].last_used = time.time()
+                self._save_index()
+        lru.insert_cache(model, best.tokens.tolist(), cache)
+        self.log.write(
+            f"[disk-cache] restored {best.tokens.size}-token checkpoint "
+            f"({best.nbytes / (1 << 20):.0f} MB in {time.time() - t0:.1f}s) — "
+            f"prefill resumes from token {best_usable}/{n}\n"
+        )
+        return True
+
+    # -- server integration ---------------------------------------------------
+
+    def install(self) -> "DiskPromptCache":
+        """Wrap ``LRUPromptCache`` so all servers persist through this store."""
+        from mlx_lm.models.cache import LRUPromptCache
+
+        store = self
+        self._orig_fetch = LRUPromptCache.fetch_nearest_cache
+        self._orig_insert = LRUPromptCache.insert_cache
+
+        def fetch_nearest_cache(lru, model, tokens):
+            cache, rest = store._orig_fetch(lru, model, tokens)
+            try:
+                reused = len(tokens) - len(rest)
+                if store.restore_into(lru, model, tokens, reused):
+                    cache, rest = store._orig_fetch(lru, model, tokens)
+            except Exception as e:  # persistence must never break serving
+                store.log.write(f"[disk-cache] restore skipped: {e}\n")
+            return cache, rest
+
+        def insert_cache(lru, model, tokens, prompt_cache, **kwargs):
+            store._orig_insert(lru, model, tokens, prompt_cache, **kwargs)
+            try:
+                store.maybe_save(model, tokens, prompt_cache)
+            except Exception as e:
+                store.log.write(f"[disk-cache] save skipped: {e}\n")
+
+        LRUPromptCache.fetch_nearest_cache = fetch_nearest_cache
+        LRUPromptCache.insert_cache = insert_cache
+        atexit.register(self.flush)
+        return self
+
+    def uninstall(self) -> None:
+        from mlx_lm.models.cache import LRUPromptCache
+
+        if self._orig_fetch is not None:
+            LRUPromptCache.fetch_nearest_cache = self._orig_fetch
+        if self._orig_insert is not None:
+            LRUPromptCache.insert_cache = self._orig_insert
+        self._orig_fetch = None
+        self._orig_insert = None
+
+
+def install(cache_dir, budget_gb: float = 10.0, min_tokens: int = 512,
+            save_every: int = 1024, log: TextIO = sys.stderr) -> DiskPromptCache:
+    """Create a ``DiskPromptCache`` and patch it into ``mlx_lm.server``."""
+    store = DiskPromptCache(
+        cache_dir, budget_gb=budget_gb, min_tokens=min_tokens,
+        save_every=save_every, log=log,
+    )
+    return store.install()

--- a/disk_prompt_cache.py
+++ b/disk_prompt_cache.py
@@ -287,6 +287,7 @@ class DiskPromptCache:
                 if self._file(entry.digest).exists():
                     entries[entry.digest] = entry
         except FileNotFoundError:
+            # Expected on first run (no index written yet): start empty.
             pass
         except Exception as e:
             self.log.write(
@@ -299,8 +300,10 @@ class DiskPromptCache:
             if f.stem not in self._entries:
                 try:
                     f.unlink()
-                except OSError:
-                    pass
+                except OSError as e:
+                    self.log.write(
+                        f"[disk-cache] failed to remove stale file {f}: {e}\n"
+                    )
 
     def _save_index(self) -> None:
         # Called with self._lock held. Atomic via tmp + rename.
@@ -317,9 +320,11 @@ class DiskPromptCache:
         # Called with self._lock held.
         self._entries.pop(digest, None)
         try:
-            self._file(digest).unlink()
-        except OSError:
-            pass
+            self._file(digest).unlink(missing_ok=True)
+        except OSError as e:
+            self.log.write(
+                f"[disk-cache] failed to remove checkpoint {digest}: {e}\n"
+            )
 
     def _evict_over_budget(self, protect: str) -> None:
         # Called with self._lock held.
@@ -435,9 +440,11 @@ class DiskPromptCache:
             mx.save_safetensors(str(path), data, meta)
         except Exception as e:
             try:
-                path.unlink()
-            except OSError:
-                pass
+                path.unlink(missing_ok=True)
+            except OSError as unlink_err:
+                self.log.write(
+                    f"[disk-cache] cleanup failed for {path}: {unlink_err}\n"
+                )
             with self._lock:
                 self._pending.pop(digest, None)
             self.log.write(f"[disk-cache] save failed: {e}\n")
@@ -533,6 +540,11 @@ class DiskPromptCache:
     def install(self) -> "DiskPromptCache":
         """Wrap ``LRUPromptCache`` so all servers persist through this store."""
         from mlx_lm.models.cache import LRUPromptCache
+
+        if self._orig_fetch is not None:
+            # Already installed: re-wrapping would capture our own wrappers
+            # as the "originals" and make uninstall leave a permanent patch.
+            return self
 
         store = self
         self._orig_fetch = LRUPromptCache.fetch_nearest_cache

--- a/layers/polar_kv_cache.py
+++ b/layers/polar_kv_cache.py
@@ -406,17 +406,30 @@ class TurboQuantKVCache:
     def state(self, v):
         if not v:
             return
+
+        def _norm(x):
+            # A deserialized state (mlx tree_unflatten) hands back lists in
+            # place of tuples and may use zero-size arrays for absent tiers.
+            if x is None:
+                return None
+            if isinstance(x, (list, tuple)):
+                return tuple(x)
+            if isinstance(x, mx.array) and x.size == 0:
+                return None
+            return x
+
         # 2-tuple legacy form: (tq_keys, tq_values)
         if len(v) == 2:
-            self._tq_keys, self._tq_values = v
+            self._tq_keys = _norm(v[0])
+            self._tq_values = _norm(v[1])
             return
         # 4-tuple form: (tq_keys, tq_values, fp16_keys, fp16_values)
         if len(v) == 4:
             tq_k, tq_v, fp_k, fp_v = v
-            self._tq_keys = tq_k
-            self._tq_values = tq_v
-            self._fp16_keys = fp_k
-            self._fp16_values = fp_v
+            self._tq_keys = _norm(tq_k)
+            self._tq_values = _norm(tq_v)
+            self._fp16_keys = _norm(fp_k)
+            self._fp16_values = _norm(fp_v)
             return
         raise ValueError(
             f"Unexpected state length {len(v)}; expected 2 or 4."
@@ -460,6 +473,48 @@ class TurboQuantKVCache:
             raise ValueError(
                 f"Unexpected meta_state length {len(v)}; expected 4, 5, or 6."
             )
+
+    @classmethod
+    def from_state(cls, state, meta_state):
+        """Recreate a cache from ``(state, meta_state)``.
+
+        This is the ``mlx_lm.models.cache`` deserialization protocol, used by
+        the turboquant-serve disk prompt cache. Constructor params come from
+        ``meta_state`` (any of the 4/5/6-tuple forms the setter accepts).
+        """
+        v = list(meta_state)
+        if len(v) == 4:
+            k_bits = v_bits = int(v[1])
+            group_size, seed, min_tok = int(v[2]), int(v[3]), 0
+        elif len(v) in (5, 6):
+            k_bits, v_bits = int(v[1]), int(v[2])
+            group_size, seed = int(v[3]), int(v[4])
+            min_tok = int(v[5]) if len(v) == 6 else 0
+        else:
+            raise ValueError(
+                f"Unexpected meta_state length {len(v)}; expected 4, 5, or 6."
+            )
+        obj = cls(
+            k_bits=k_bits,
+            v_bits=v_bits,
+            group_size=group_size,
+            seed=seed,
+            min_tokens_before_quant=min_tok,
+        )
+        obj.state = state
+        obj.offset = int(v[0])
+        # The serialized fp16 tier is trimmed to the tokens it holds, but the
+        # update path slice-assigns into a buffer preallocated at the full
+        # threshold width — re-pad it so later appends fit.
+        if obj._fp16_keys is not None:
+            held = obj._fp16_keys.shape[-2]
+            if held < min_tok:
+                pad = [(0, 0)] * (obj._fp16_keys.ndim - 2) + [
+                    (0, min_tok - held), (0, 0)
+                ]
+                obj._fp16_keys = mx.pad(obj._fp16_keys, pad)
+                obj._fp16_values = mx.pad(obj._fp16_values, pad)
+        return obj
 
     def is_trimmable(self):
         return True

--- a/serve.py
+++ b/serve.py
@@ -57,6 +57,29 @@ Usage:
     # Code) — mirror prefill keepalives as real SSE data chunks:
     turboquant-serve --model manjunathshiva/qwen3.5-122b-tq3 \
         --cache-budget-gb 4 --prefill-keepalive --prompt-concurrency 1
+    # Persist the prompt cache to disk so a restarted server resumes a long
+    # agentic conversation instead of re-prefilling it from scratch:
+    turboquant-serve --model manjunathshiva/qwen3.5-122b-tq3 \
+        --cache-budget-gb 4 --disk-cache --prompt-concurrency 1
+
+Disk prompt cache (cold prefill survives restarts)
+--------------------------------------------------
+``--disk-cache [DIR]`` makes the prompt-prefix cache persistent: after each
+completed request the KV cache is checkpointed to DIR (default: a per-model
+directory under ``~/.cache/turboquant/prompt-cache``), and any later request
+— including the first one after a server restart — resumes from the longest
+saved token prefix instead of re-prefilling from scratch. On a 16 GB mini
+serving a streaming 122B, that turns the ~13-minute cold 22K-token re-prefill
+after a restart into a checkpoint load plus a short suffix prefill. Matching
+is token-level longest-common-prefix (same semantics as the in-memory cache),
+writes happen on a background thread, and the store is trimmed to
+``--disk-cache-budget-gb`` (default 10) by least-recently-used eviction.
+``--disk-cache-min-tokens`` (default 512) skips checkpointing short prompts;
+``--disk-cache-save-every`` (default 1024) throttles how often a growing
+conversation is re-checkpointed — a restart loses at most that much prefill.
+Works with ``--kv-bits``/``--kv-k-bits`` (TurboQuant KV caches serialize) and
+with hybrid-attention models (non-trimmable GDN/Mamba states restore from
+strict-prefix checkpoints). Single server process per cache directory.
 
 Prefill keepalive (long cold prefills behind a proxy)
 -----------------------------------------------------
@@ -294,6 +317,60 @@ def _extract_prefill_stats_args(argv):
     return dict(stats_file=ns.prefill_stats_file), remaining
 
 
+def _extract_disk_cache_args(argv):
+    """Peel the disk prompt-cache flags off ``argv``.
+
+    ``--disk-cache [DIR]`` persists prompt-cache checkpoints to disk and
+    restores them across server restarts (and in-memory evictions), so a
+    restarted server resumes a long conversation with a file load plus a
+    short suffix prefill instead of a full cold prefill. DIR defaults to a
+    per-model directory under ``~/.cache/turboquant/prompt-cache``.
+    Returns ``(config | None, remaining_argv)``.
+    """
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--disk-cache", dest="disk_cache", nargs="?",
+                        const="auto", default=None)
+    parser.add_argument("--disk-cache-budget-gb", dest="budget_gb",
+                        type=float, default=10.0)
+    parser.add_argument("--disk-cache-min-tokens", dest="min_tokens",
+                        type=int, default=512)
+    parser.add_argument("--disk-cache-save-every", dest="save_every",
+                        type=int, default=1024)
+    ns, remaining = parser.parse_known_args(argv)
+
+    if ns.disk_cache is None:
+        return None, remaining
+
+    cache_dir = ns.disk_cache
+    if cache_dir == "auto":
+        import hashlib
+        from pathlib import Path
+
+        # The model arg stays in `remaining` for mlx_lm.server; peek at it
+        # to build a stable per-model default directory.
+        model = "default"
+        for i, a in enumerate(remaining):
+            if a == "--model" and i + 1 < len(remaining):
+                model = remaining[i + 1]
+                break
+            if a.startswith("--model="):
+                model = a.split("=", 1)[1]
+                break
+        tag = hashlib.sha256(model.encode()).hexdigest()[:8]
+        name = model.rstrip("/").rsplit("/", 1)[-1] or "default"
+        cache_dir = str(
+            Path("~/.cache/turboquant/prompt-cache").expanduser()
+            / f"{name}-{tag}"
+        )
+
+    return dict(
+        cache_dir=cache_dir,
+        budget_gb=ns.budget_gb,
+        min_tokens=ns.min_tokens,
+        save_every=ns.save_every,
+    ), remaining
+
+
 def _extract_prefill_keepalive_args(argv):
     """Peel the prefill-keepalive flags off ``argv``.
 
@@ -506,11 +583,17 @@ def main() -> None:
     prefill_stats_config, remaining = _extract_prefill_stats_args(remaining)
     prefill_keepalive_config, remaining = _extract_prefill_keepalive_args(remaining)
     rep_config, remaining = _extract_rep_penalty_args(remaining)
+    disk_cache_config, remaining = _extract_disk_cache_args(remaining)
     _patch_loader(stream_config)
     if rep_config is not None:
         _patch_default_rep_penalty(rep_config)
     if kv_config is not None:
         _patch_kv_cache(kv_config)
+    if disk_cache_config is not None:
+        # Install before prefill-stats so the stats wrapper (which patches
+        # last, hence runs first) records reuse *including* disk restores.
+        from turboquant_mlx.disk_prompt_cache import install as _install_disk_cache
+        _install_disk_cache(**disk_cache_config)
     if prefill_stats_config is not None:
         from turboquant_mlx.prefill_stats import install as _install_prefill_stats
         _install_prefill_stats(**prefill_stats_config)
@@ -544,6 +627,16 @@ def main() -> None:
             f"group={kv_config['group_size']}, "
             f"sink={kv_config['min_tokens_before_quant']} "
             "(forces single-stream serving)\n"
+        )
+    if disk_cache_config is not None:
+        sys.stderr.write(
+            f"[turboquant-serve] Disk prompt cache: ON "
+            f"(dir={disk_cache_config['cache_dir']}, "
+            f"budget={disk_cache_config['budget_gb']:g} GB, "
+            f"min_tokens={disk_cache_config['min_tokens']}, "
+            f"save_every={disk_cache_config['save_every']}) — prompt-cache "
+            "checkpoints persist across restarts; cold prefill resumes from "
+            "the longest saved prefix.\n"
         )
     if prefill_stats_config is not None:
         dest = prefill_stats_config["stats_file"] or "stderr only"

--- a/tests/test_disk_prompt_cache.py
+++ b/tests/test_disk_prompt_cache.py
@@ -1,0 +1,374 @@
+"""Tests for the disk-persistent prompt cache (turboquant-serve --disk-cache).
+
+Covers:
+1. Checkpoint file round-trip for every cache family we serve: standard
+   ``KVCache``, non-trimmable ``ArraysCache`` (hybrid GDN/Mamba state), and
+   ``TurboQuantKVCache`` (both with and without the fp16 sink tier, whose
+   absent tensors are None inside ``state``).
+2. ``TurboQuantKVCache.from_state`` — meta_state forms and post-restore
+   updates (fp16 tier re-padded to the threshold width).
+3. Store save policy: min-tokens gate, save-every stride along a lineage,
+   strict-prefix supersede for trimmable checkpoints (and NOT for
+   non-trimmable ones), LRU byte-budget eviction protecting the newest write.
+4. The restore path through a patched ``LRUPromptCache``: a fresh cache
+   instance (simulated server restart) resumes from the on-disk checkpoint —
+   strict-prefix extension for any cache type, trim-back reuse only for
+   trimmable caches, and no restore when the win is below the gain floor.
+"""
+
+import json
+
+import mlx.core as mx
+import pytest
+
+from mlx_lm.models.cache import ArraysCache, KVCache, LRUPromptCache
+
+from turboquant_mlx.disk_prompt_cache import (
+    _MIN_GAIN_TOKENS,
+    DiskPromptCache,
+    load_cache_file,
+    save_cache_file,
+)
+from turboquant_mlx.layers.polar_kv_cache import TurboQuantKVCache
+
+MODEL_KEY = ("model-a", None, None)
+
+
+def _kv_cache(n_tokens, dim=4):
+    c = KVCache()
+    c.update_and_fetch(
+        mx.random.normal((1, 1, n_tokens, dim)),
+        mx.random.normal((1, 1, n_tokens, dim)),
+    )
+    return c
+
+
+def _arrays_cache():
+    c = ArraysCache(2)
+    c[0] = mx.random.normal((1, 4))
+    c[1] = mx.random.normal((1, 3, 5))
+    return c
+
+
+def _tq_cache(n_tokens=16, min_tok=0):
+    c = TurboQuantKVCache(k_bits=8, v_bits=3,
+                          min_tokens_before_quant=min_tok)
+    c.update_and_fetch(
+        mx.random.normal((1, 2, n_tokens, 64)),
+        mx.random.normal((1, 2, n_tokens, 64)),
+    )
+    return c
+
+
+# ---------------------------------------------------------------------------
+# 1+2. Checkpoint file round-trip
+# ---------------------------------------------------------------------------
+
+def test_round_trip_standard_and_tq(tmp_path):
+    kv = _kv_cache(10)
+    arr = _arrays_cache()
+    tq_sink = _tq_cache(min_tok=4)   # fp16 tier present
+    tq_flat = _tq_cache(min_tok=0)   # fp16 tier None inside state
+
+    path = tmp_path / "ckpt.safetensors"
+    save_cache_file(path, [kv, tq_sink, tq_flat, arr], {"tokens": "[1,2]"})
+    loaded, meta = load_cache_file(path)
+    lkv, ltq_sink, ltq_flat, larr = loaded
+
+    assert meta["tokens"] == "[1,2]"
+    assert [type(c).__name__ for c in loaded] == [
+        "KVCache", "TurboQuantKVCache", "TurboQuantKVCache", "ArraysCache"
+    ]
+
+    assert lkv.offset == kv.offset
+    assert mx.allclose(lkv.state[0], kv.state[0]).item()
+    assert all(
+        mx.allclose(x, y).item() for x, y in zip(larr.state, arr.state)
+    )
+
+    # TQ with sink tier: params, offset, packed payload, and the fp16 tier
+    # re-padded to the full threshold width for later slice-assign appends.
+    assert ltq_sink.offset == tq_sink.offset == 16
+    assert ltq_sink._k_bits == 8 and ltq_sink._v_bits == 3
+    assert ltq_sink._fp16_keys.shape[-2] == 4
+    b_total = tq_sink.offset - 4
+    assert mx.array_equal(
+        ltq_sink._tq_keys[0], tq_sink._tq_keys[0][..., :b_total, :]
+    ).item()
+    assert mx.array_equal(
+        ltq_sink._tq_values[1], tq_sink._tq_values[1][..., :b_total, :]
+    ).item()
+
+    # TQ without sink tier: absent fp16 tensors restore to None.
+    assert ltq_flat._fp16_keys is None and ltq_flat._fp16_values is None
+    assert mx.array_equal(
+        ltq_flat._tq_keys[0], tq_flat._tq_keys[0][..., :16, :]
+    ).item()
+
+    # All restored caches must keep working (capacity/expansion paths).
+    lkv.update_and_fetch(
+        mx.random.normal((1, 1, 6, 4)), mx.random.normal((1, 1, 6, 4))
+    )
+    ltq_sink.update_and_fetch(
+        mx.random.normal((1, 2, 8, 64)), mx.random.normal((1, 2, 8, 64))
+    )
+    assert lkv.offset == 16 and ltq_sink.offset == 24
+
+
+def test_tq_from_state_meta_forms():
+    tq = _tq_cache(min_tok=4)
+    state = tq.state
+
+    # 6-tuple (current)
+    c6 = TurboQuantKVCache.from_state(state, tq.meta_state)
+    assert (c6.offset, c6._k_bits, c6._v_bits,
+            c6._min_tokens_before_quant) == (16, 8, 3, 4)
+
+    # 5-tuple (item-#1 era, no threshold)
+    c5 = TurboQuantKVCache.from_state(state, ("16", "8", "3", "64", "42"))
+    assert c5._min_tokens_before_quant == 0
+
+    # 4-tuple (legacy uniform bits)
+    c4 = TurboQuantKVCache.from_state(state, ("16", "3", "64", "42"))
+    assert c4._k_bits == c4._v_bits == 3
+
+    with pytest.raises(ValueError):
+        TurboQuantKVCache.from_state(state, ("1", "2"))
+
+
+# ---------------------------------------------------------------------------
+# 3. Save policy
+# ---------------------------------------------------------------------------
+
+def _store(tmp_path, **kw):
+    kw.setdefault("min_tokens", 4)
+    kw.setdefault("save_every", 100)
+    kw.setdefault("sync", True)
+    return DiskPromptCache(tmp_path, **kw)
+
+
+def test_min_tokens_gate(tmp_path):
+    store = _store(tmp_path, min_tokens=512)
+    store.maybe_save(MODEL_KEY, list(range(100)), [_kv_cache(100)])
+    assert len(store) == 0
+
+
+def test_save_and_covered_skip(tmp_path):
+    store = _store(tmp_path)
+    tokens = list(range(600))
+    store.maybe_save(MODEL_KEY, tokens, [_kv_cache(600)])
+    assert len(store) == 1
+    assert len(list(tmp_path.glob("*.safetensors"))) == 1
+
+    # Same tokens again, and a strict prefix of the stored tokens: covered.
+    store.maybe_save(MODEL_KEY, tokens, [_kv_cache(600)])
+    store.maybe_save(MODEL_KEY, tokens[:400], [_kv_cache(400)])
+    assert len(store) == 1
+
+
+def test_stride_throttle_and_prefix_supersede(tmp_path):
+    store = _store(tmp_path, save_every=100)
+    tokens = list(range(600))
+    store.maybe_save(MODEL_KEY, tokens, [_kv_cache(600)])
+
+    # Extending the lineage by < save_every is throttled.
+    store.maybe_save(MODEL_KEY, tokens + [7] * 50, [_kv_cache(650)])
+    assert len(store) == 1
+
+    # Extending by >= save_every writes, and the new trimmable checkpoint
+    # supersedes its stored strict prefix.
+    longer = tokens + [7] * 150
+    store.maybe_save(MODEL_KEY, longer, [_kv_cache(750)])
+    assert len(store) == 1
+    files = list(tmp_path.glob("*.safetensors"))
+    assert len(files) == 1
+    loaded, meta = load_cache_file(files[0])
+    assert json.loads(meta["tokens"]) == longer
+
+
+def test_non_trimmable_keeps_prefixes(tmp_path):
+    store = _store(tmp_path, save_every=100)
+    tokens = list(range(600))
+    store.maybe_save(MODEL_KEY, tokens, [_arrays_cache()])
+    store.maybe_save(MODEL_KEY, tokens + [7] * 150, [_arrays_cache()])
+    # A non-trimmable checkpoint can't be cut back, so the shorter prefix
+    # stays as divergence insurance.
+    assert len(store) == 2
+
+
+def test_budget_eviction_protects_newest(tmp_path):
+    store = _store(tmp_path, budget_gb=1e-6)  # ~1 KB: everything over budget
+    a = list(range(600))
+    b = [9] + list(range(599))  # different lineage
+    store.maybe_save(MODEL_KEY, a, [_kv_cache(600)])
+    store.maybe_save(MODEL_KEY, b, [_kv_cache(600)])
+    # Both checkpoints exceed the budget; the older one is evicted, the
+    # just-written one is protected.
+    assert len(store) == 1
+    files = list(tmp_path.glob("*.safetensors"))
+    assert len(files) == 1
+    _, meta = load_cache_file(files[0])
+    assert json.loads(meta["tokens"]) == b
+
+
+def test_background_writer_and_index_reload(tmp_path):
+    # Async mode: payload is evaluated on the caller's thread (MLX graphs
+    # can't be evaluated cross-thread), the writer thread only does file I/O.
+    store = DiskPromptCache(tmp_path, min_tokens=4, sync=False)
+    store.maybe_save(MODEL_KEY, list(range(600)), [_kv_cache(600)])
+    store.flush()
+    assert len(store) == 1
+
+    # A new store on the same directory (simulated restart) sees the entry.
+    store2 = _store(tmp_path)
+    assert len(store2) == 1
+
+
+def test_pending_saves_throttle_rapid_inserts(tmp_path):
+    # The server checkpoints each prompt segment back-to-back; while the
+    # first write is still queued the stride throttle must already see it,
+    # or near-duplicate multi-GB files get written one token apart.
+    import time as _time
+
+    store = DiskPromptCache(tmp_path, min_tokens=4, save_every=100,
+                            sync=False)
+    orig_do_save = store._do_save
+
+    def slow_do_save(*args):
+        _time.sleep(0.3)
+        orig_do_save(*args)
+
+    store._do_save = slow_do_save
+    tokens = list(range(600))
+    store.maybe_save(MODEL_KEY, tokens, [_kv_cache(600)])
+    store.maybe_save(MODEL_KEY, tokens + [7], [_kv_cache(601)])
+    store.flush()
+    assert len(store) == 1
+
+
+def test_corrupt_index_starts_empty_and_prunes_orphans(tmp_path):
+    (tmp_path / "index.json").write_text("{not json", encoding="utf-8")
+    (tmp_path / "deadbeef.safetensors").write_bytes(b"orphan")
+    store = _store(tmp_path)
+    assert len(store) == 0
+    assert not (tmp_path / "deadbeef.safetensors").exists()
+
+
+# ---------------------------------------------------------------------------
+# 4. Restore through a patched LRUPromptCache (simulated server restart)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def installed_store(tmp_path):
+    store = _store(tmp_path)
+    store.install()
+    try:
+        yield store
+    finally:
+        store.uninstall()
+
+
+def test_restart_restores_strict_prefix(installed_store):
+    tokens = list(range(600))
+    lru1 = LRUPromptCache(max_size=10)
+    lru1.insert_cache(MODEL_KEY, tokens, [_kv_cache(600)])
+    assert len(installed_store) == 1  # insert mirrored to disk
+
+    # "Restart": a fresh in-memory cache knows nothing...
+    lru2 = LRUPromptCache(max_size=10)
+    suffix = [7] * 20
+    cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, tokens + suffix)
+    # ...but the disk checkpoint supplies the 600-token prefix.
+    assert cache is not None
+    assert rest == suffix
+    assert cache[0].offset == 600
+
+
+def test_restart_restores_non_trimmable_strict_prefix(installed_store):
+    tokens = list(range(600))
+    lru1 = LRUPromptCache(max_size=10)
+    lru1.insert_cache(MODEL_KEY, tokens, [_arrays_cache()])
+
+    lru2 = LRUPromptCache(max_size=10)
+    cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, tokens + [7] * 20)
+    assert cache is not None
+    assert rest == [7] * 20
+
+
+def test_divergent_checkpoint_trims_only_if_trimmable(installed_store):
+    stored = list(range(600)) + [1, 2, 3]
+    request = list(range(600)) + [8, 8, 8, 8]
+
+    # Trimmable: the divergent checkpoint is loaded and trimmed back.
+    lru1 = LRUPromptCache(max_size=10)
+    lru1.insert_cache(MODEL_KEY, stored, [_kv_cache(603)])
+    lru2 = LRUPromptCache(max_size=10)
+    cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, request)
+    assert cache is not None
+    assert rest == request[600:]
+    assert cache[0].offset == 600
+
+
+def test_divergent_non_trimmable_not_restored(tmp_path):
+    store = _store(tmp_path)
+    store.install()
+    try:
+        stored = list(range(600)) + [1, 2, 3]
+        request = list(range(600)) + [8, 8, 8, 8]
+        lru1 = LRUPromptCache(max_size=10)
+        lru1.insert_cache(MODEL_KEY, stored, [_arrays_cache()])
+        lru2 = LRUPromptCache(max_size=10)
+        cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, request)
+        assert cache is None
+        assert rest == request
+    finally:
+        store.uninstall()
+
+
+def test_no_restore_below_gain_floor(installed_store):
+    tokens = list(range(_MIN_GAIN_TOKENS // 2))
+    # min_tokens=4 lets this checkpoint save, but restoring it can never win
+    # more than _MIN_GAIN_TOKENS//2 tokens.
+    lru1 = LRUPromptCache(max_size=10)
+    lru1.insert_cache(MODEL_KEY, tokens, [_kv_cache(len(tokens))])
+    assert len(installed_store) == 1
+
+    lru2 = LRUPromptCache(max_size=10)
+    cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, tokens + [7] * 10)
+    assert cache is None
+    assert rest == tokens + [7] * 10
+
+
+def test_other_model_key_not_restored(installed_store):
+    tokens = list(range(600))
+    lru1 = LRUPromptCache(max_size=10)
+    lru1.insert_cache(MODEL_KEY, tokens, [_kv_cache(600)])
+
+    lru2 = LRUPromptCache(max_size=10)
+    other = ("model-b", None, None)
+    cache, rest = lru2.fetch_nearest_cache(other, tokens + [7] * 20)
+    assert cache is None
+
+
+def test_uninstall_restores_originals(tmp_path):
+    orig_fetch = LRUPromptCache.fetch_nearest_cache
+    orig_insert = LRUPromptCache.insert_cache
+    store = _store(tmp_path)
+    store.install()
+    assert LRUPromptCache.fetch_nearest_cache is not orig_fetch
+    store.uninstall()
+    assert LRUPromptCache.fetch_nearest_cache is orig_fetch
+    assert LRUPromptCache.insert_cache is orig_insert
+
+
+def test_tq_kv_cache_restores_through_lru(installed_store):
+    tokens = list(range(600))
+    lru1 = LRUPromptCache(max_size=10)
+    lru1.insert_cache(MODEL_KEY, tokens, [_tq_cache(n_tokens=600, min_tok=4)])
+
+    lru2 = LRUPromptCache(max_size=10)
+    cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, tokens + [7] * 20)
+    assert cache is not None
+    assert rest == [7] * 20
+    assert isinstance(cache[0], TurboQuantKVCache)
+    assert cache[0].offset == 600

--- a/tests/test_disk_prompt_cache.py
+++ b/tests/test_disk_prompt_cache.py
@@ -355,6 +355,7 @@ def test_uninstall_restores_originals(tmp_path):
     orig_insert = LRUPromptCache.insert_cache
     store = _store(tmp_path)
     store.install()
+    store.install()  # double-install must not capture our own wrappers
     assert LRUPromptCache.fetch_nearest_cache is not orig_fetch
     store.uninstall()
     assert LRUPromptCache.fetch_nearest_cache is orig_fetch


### PR DESCRIPTION
## What

Makes the server's prompt-prefix cache a **disk citizen**: every completed request's KV cache is checkpointed to a cache directory, and on a prompt-cache miss — most importantly the first request after a server restart — the best on-disk checkpoint is loaded back and only the token suffix is prefilled.

Inspired by DwarfStar's "the KV cache is a first-class disk citizen", adapted to mlx_lm's token-level prompt trie: matching is token-level longest-common-prefix (no byte/retokenization keying problems, no stored logits needed). Strict-prefix checkpoints extend **any** cache type (including non-trimmable GDN/Mamba states on hybrid models); longer/divergent checkpoints are used only for trimmable caches and trimmed back after load.

## Usage

```bash
turboquant-serve --model manjunathshiva/qwen3.5-122b-tq3 \
    --cache-budget-gb 4 --disk-cache --prompt-concurrency 1
```

- `--disk-cache [DIR]` — enable; DIR defaults to a per-model directory under `~/.cache/turboquant/prompt-cache`
- `--disk-cache-budget-gb` (10) — LRU byte-budget eviction
- `--disk-cache-min-tokens` (512) — never checkpoint short prompts
- `--disk-cache-save-every` (1024) — per-lineage re-checkpoint stride; a restart loses at most this much prefill

## How

- `disk_prompt_cache.py` wraps `LRUPromptCache.fetch_nearest_cache` / `insert_cache` (same pattern as prefill-stats). Checkpoints are `save_prompt_cache`-compatible safetensors plus an `index.json` with token lists.
- Save policy: min-tokens gate; save-every stride along a conversation lineage (aware of enqueued-but-unwritten saves — the server checkpoints prompt segments back-to-back, and without that the throttle races and writes near-duplicate multi-GB files); trimmable checkpoints supersede stored strict prefixes (mirrors the trie's `pop_prefixes`); LRU eviction to budget.
- Writes run on a background thread; the payload is extracted and `mx.eval`'d on the generation thread because MLX graphs cannot be evaluated cross-thread. Flush at exit.
- `TurboQuantKVCache` gains `from_state` (plus state-setter normalization and fp16-sink re-padding), so `--kv-bits` / `--kv-k-bits` caches persist too. `None` state leaves (absent fp16 tier) are stored as placeholders whose key paths are recorded in metadata.

## Measured

64 GB M4, Qwen3.6-35B-A3B-tq3-g32 (hybrid GDN → exercises the non-trimmable strict-prefix path), 16.3K-token conversation, next turn after a restart:

| Scenario | Turn latency |
|---|---|
| Server stayed up (in-memory) | 1.0 s |
| **Restart + `--disk-cache`** | **3.0 s** |
| Restart, no checkpoint | 21.1 s |

**6.9x** faster restart turn; 99.9% of the prompt served from the 700 MB checkpoint (22 tokens freshly prefilled); greedy output **byte-identical** to the never-restarted server. On a 16 GB mini streaming a 122B, the no-checkpoint column is ~13 minutes for a 22K-token conversation, so the multiplier there is far larger.

## Tests

17 new tests in `tests/test_disk_prompt_cache.py` (checkpoint round-trip for KVCache / ArraysCache / TurboQuantKVCache, save policy incl. the pending-save race regression, restart-restore through a patched `LRUPromptCache`, trim-vs-non-trimmable semantics, corrupt-index recovery). Full suite: **173 passed**.

## Notes

- Single server process per cache directory (documented).
- Restore only triggers when the disk checkpoint wins ≥256 tokens over what the in-memory cache already covers.
- No release with this PR: the PyPI tag waits until the remaining DwarfStar-inspired ideas are tested.