### PR TITLE
feat: asymmetric expert precision (--expert-down-bits) — ternary up/gate + higher-bit down_proj

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Asymmetric expert precision** (`convert --expert-down-bits {2,3,4}`):
+  quantize MoE expert down-projections at a higher-precision Gaussian
+  codebook while up/gate take the `--mlp-bits` / `--ternary-experts` tier —
+  the down projection is the SwiGLU summation bottleneck, and llama.cpp-family
+  2-bit mixes (up/gate IQ2_XXS, down Q2_K) rely on exactly this asymmetry.
+  Applies only to MoE SwitchLinear experts (dense MLPs are untouched); the
+  loader needs no matching rule because per-layer bits are self-describing
+  via the on-disk codebook length. Works with both the in-memory and
+  `--streaming` converters.
+
+### Added
+
 - **Disk-persistent prompt cache on `turboquant-serve`** (`--disk-cache
   [DIR]`, plus `--disk-cache-budget-gb` / `--disk-cache-min-tokens` /
   `--disk-cache-save-every`): each completed request's KV cache is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,10 +16,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Applies only to MoE SwitchLinear experts (dense MLPs are untouched); the
   loader needs no matching rule because per-layer bits are self-describing
   via the on-disk codebook length. Works with both the in-memory and
-  `--streaming` converters.
-
-### Added
-
+  `--streaming` converters. Validated on Qwen3.6-35B-A3B: `--ternary-experts
+  --expert-down-bits 4` (11.7 GB, vs 9.4 GB pure ternary / 16.4 GB tq3) is
+  the first sub-2-bit-expert build to pass an agent-harness smoke test
+  (Opencode 3/3, matching the 3-bit control's trajectory and latency), where
+  pure ternary scores 0/4 and `--expert-down-bits 3` still fails on
+  multi-step error recovery.
 - **Disk-persistent prompt cache on `turboquant-serve`** (`--disk-cache
   [DIR]`, plus `--disk-cache-budget-gb` / `--disk-cache-min-tokens` /
   `--disk-cache-save-every`): each completed request's KV cache is

--- a/config.py
+++ b/config.py
@@ -43,6 +43,13 @@ class TurboQuantConfig:
     mlp_bits: Optional[int] = None
     mlp_group_size: Optional[int] = None  # block-scale override for the MLP/expert tier
     ternary_experts: bool = False  # ternary (1.58-bit) MoE experts, stored 2-bit
+    # Asymmetric expert precision (DwarfStar-style): keep the expert
+    # down-projections at a higher-precision Gaussian codebook while up/gate
+    # take the mlp_bits / ternary tier. The down projection is the summation
+    # bottleneck of the SwiGLU, and llama.cpp-family low-bit mixes (q2:
+    # up/gate IQ2_XXS, down Q2_K) rely on exactly this asymmetry. None
+    # disables. Applies only to MoE SwitchLinear experts, never dense MLPs.
+    expert_down_bits: Optional[int] = None
 
     def __post_init__(self):
         if self.bits not in (2, 3, 4):
@@ -62,6 +69,9 @@ class TurboQuantConfig:
             raise ValueError(f"rotation must be 'hadamard', 'blockwise_hadamard', or 'none', got {self.rotation}")
         if not isinstance(self.ternary_experts, bool):
             raise ValueError(f"ternary_experts must be a bool, got {self.ternary_experts!r}")
+        if self.expert_down_bits is not None and self.expert_down_bits not in (2, 3, 4):
+            raise ValueError(
+                f"expert_down_bits must be 2, 3, or 4, got {self.expert_down_bits}")
 
     def bits_for_path(self, path: str) -> int:
         """Resolve the bit-width for a layer based on its dotted path.
@@ -109,6 +119,7 @@ class TurboQuantConfig:
             "mlp_bits": self.mlp_bits,
             "mlp_group_size": self.mlp_group_size,
             "ternary_experts": self.ternary_experts,
+            "expert_down_bits": self.expert_down_bits,
         }
 
     @classmethod
@@ -124,6 +135,7 @@ class TurboQuantConfig:
             mlp_bits=d.get("mlp_bits", None),
             mlp_group_size=d.get("mlp_group_size", None),
             ternary_experts=d.get("ternary_experts", False),
+            expert_down_bits=d.get("expert_down_bits", None),
         )
 
     @property

--- a/convert.py
+++ b/convert.py
@@ -33,6 +33,7 @@ def convert(
     mlp_bits: int = None,
     mlp_group_size: int = None,
     ternary_experts: bool = False,
+    expert_down_bits: int = None,
 ):
     """Convert a HuggingFace model to TurboQuant-compressed MLX format.
 
@@ -70,6 +71,7 @@ def convert(
         mlp_bits=mlp_bits,
         mlp_group_size=mlp_group_size,
         ternary_experts=ternary_experts,
+        expert_down_bits=expert_down_bits,
     )
 
     # Load model
@@ -199,6 +201,15 @@ def configure_parser() -> argparse.ArgumentParser:
              "Attention stays at --attn-bits/--bits.",
     )
     parser.add_argument(
+        "--expert-down-bits",
+        type=int, default=None, choices=[2, 3, 4],
+        help="Asymmetric expert precision: quantize MoE expert down "
+             "projections at this Gaussian-codebook width while up/gate take "
+             "the --mlp-bits / --ternary-experts tier. The down projection is "
+             "the SwiGLU summation bottleneck; llama.cpp-family 2-bit mixes "
+             "keep it above up/gate for exactly this reason.",
+    )
+    parser.add_argument(
         "--streaming",
         action="store_true",
         help="Memory-bounded conversion: write each quantized layer to a shard "
@@ -229,6 +240,7 @@ def main():
             mlp_bits=args.mlp_bits,
             mlp_group_size=args.mlp_group_size,
             ternary_experts=args.ternary_experts,
+            expert_down_bits=args.expert_down_bits,
         )
         return
     convert(
@@ -245,6 +257,7 @@ def main():
         mlp_bits=args.mlp_bits,
         mlp_group_size=args.mlp_group_size,
         ternary_experts=args.ternary_experts,
+        expert_down_bits=args.expert_down_bits,
     )
 
 

--- a/convert_streaming.py
+++ b/convert_streaming.py
@@ -117,6 +117,7 @@ def convert_streaming(
     mlp_bits: int = None,
     mlp_group_size: int = None,
     ternary_experts: bool = False,
+    expert_down_bits: int = None,
     max_file_size_gb: int = MAX_FILE_SIZE_GB,
 ):
     """Convert an HF model to TurboQuant MLX format with bounded peak memory.
@@ -137,6 +138,7 @@ def convert_streaming(
         rotation_seed=rotation_seed, fuse_rotations=fuse_rotations,
         use_qjl=use_qjl, attn_bits=attn_bits, mlp_bits=mlp_bits,
         mlp_group_size=mlp_group_size, ternary_experts=ternary_experts,
+        expert_down_bits=expert_down_bits,
     )
 
     print(f"[INFO] Loading model from {hf_path} (lazy)")

--- a/quantize_model.py
+++ b/quantize_model.py
@@ -210,6 +210,14 @@ def turboquant_quantize(
             # Ternary experts pack as base-3 trits (3-entry codebook, 20/uint32,
             # ~1.6 bpw); bits=2 is storage/scale semantics only.
             layer_bits = 2 if use_ternary else tq_config.bits_for_path(path)
+            if (tq_config.expert_down_bits is not None
+                    and path.split(".")[-1] == "down_proj"):
+                # Asymmetric expert precision: the down projection carries a
+                # higher-precision Gaussian codebook than the up/gate tier.
+                # The loader needs no matching rule — per-layer bits are
+                # self-describing via the on-disk codebook length.
+                use_ternary = False
+                layer_bits = tq_config.expert_down_bits
             label = "ternary" if use_ternary else f"{layer_bits}b"
             print(f"[INFO] Quantizing SwitchLinear {path} ({num_experts} experts, {input_dims}d, {label} g{expert_group_size})")
 

--- a/tests/test_asymmetric_experts.py
+++ b/tests/test_asymmetric_experts.py
@@ -1,0 +1,121 @@
+"""Tests for asymmetric expert precision (--expert-down-bits).
+
+DwarfStar-style expert mix: MoE up/gate projections take the mlp_bits /
+ternary tier while the down projections (the SwiGLU summation bottleneck)
+keep a higher-precision Gaussian codebook. The loader needs no matching
+rule because per-layer bits are self-describing via the on-disk codebook
+length — these tests pin both halves of that contract:
+
+1. Config: validation + round-trip through the config.json quantization dict.
+2. Converter: down_proj switch layers get a 2^bits codebook, up/gate get the
+   3-entry trit codebook (or their own tier when ternary is off), and dense
+   (non-expert) down_proj linears are untouched by the override.
+3. Loader agreement: rebuilding layers from the saved weights reproduces the
+   mixed tier (trit up/gate, codebook down) via codebook-length detection.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from mlx_lm.models.switch_layers import SwitchGLU
+
+from turboquant_mlx.config import TurboQuantConfig
+from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
+from turboquant_mlx.quantize_model import turboquant_quantize
+
+
+class TinyMoEBlock(nn.Module):
+    def __init__(self, dims=64, hidden=128, num_experts=4):
+        super().__init__()
+        self.switch_mlp = SwitchGLU(dims, hidden, num_experts)
+
+
+class TinyModel(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.mlp = TinyMoEBlock()
+        # A dense down_proj outside the expert tier must not be affected.
+        self.dense_mlp = nn.Module()
+        self.dense_mlp.down_proj = nn.Linear(64, 64, bias=False)
+
+
+def _quantize(**cfg_kwargs):
+    model = TinyModel()
+    mx.eval(model.parameters())
+    tq_config = TurboQuantConfig(group_size=32, mlp_group_size=32,
+                                 **cfg_kwargs)
+    model, config = turboquant_quantize(model, {"model_type": "test"},
+                                        tq_config)
+    return model, config, tq_config
+
+
+def test_config_validation_and_round_trip():
+    with pytest.raises(ValueError):
+        TurboQuantConfig(expert_down_bits=1)
+    with pytest.raises(ValueError):
+        TurboQuantConfig(expert_down_bits=8)
+
+    cfg = TurboQuantConfig(ternary_experts=True, expert_down_bits=3)
+    again = TurboQuantConfig.from_dict(cfg.to_dict())
+    assert again.expert_down_bits == 3
+    assert again.ternary_experts is True
+
+    # Absent key (models converted before this feature) -> disabled.
+    legacy = TurboQuantConfig.from_dict({"bits": 3})
+    assert legacy.expert_down_bits is None
+
+
+def test_ternary_up_gate_with_codebook_down():
+    model, _, _ = _quantize(ternary_experts=True, expert_down_bits=3)
+
+    gate = model.mlp.switch_mlp.gate_proj
+    up = model.mlp.switch_mlp.up_proj
+    down = model.mlp.switch_mlp.down_proj
+    for layer in (gate, up, down):
+        assert isinstance(layer, PolarQuantizedSwitchLinear)
+
+    # up/gate: ternary -> self-describing 3-entry codebook
+    assert gate.codebook.shape[-1] == 3
+    assert up.codebook.shape[-1] == 3
+    # down: 3-bit Gaussian codebook, not ternary
+    assert down.codebook.shape[-1] == 8
+
+    # dense (non-expert) down_proj is untouched by the expert override:
+    # quantized as a plain linear at the base width, never at expert_down_bits
+    dense = model.dense_mlp.down_proj
+    assert not isinstance(dense, PolarQuantizedSwitchLinear)
+
+
+def test_down_override_without_ternary():
+    model, _, _ = _quantize(bits=2, expert_down_bits=4)
+    assert model.mlp.switch_mlp.gate_proj.codebook.shape[-1] == 4   # 2-bit
+    assert model.mlp.switch_mlp.down_proj.codebook.shape[-1] == 16  # 4-bit
+
+
+def test_disabled_is_uniform():
+    model, _, _ = _quantize(ternary_experts=True)
+    for name in ("gate_proj", "up_proj", "down_proj"):
+        assert getattr(model.mlp.switch_mlp, name).codebook.shape[-1] == 3
+
+
+def test_loader_rebuilds_mixed_tier_from_codebook_length():
+    from mlx.utils import tree_flatten
+
+    model, _, tq_config = _quantize(ternary_experts=True, expert_down_bits=3)
+    weights = dict(tree_flatten(model.parameters()))
+
+    # Simulate a fresh load: a float model rebuilt into quantized layers
+    # purely from the saved weights (codebook length = the format marker).
+    from turboquant_mlx.generate import _prepare_polar_layers
+
+    fresh = TinyModel()
+    mx.eval(fresh.parameters())
+    fresh = _prepare_polar_layers(fresh, weights, tq_config)
+
+    gate = fresh.mlp.switch_mlp.gate_proj
+    down = fresh.mlp.switch_mlp.down_proj
+    assert isinstance(gate, PolarQuantizedSwitchLinear)
+    assert isinstance(down, PolarQuantizedSwitchLinear)
+    assert gate.trit and gate.bits == 2
+    assert not down.trit and down.bits == 3


### PR DESCRIPTION
## What

Adds `--expert-down-bits {2,3,4}` to both converters (`convert.py`, `convert_streaming.py`): MoE expert **down-projections** are quantized at a higher-precision Gaussian codebook while up/gate take the `--mlp-bits` / `--ternary-experts` tier. Dense MLPs, attention, and shared experts are untouched.

This is the llama.cpp-family low-bit mixing strategy (up/gate IQ2_XXS, down Q2_K) applied to TurboQuant's ternary tier: the down projection is the SwiGLU summation bottleneck and deserves the bit budget.

## Why the loader needs no changes

Per-layer bits are self-describing via the on-disk codebook length (3 entries → ternary trit decode, 2^b → b-bit bit-packed), so `_prepare_polar_layers` already reconstructs mixed-tier switch layers correctly. `expert_down_bits` is stored in the `quantization` config block for provenance only.

## Validation (Qwen3.6-35B-A3B)

Dose-response on the Opencode agent-harness smoke test (planted off-by-one + failing pytest; temp 0.7 no-think; details in RandD `scripts/opencode_smoke/RESULTS.md`):

| Expert recipe | Size | Opencode | Failure mode |
|---|---|---|---|
| all ternary (1.58-bit) | 9.4 GB | 0/4 ✗ | never grounds the given command; across-turn perseveration |
| ternary + down_proj 3-bit | 11.0 GB | 0/3 ✗ | grounds + investigates, then perseverates on first hard error |
| **ternary + down_proj 4-bit** | **11.7 GB** | **3/3 ✓** | clean run → read → minimal edit → verify, 35–36 s (3-bit control: 33 s) |
| tq3 (all 3-bit, control) | 16.4 GB | 1/1 ✓ | — |

The down4 build is the first sub-2-bit-expert model to pass the agent-harness test, at 4.7 GB smaller than tq3 — generation peak 13.9 GB, i.e. 16 GB-mini-resident viable. Both variants also ran the 6-test stress harness (math/code/needle pass; long-form think-loop quirks match the pure-ternary baseline).

## Tests

- `tests/test_asymmetric_experts.py` (5 new tests): switch gate/up ternary + down override codebook sizes, override-without-ternary, disabled = uniform, and loader round-trip via `_prepare_polar_layers`.
- Full suite: 178 passed.

Per the agreed plan, this merges without a version tag — no PyPI release until all six ds4 ideas are tested.