### PR TITLE
feat: greedy tool-call syntax on turboquant-serve (--tool-syntax-greedy)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Greedy tool-call syntax on `turboquant-serve`** (`--tool-syntax-greedy`,
+  optional `--tool-syntax-tags "<open>,</close>"`): a per-request logits
+  processor masks logits to argmax while the generation is inside a
+  `<tool_call>`...`</tool_call>` block — braces, keys, colons, tags — and
+  leaves the configured sampler in charge of JSON *value* strings (free-text
+  payloads) and of the decision to emit a tool call at all, so agent
+  harnesses can serve low-bit builds at temperature without fabricated
+  tool-call structure. Composes with any sampler and with the repetition
+  penalties (argmax of the penalized distribution). Validated on the 35B
+  asymmetric-ternary build: well-formed `tool_calls` via curl, and no
+  regression on the Opencode agent smoke test (2/2 pass, same latency).
+
 - **Asymmetric expert precision** (`convert --expert-down-bits {2,3,4}`):
   quantize MoE expert down-projections at a higher-precision Gaussian
   codebook while up/gate take the `--mlp-bits` / `--ternary-experts` tier —

--- a/serve.py
+++ b/serve.py
@@ -61,6 +61,10 @@ Usage:
     # agentic conversation instead of re-prefilling it from scratch:
     turboquant-serve --model manjunathshiva/qwen3.5-122b-tq3 \
         --cache-budget-gb 4 --disk-cache --prompt-concurrency 1
+    # Agent harness on a low-bit build: sample normally, but decode tool-call
+    # structure greedily so fabricated syntax can't slip in:
+    turboquant-serve --model <tq-path> --temp 0.7 --tool-syntax-greedy \
+        --prompt-concurrency 1
 
 Disk prompt cache (cold prefill survives restarts)
 --------------------------------------------------
@@ -80,6 +84,17 @@ conversation is re-checkpointed — a restart loses at most that much prefill.
 Works with ``--kv-bits``/``--kv-k-bits`` (TurboQuant KV caches serialize) and
 with hybrid-attention models (non-trimmable GDN/Mamba states restore from
 strict-prefix checkpoints). Single server process per cache directory.
+
+Greedy tool-call syntax (--tool-syntax-greedy)
+----------------------------------------------
+Agent harnesses need temperature (greedy loops across turns on low-bit
+builds) but sampled *structure* is where those builds fabricate tool calls.
+``--tool-syntax-greedy`` masks the logits to argmax while the generation is
+inside a ``<tool_call>``...``</tool_call>`` block — braces, keys, colons,
+tags — and leaves the configured sampler in charge of the JSON *value*
+strings (the free-text payloads, where greedy causes repetition) and of the
+decision to emit a tool call at all. Tags are configurable via
+``--tool-syntax-tags "<open>,</close>"`` for non-Hermes templates.
 
 Prefill keepalive (long cold prefills behind a proxy)
 -----------------------------------------------------
@@ -544,6 +559,32 @@ def _patch_default_rep_penalty(rep_config) -> None:
     APIHandler.validate_model_parameters = validate_model_parameters
 
 
+def _extract_tool_syntax_greedy_args(argv):
+    """Peel ``--tool-syntax-greedy`` (and optional ``--tool-syntax-tags``).
+
+    ``--tool-syntax-tags`` takes ``"<open>,</close>"`` for chat templates
+    that don't use the Hermes-style ``<tool_call>`` markers.
+
+    Returns ``(config | None, remaining_argv)``.
+    """
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--tool-syntax-greedy", action="store_true")
+    parser.add_argument("--tool-syntax-tags", type=str, default=None)
+    ns, remaining = parser.parse_known_args(argv)
+    if not ns.tool_syntax_greedy:
+        return None, remaining
+    config = {}
+    if ns.tool_syntax_tags is not None:
+        open_tag, _, close_tag = ns.tool_syntax_tags.partition(",")
+        if not open_tag or not close_tag:
+            raise SystemExit(
+                "--tool-syntax-tags expects '<open>,</close>', got: "
+                f"{ns.tool_syntax_tags!r}"
+            )
+        config = {"open_tag": open_tag, "close_tag": close_tag}
+    return config, remaining
+
+
 def _patch_prefill_keepalive(interval: float = 10.0) -> None:
     """Mirror mlx_lm's prefill keepalive *comments* as real SSE ``data:`` chunks.
 
@@ -584,7 +625,11 @@ def main() -> None:
     prefill_keepalive_config, remaining = _extract_prefill_keepalive_args(remaining)
     rep_config, remaining = _extract_rep_penalty_args(remaining)
     disk_cache_config, remaining = _extract_disk_cache_args(remaining)
+    tool_greedy_config, remaining = _extract_tool_syntax_greedy_args(remaining)
     _patch_loader(stream_config)
+    if tool_greedy_config is not None:
+        from turboquant_mlx.tool_syntax_greedy import install as _install_tool_greedy
+        _install_tool_greedy(**tool_greedy_config)
     if rep_config is not None:
         _patch_default_rep_penalty(rep_config)
     if kv_config is not None:
@@ -637,6 +682,18 @@ def main() -> None:
             f"save_every={disk_cache_config['save_every']}) — prompt-cache "
             "checkpoints persist across restarts; cold prefill resumes from "
             "the longest saved prefix.\n"
+        )
+    if tool_greedy_config is not None:
+        from turboquant_mlx.tool_syntax_greedy import (
+            _DEFAULT_CLOSE_TAG,
+            _DEFAULT_OPEN_TAG,
+        )
+        open_tag = tool_greedy_config.get("open_tag", _DEFAULT_OPEN_TAG)
+        close_tag = tool_greedy_config.get("close_tag", _DEFAULT_CLOSE_TAG)
+        sys.stderr.write(
+            f"[turboquant-serve] Tool-syntax greedy: ON "
+            f"(tags {open_tag}...{close_tag}) — structural tokens decode at "
+            "argmax; JSON value strings keep the request sampler.\n"
         )
     if prefill_stats_config is not None:
         dest = prefill_stats_config["stats_file"] or "stderr only"

--- a/serve.py
+++ b/serve.py
@@ -572,6 +572,10 @@ def _extract_tool_syntax_greedy_args(argv):
     parser.add_argument("--tool-syntax-tags", type=str, default=None)
     ns, remaining = parser.parse_known_args(argv)
     if not ns.tool_syntax_greedy:
+        if ns.tool_syntax_tags is not None:
+            raise SystemExit(
+                "--tool-syntax-tags requires --tool-syntax-greedy"
+            )
         return None, remaining
     config = {}
     if ns.tool_syntax_tags is not None:

--- a/tests/test_tool_syntax_greedy.py
+++ b/tests/test_tool_syntax_greedy.py
@@ -1,0 +1,235 @@
+"""Tests for the tool-syntax greedy logits processor.
+
+A character tokenizer (one token id per code point) drives the processor
+through scripted generations; the assertion at each step is whether the
+processor left the logits untouched (sampled) or masked them to argmax
+(greedy).
+"""
+
+import math
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.tool_syntax_greedy import ToolSyntaxGreedyProcessor
+
+
+class CharTokenizer:
+    def decode(self, ids):
+        return "".join(chr(i) for i in ids)
+
+
+def _encode(text):
+    return [ord(c) for c in text]
+
+
+VOCAB = 4096
+
+
+def _logits():
+    """Fixed non-trivial logits: argmax at index 7."""
+    row = mx.zeros((1, VOCAB))
+    row = mx.where(mx.arange(VOCAB) == 7, mx.array(2.0), row)
+    row = mx.where(mx.arange(VOCAB) == 11, mx.array(1.0), row)
+    return row
+
+
+def _is_greedy(out):
+    """True when all but one entry are -inf."""
+    finite = mx.isinf(out).astype(mx.int32).sum().item()
+    return finite == VOCAB - 1
+
+
+def _drive(prompt, generated, **proc_kwargs):
+    """Run the processor over a scripted generation.
+
+    Returns a list of (position, char_about_to_be_emitted, greedy_bool) for
+    each generated character: the processor is consulted with the history
+    *before* that character, exactly like real decoding.
+    """
+    proc = ToolSyntaxGreedyProcessor(CharTokenizer(), **proc_kwargs)
+    history = _encode(prompt)
+    decisions = []
+    for i, ch in enumerate(generated):
+        out = proc(mx.array(history), _logits())
+        decisions.append((i, ch, _is_greedy(out)))
+        history.append(ord(ch))
+    return decisions
+
+
+def _decision_str(decisions):
+    """Render decisions as a string of s/G aligned with the generated text."""
+    return "".join("G" if g else "s" for _, _, g in decisions)
+
+
+def test_outside_tool_block_never_masks():
+    gen = "Sure, let me check the weather for you."
+    decisions = _drive("What is the weather?", gen)
+    assert _decision_str(decisions) == "s" * len(gen)
+
+
+def test_structural_greedy_value_sampled():
+    gen = '<tool_call>{"name": "get_weather", "arguments": {"city": "Paris"}}</tool_call>'
+    decisions = _drive("", gen)
+    txt = _decision_str(decisions)
+    # The decision to open a tool call is the sampler's: positions emitting
+    # the opening tag itself are sampled until the tag completes.
+    assert txt[: len("<tool_call>")] == "s" * len("<tool_call>")
+    by_pos = dict(enumerate(txt))
+
+    def span(sub):
+        start = gen.index(sub)
+        return "".join(by_pos[i] for i in range(start, start + len(sub)))
+
+    # Keys and punctuation are greedy.
+    assert span('"name"') == "G" * 6
+    assert span('"arguments"') == "G" * 11
+    assert span(": {") == "GGG"
+    # Value string *contents* are sampled: the opening quote is emitted at a
+    # greedy position, the characters inside (and the closing quote's
+    # position, decided while still in-string) are sampled.
+    start = gen.index('"Paris"')
+    assert txt[start] == "G"                       # opening quote
+    assert txt[start + 1 : start + 7] == "ssssss"  # P a r i s + closing pos
+    # After the value closes, structure is greedy again (closing braces).
+    tail = gen.index("}}")
+    assert txt[tail] == "G" and txt[tail + 1] == "G"
+
+
+def test_after_close_tag_returns_to_sampled():
+    gen = '<tool_call>{"name": "x"}</tool_call> Done thinking.'
+    decisions = _drive("", gen)
+    txt = _decision_str(decisions)
+    after = gen.index(" Done")
+    assert txt[after:] == "s" * (len(gen) - after)
+
+
+def test_nested_containers_and_arrays():
+    gen = '<tool_call>{"arguments": {"items": [1, "two", {"k": "v"}]}}</tool_call>'
+    decisions = _drive("", gen)
+    txt = _decision_str(decisions)
+
+    def at(sub, offset=0):
+        return txt[gen.index(sub) + offset]
+
+    assert at("[1, ") == "G"          # array punctuation greedy
+    # "two" is an array element -> value string, contents sampled
+    start = gen.index('"two"')
+    assert txt[start] == "G"
+    assert txt[start + 1 : start + 5] == "ssss"
+    # nested object key "k" greedy, its value "v" sampled inside
+    kstart = gen.index('"k"')
+    assert txt[kstart : kstart + 3] == "GGG"
+    vstart = gen.index('"v"')
+    assert txt[vstart] == "G"
+    assert txt[vstart + 1] == "s"
+
+
+def test_escaped_quote_stays_in_string():
+    gen = '<tool_call>{"a": "say \\"hi\\" ok"}</tool_call>'
+    decisions = _drive("", gen)
+    txt = _decision_str(decisions)
+    # Every char between the value's opening quote and its true closing
+    # quote is sampled — the escaped quotes must not end the string.
+    start = gen.index('"say')
+    end = gen.index('"}', start)
+    assert txt[start + 1 : end + 1] == "s" * (end - start)
+    # After the true close, structure is greedy again.
+    assert txt[gen.index("}")] == "G"
+
+
+def test_prompt_tool_call_is_ignored():
+    prompt = 'Earlier: <tool_call>{"name": "old"}'  # unclosed block in prompt
+    gen = "A normal sentence."
+    decisions = _drive(prompt, gen)
+    assert _decision_str(decisions) == "s" * len(gen)
+
+
+def test_custom_tags():
+    gen = "<fn>{\"name\": \"x\"}</fn>"
+    decisions = _drive("", gen, open_tag="<fn>", close_tag="</fn>")
+    txt = _decision_str(decisions)
+    assert txt[gen.index('{"name"')] == "G"
+    assert "G" in txt
+
+
+def test_rewind_rebuilds_state():
+    proc = ToolSyntaxGreedyProcessor(CharTokenizer())
+    prompt = _encode("hi ")
+    gen = '<tool_call>{"a"'
+    history = prompt + []
+    for ch in gen:
+        proc(mx.array(history), _logits())
+        history.append(ord(ch))
+    # Inside the block now: structural position -> greedy.
+    assert _is_greedy(proc(mx.array(history), _logits()))
+    # Rewind to just the prompt (rejected speculative draft) and emit plain
+    # text instead: must be sampled again.
+    history = prompt + _encode("hello")
+    out = proc(mx.array(history), _logits())
+    assert not _is_greedy(out)
+
+
+def test_greedy_mask_preserves_argmax():
+    proc = ToolSyntaxGreedyProcessor(CharTokenizer())
+    history = _encode('<tool_call>{')
+    proc(mx.array(_encode("")), _logits())  # first call sets prompt base
+    out = proc(mx.array(history), _logits())
+    assert _is_greedy(out)
+    assert mx.argmax(out, axis=-1).item() == 7
+    assert out[0, 7].item() == pytest.approx(2.0)
+    assert math.isinf(out[0, 11].item()) and out[0, 11].item() < 0
+
+
+def test_install_is_idempotent_and_appends_processor():
+    import mlx_lm.server as server_mod
+
+    import turboquant_mlx.tool_syntax_greedy as tsg
+
+    orig_sampler = server_mod._make_sampler
+    orig_procs = server_mod._make_logits_processors
+    try:
+        tsg.install()
+        first_sampler = server_mod._make_sampler
+        tsg.install()  # second install must not re-wrap
+        assert server_mod._make_sampler is first_sampler
+
+        class _Args:
+            class sampling:
+                temperature = 0.7
+                top_p = 0.8
+                top_k = 20
+                min_p = 0.0
+                xtc_probability = 0.0
+                xtc_threshold = 0.0
+
+            class logits:
+                logit_bias = None
+                repetition_penalty = None
+                repetition_context_size = 20
+                presence_penalty = None
+                presence_context_size = 20
+                frequency_penalty = None
+                frequency_context_size = 20
+
+        class _Tok:
+            eos_token_id = 0
+
+            def encode(self, s):
+                return [1]
+
+            def decode(self, ids):
+                return "".join(chr(i) for i in ids)
+
+        server_mod._make_sampler(_Args, _Tok())
+        procs = server_mod._make_logits_processors(_Args)
+        assert any(isinstance(p, ToolSyntaxGreedyProcessor) for p in procs)
+        # A second request gets a *fresh* processor (stateful, per-request).
+        procs2 = server_mod._make_logits_processors(_Args)
+        p1 = [p for p in procs if isinstance(p, ToolSyntaxGreedyProcessor)][0]
+        p2 = [p for p in procs2 if isinstance(p, ToolSyntaxGreedyProcessor)][0]
+        assert p1 is not p2
+    finally:
+        server_mod._make_sampler = orig_sampler
+        server_mod._make_logits_processors = orig_procs
+        tsg._INSTALLED = False

--- a/tests/test_tool_syntax_greedy.py
+++ b/tests/test_tool_syntax_greedy.py
@@ -153,6 +153,49 @@ def test_custom_tags():
     assert "G" in txt
 
 
+class ByteTokenizer:
+    """One token id per UTF-8 *byte* — every multi-byte character arrives
+    split across calls, exercising the partial-character hold-back."""
+
+    def decode(self, ids):
+        return bytes(ids).decode("utf-8", errors="replace")
+
+
+def test_multibyte_utf8_split_across_tokens():
+    gen = '<tool_call>{"città": "Zürich"}</tool_call> naïve tail'
+    data = gen.encode("utf-8")
+    proc = ToolSyntaxGreedyProcessor(ByteTokenizer())
+    history = list("prompt ".encode("utf-8"))
+    decisions = []
+    for b in data:
+        out = proc(mx.array(history), _logits())
+        decisions.append(_is_greedy(out))
+        history.append(b)
+
+    def bpos(sub):
+        return data.index(sub.encode("utf-8"))
+
+    # Opening the block is the sampler's decision.
+    assert not any(decisions[: len("<tool_call>")])
+    # Structure and the non-ASCII key are greedy end to end — the split
+    # bytes of 'à' must not corrupt the scanner's string state.
+    assert decisions[bpos("{")]
+    kstart = bpos('"città"')
+    klen = len('"città"'.encode("utf-8"))
+    assert all(decisions[kstart : kstart + klen])
+    # Value contents (including the split 'ü' and the closing-quote
+    # position) are sampled; the quote that opens the value is greedy.
+    vstart = bpos('"Zürich"')
+    vlen = len('"Zürich"'.encode("utf-8"))
+    assert decisions[vstart]
+    assert not any(decisions[vstart + 1 : vstart + vlen])
+    # Back to structure after the value closes.
+    assert decisions[bpos("}")]
+    # The close tag must still be recognized with multi-byte text around it.
+    tail = bpos(" naïve")
+    assert not any(decisions[tail:])
+
+
 def test_rewind_rebuilds_state():
     proc = ToolSyntaxGreedyProcessor(CharTokenizer())
     prompt = _encode("hi ")
@@ -181,10 +224,22 @@ def test_greedy_mask_preserves_argmax():
     assert math.isinf(out[0, 11].item()) and out[0, 11].item() < 0
 
 
+def test_tags_without_greedy_flag_errors():
+    from turboquant_mlx.serve import _extract_tool_syntax_greedy_args
+
+    with pytest.raises(SystemExit):
+        _extract_tool_syntax_greedy_args(["--tool-syntax-tags", "<fn>,</fn>"])
+    config, remaining = _extract_tool_syntax_greedy_args(
+        ["--tool-syntax-greedy", "--tool-syntax-tags", "<fn>,</fn>", "--model", "m"]
+    )
+    assert config == {"open_tag": "<fn>", "close_tag": "</fn>"}
+    assert remaining == ["--model", "m"]
+
+
 def test_install_is_idempotent_and_appends_processor():
     import mlx_lm.server as server_mod
 
-    import turboquant_mlx.tool_syntax_greedy as tsg
+    from turboquant_mlx import tool_syntax_greedy as tsg
 
     orig_sampler = server_mod._make_sampler
     orig_procs = server_mod._make_logits_processors
@@ -232,4 +287,3 @@ def test_install_is_idempotent_and_appends_processor():
     finally:
         server_mod._make_sampler = orig_sampler
         server_mod._make_logits_processors = orig_procs
-        tsg._INSTALLED = False

--- a/tool_syntax_greedy.py
+++ b/tool_syntax_greedy.py
@@ -154,16 +154,23 @@ class ToolSyntaxGreedyProcessor:
             self._pos = self._base
         if n > self._pos:
             new_ids = tokens[self._pos:].tolist()
-            self._scanner.consume(self.tokenizer.decode(new_ids))
-            self._pos = n
+            text = self.tokenizer.decode(new_ids)
+            # A multi-byte character split across the decode boundary shows
+            # up as trailing replacement characters; hold those tokens back
+            # and re-decode them together with the next call's tokens. Safe
+            # to defer: every structural character is single-byte ASCII, so
+            # pending partial bytes can never complete a tag or quote.
+            held = 0
+            while text.endswith("�") and held < len(new_ids):
+                held += 1
+                text = self.tokenizer.decode(new_ids[:-held])
+            self._scanner.consume(text)
+            self._pos = n - held
         if not self._scanner.force_greedy:
             return logits
         idx = mx.argmax(logits, axis=-1, keepdims=True)
         mask = mx.arange(logits.shape[-1]) == idx
         return mx.where(mask, logits, mx.array(-math.inf, dtype=logits.dtype))
-
-
-_INSTALLED = False
 
 
 def install(
@@ -176,11 +183,14 @@ def install(
     server calls ``_make_sampler(args, tokenizer)`` immediately before it on
     the same thread in both the batched and single-stream paths — so the
     sampler patch stashes the tokenizer for the processor patch to read.
+
+    Idempotent: the wrapper functions carry a marker attribute, so a second
+    ``install`` is a no-op instead of double-wrapping.
     """
-    global _INSTALLED
-    if _INSTALLED:
-        return
     import mlx_lm.server as _server_mod
+
+    if getattr(_server_mod._make_sampler, "_tool_syntax_greedy", False):
+        return
 
     _orig_make_sampler = _server_mod._make_sampler
     _orig_make_processors = _server_mod._make_logits_processors
@@ -199,6 +209,6 @@ def install(
             )
         return processors
 
+    _make_sampler._tool_syntax_greedy = True
     _server_mod._make_sampler = _make_sampler
     _server_mod._make_logits_processors = _make_logits_processors
-    _INSTALLED = True

--- a/tool_syntax_greedy.py
+++ b/tool_syntax_greedy.py
@@ -1,0 +1,204 @@
+"""Greedy sampling on tool-call structural tokens (DwarfStar-style).
+
+Low-bit builds serve agent harnesses at temperature (greedy loops across
+turns), but sampled *structure* is exactly where they fabricate tool calls:
+a wrong brace, a hallucinated key, a truncated tag. DwarfStar's answer is to
+force temp=0 whenever the model is emitting tool-call syntax and keep the
+configured sampler for the free-text argument payloads (greedy on long
+bodies causes repetition). This module is the serve-side port: a stateful
+logits processor that masks logits to the argmax token while the generation
+sits inside a ``<tool_call>``...``</tool_call>`` block, except inside JSON
+*value* strings.
+
+Position classification, from the generated text so far:
+
+- outside a tool block                          -> sampled (the *decision* to
+  call a tool stays with the sampler)
+- inside a block, structural (braces, colons,
+  commas, whitespace, tags, numbers, literals)  -> greedy
+- inside a block, JSON key string               -> greedy
+- inside a block, JSON value string             -> sampled
+
+The processor composes with any sampler because an all-``-inf``-but-argmax
+logit row survives temperature/top-p/top-k unchanged. It runs after the
+other processors (repetition penalties), so "argmax" means argmax of the
+penalized distribution.
+
+State is tracked incrementally: each call decodes only the token ids added
+since the previous call and advances a small text scanner. If the token
+history rewinds (a rejected speculative-decoding draft), the scanner rebuilds
+from the start of the generation. Prompt tokens are never scanned — a
+``<tool_call>`` in the prompt (few-shot examples, prior turns) cannot flip
+the state.
+
+A malformed block that opens a value string and never closes it leaves the
+tail of that block sampled (the close tag is only recognized outside
+strings); generation still terminates through the normal stop tokens.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import List, Optional
+
+import mlx.core as mx
+
+_DEFAULT_OPEN_TAG = "<tool_call>"
+_DEFAULT_CLOSE_TAG = "</tool_call>"
+
+
+class _ToolBlockScanner:
+    """Incremental text scanner deciding sampled-vs-greedy for the next token.
+
+    Tracks whether the cursor sits inside an open ``open_tag`` block and, if
+    so, a minimal JSON context: container stack (objects remember whether the
+    next string is a key), in-string flag, and backslash escapes. Tags are
+    matched on a rolling ``endswith`` so they may arrive split across tokens.
+    """
+
+    def __init__(self, open_tag: str, close_tag: str) -> None:
+        self.open_tag = open_tag
+        self.close_tag = close_tag
+        self._tail_keep = max(len(open_tag), len(close_tag))
+        self.reset()
+
+    def reset(self) -> None:
+        self.in_tool = False
+        self._tail = ""
+        # JSON context, valid while in_tool:
+        self._stack: List[List] = []  # ["obj", expect_key] | ["arr"]
+        self._in_string = False
+        self._string_is_value = False
+        self._escape = False
+
+    def consume(self, text: str) -> None:
+        for ch in text:
+            self._consume_char(ch)
+
+    def _consume_char(self, ch: str) -> None:
+        self._tail = (self._tail + ch)[-self._tail_keep:]
+        if not self.in_tool:
+            if self._tail.endswith(self.open_tag):
+                self.in_tool = True
+                self._stack = []
+                self._in_string = False
+                self._escape = False
+            return
+
+        if self._in_string:
+            if self._escape:
+                self._escape = False
+            elif ch == "\\":
+                self._escape = True
+            elif ch == '"':
+                self._in_string = False
+            return
+
+        if self._tail.endswith(self.close_tag):
+            self.in_tool = False
+            return
+
+        if ch == '"':
+            self._in_string = True
+            self._escape = False
+            top = self._stack[-1] if self._stack else None
+            # A string right after '{' or ',' in an object is a key; any
+            # other position (after ':', in an array, bare) is a value.
+            self._string_is_value = not (top is not None and top[0] == "obj" and top[1])
+        elif ch == "{":
+            self._stack.append(["obj", True])
+        elif ch == "[":
+            self._stack.append(["arr"])
+        elif ch in "}]":
+            if self._stack:
+                self._stack.pop()
+        elif ch == ":":
+            if self._stack and self._stack[-1][0] == "obj":
+                self._stack[-1][1] = False
+        elif ch == ",":
+            if self._stack and self._stack[-1][0] == "obj":
+                self._stack[-1][1] = True
+
+    @property
+    def force_greedy(self) -> bool:
+        return self.in_tool and not (self._in_string and self._string_is_value)
+
+
+class ToolSyntaxGreedyProcessor:
+    """Logits processor: argmax while inside tool-call structural syntax.
+
+    One instance per request — it carries generation state. ``tokens`` on the
+    first call is the prompt; everything before that length is skipped so
+    only generated text drives the scanner.
+    """
+
+    def __init__(
+        self,
+        tokenizer,
+        open_tag: str = _DEFAULT_OPEN_TAG,
+        close_tag: str = _DEFAULT_CLOSE_TAG,
+    ) -> None:
+        self.tokenizer = tokenizer
+        self._scanner = _ToolBlockScanner(open_tag, close_tag)
+        self._base: Optional[int] = None  # prompt length, set on first call
+        self._pos = 0  # token ids consumed into the scanner so far
+
+    def __call__(self, tokens: mx.array, logits: mx.array) -> mx.array:
+        n = tokens.size
+        if self._base is None:
+            self._base = n
+            self._pos = n
+        elif n < self._pos:
+            # History rewound (rejected speculative draft): rebuild.
+            self._scanner.reset()
+            self._pos = self._base
+        if n > self._pos:
+            new_ids = tokens[self._pos:].tolist()
+            self._scanner.consume(self.tokenizer.decode(new_ids))
+            self._pos = n
+        if not self._scanner.force_greedy:
+            return logits
+        idx = mx.argmax(logits, axis=-1, keepdims=True)
+        mask = mx.arange(logits.shape[-1]) == idx
+        return mx.where(mask, logits, mx.array(-math.inf, dtype=logits.dtype))
+
+
+_INSTALLED = False
+
+
+def install(
+    open_tag: str = _DEFAULT_OPEN_TAG,
+    close_tag: str = _DEFAULT_CLOSE_TAG,
+) -> None:
+    """Patch ``mlx_lm.server`` so every request gets a fresh processor.
+
+    ``_make_logits_processors(args)`` never sees the tokenizer, but the
+    server calls ``_make_sampler(args, tokenizer)`` immediately before it on
+    the same thread in both the batched and single-stream paths — so the
+    sampler patch stashes the tokenizer for the processor patch to read.
+    """
+    global _INSTALLED
+    if _INSTALLED:
+        return
+    import mlx_lm.server as _server_mod
+
+    _orig_make_sampler = _server_mod._make_sampler
+    _orig_make_processors = _server_mod._make_logits_processors
+    _ctx: dict = {}
+
+    def _make_sampler(args, tokenizer):
+        _ctx["tokenizer"] = tokenizer
+        return _orig_make_sampler(args, tokenizer)
+
+    def _make_logits_processors(args):
+        processors = list(_orig_make_processors(args))
+        tokenizer = _ctx.get("tokenizer")
+        if tokenizer is not None:
+            processors.append(
+                ToolSyntaxGreedyProcessor(tokenizer, open_tag, close_tag)
+            )
+        return processors
+
+    _server_mod._make_sampler = _make_sampler
+    _server_mod._make_logits_processors = _make_logits_processors
+    _INSTALLED = True


### PR DESCRIPTION
## What

Adds `--tool-syntax-greedy` (plus `--tool-syntax-tags "<open>,</close>"` for non-Hermes templates) to `turboquant-serve`: a stateful per-request logits processor that masks logits to argmax while the generation is inside a `<tool_call>`...`</tool_call>` block, except inside JSON **value** strings. DwarfStar's sampling policy, ported serve-side:

- outside a tool block → sampled (the *decision* to call a tool stays with the sampler)
- structural tokens (braces, colons, commas, tags, numbers) → greedy
- JSON key strings → greedy
- JSON value strings (free-text payloads, where greedy causes repetition) → sampled

## How

`tool_syntax_greedy.py`: an incremental text scanner (rolling tag match + minimal JSON context: container stack, key/value position, string/escape state) consumes only the token ids added since the previous call; prompt tokens are never scanned, and a history rewind (rejected speculative draft) triggers a rebuild. Masking to an all-`-inf`-but-argmax row composes with any sampler (temperature/top-p/top-k leave it fixed) and runs after the repetition penalties.

Wiring: `install()` patches `mlx_lm.server._make_sampler` (to stash the tokenizer, which `_make_logits_processors` never receives — the server calls them back-to-back on the same thread in both serving paths) and `_make_logits_processors` (to append a fresh processor per request). Double-install guarded.

## Validation (Qwen3.6-35B-A3B builds)

- Direct curl with a tools schema on the asymmetric-ternary down4 build: well-formed `tool_calls`, valid JSON args, `finish_reason: tool_calls`.
- Opencode agent smoke test, down4 + flag: **2/2 clean passes at 37 s** (36 s without the flag) — no regression.
- Pure-ternary + flag: still fails (0/2) — as expected, since that build's failures are semantic (whether/what to call), which this policy deliberately leaves to the sampler. The flag is insurance against fabricated structure, not a capability lever; documented accordingly.

## Tests

- `tests/test_tool_syntax_greedy.py` (10 new tests): sampled/greedy decision per position across scripted generations (keys vs values, nested containers/arrays, escaped quotes, custom tags, prompt tool-calls ignored, rewind rebuild, argmax preservation, idempotent install + fresh per-request processors).
- Full suite: 188 passed.

Third of the six ds4 ideas; merges without a version tag — no PyPI release until all six are tested.