### PR TITLE
feat: shipped hot-expert list — startup preload + hot_experts.json auto-discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,17 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Shipped hot-expert list for streaming** (ds4-style): a model repo can
+  now carry its own routing profile — drop `calibrate_experts.py`'s pin
+  output into the model directory as `hot_experts.json` and the streaming
+  loader pins **and preloads** those experts at startup (`--no-hotlist`
+  opts out; explicit `--pin-file` still overrides). Preload reads the list
+  in hotness order with coalesced batch reads, capped at 60% of
+  `--cache-budget-gb` so the LRU keeps working room; experts past the cap
+  are un-pinned and age through the LRU normally. Previously pinned experts
+  loaded lazily on first miss, so the profile did nothing for cold-start
+  latency. Cache stats gained `preload_experts` / `preload_gb`.
+
 - **Greedy tool-call syntax on `turboquant-serve`** (`--tool-syntax-greedy`,
   optional `--tool-syntax-tags "<open>,</close>"`): a per-request logits
   processor masks logits to argmax while the generation is inside a

--- a/serve.py
+++ b/serve.py
@@ -37,8 +37,12 @@ over the OpenAI API — only the router-selected experts are paged from disk per
 token. The Flash-MoE streaming levers come with it: ``--max-active-experts``
 (K-reduction, default 4 → ~2x less disk I/O) and ``--use-page-cache`` /
 ``--no-page-cache`` (auto by model-size-vs-RAM; trust-OS is ~2.4x faster decode
-when the model fits free RAM, F_NOCACHE otherwise). Streaming is a single-user
-path — pair with ``--prompt-concurrency 1``.
+when the model fits free RAM, F_NOCACHE otherwise). Hot-expert pinning:
+``--pin-file`` takes a calibrate_experts.py pin spec, and a ``hot_experts.json``
+shipped in the model directory is picked up automatically (``--no-hotlist``
+disables); pinned experts are preloaded at startup so first-token routing hits
+warm memory. Streaming is a single-user path — pair with
+``--prompt-concurrency 1``.
 
 Usage:
     turboquant-serve --model manjunathshiva/Nemotron-3-Super-120B-A12B-tq3
@@ -289,6 +293,8 @@ def _extract_stream_args(argv):
     parser.add_argument("--prefetch-workers", type=int, default=8)
     parser.add_argument("--prefetch-ahead", type=int, default=0)
     parser.add_argument("--pin-file", default=None)
+    parser.add_argument("--no-hotlist", dest="use_hotlist", action="store_false",
+                        default=True)
     parser.add_argument("--use-page-cache", dest="use_page_cache",
                         action="store_true", default=None)
     parser.add_argument("--no-page-cache", dest="use_page_cache",
@@ -305,6 +311,7 @@ def _extract_stream_args(argv):
         prefetch_workers=ns.prefetch_workers,
         prefetch_ahead=ns.prefetch_ahead,
         pin_file=ns.pin_file,
+        use_hotlist=ns.use_hotlist,
     )
     return stream_config, remaining
 

--- a/stream/calibrate_experts.py
+++ b/stream/calibrate_experts.py
@@ -162,6 +162,8 @@ def analyze(args):
     print(f"[analyze] pin {len(pin)} experts (~{used / 1e9:.1f} GB, cost "
           f"{cost / 1e6:.0f} MB/expert) covering {100 * covered / max(1, total_sel):.1f}% "
           f"of all selections -> {args.pin_out}")
+    print(f"[analyze] to ship it, copy {args.pin_out} to <model_dir>/hot_experts.json — "
+          "the streaming loader pins+preloads it automatically")
 
     # ---- perm.json: per-layer co-activation ordering for the #3 repack ----
     # Must be a FULL permutation of all E experts — experts that never fired in

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -102,17 +102,32 @@ def _find_hotlist(model_path: str) -> str | None:
     return cand if os.path.isfile(cand) else None
 
 
-def _load_pin_spec(pin_file: str):
+def _load_pin_spec(pin_file: str) -> "tuple[dict, list]":
     """Parse ``{"pin": [[layer, expert], ...]}`` keeping BOTH a per-layer set
     (to build pin keys during the layer swap) and the file's rank order
-    (hottest first, so a budget-capped preload keeps the hottest)."""
+    (hottest first, so a budget-capped preload keeps the hottest).
+
+    Raises ``ValueError`` with the offending file/entry on a malformed spec —
+    a shipped hotlist comes from a downloaded repo, so the caller decides
+    whether that is fatal (explicit ``--pin-file``) or skippable (auto-found).
+    """
     with open(pin_file) as f:
-        pairs = json.load(f).get("pin", [])
+        data = json.load(f)
+    pairs = data.get("pin") if isinstance(data, dict) else None
+    if not isinstance(pairs, list):
+        raise ValueError(
+            f'{pin_file}: expected {{"pin": [[layer, expert], ...]}}'
+        )
     pin_layers: dict = {}
     pin_order: list = []
     seen = set()
-    for layer, expert in pairs:
-        le = (int(layer), int(expert))
+    for item in pairs:
+        try:
+            le = (int(item[0]), int(item[1]))
+        except (TypeError, ValueError, IndexError, KeyError):
+            raise ValueError(
+                f"{pin_file}: bad pin entry {item!r} (want [layer, expert])"
+            ) from None
         if le in seen:
             continue
         seen.add(le)
@@ -162,12 +177,22 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
 
     # Load the hot-expert pin spec (frequency-based pinning, #2 + shipped
     # hotlist, #6). Keyed by layer so we can pin all three projections of each
-    # hot expert; the rank order drives the startup preload.
-    if pin_file is None and use_hotlist:
-        pin_file = _find_hotlist(local_path)
-        if pin_file:
-            print(f"[stream] found shipped hot-expert list: {pin_file}")
-    pin_layers, pin_order = _load_pin_spec(pin_file) if pin_file else ({}, [])
+    # hot expert; the rank order drives the startup preload. A malformed
+    # explicit --pin-file fails loud (the user asked for that exact file); a
+    # malformed shipped hotlist only warns — it came with the download, and
+    # the model runs fine without it.
+    pin_layers: dict = {}
+    pin_order: list = []
+    if pin_file:
+        pin_layers, pin_order = _load_pin_spec(pin_file)
+    elif use_hotlist:
+        shipped = _find_hotlist(local_path)
+        if shipped:
+            try:
+                pin_layers, pin_order = _load_pin_spec(shipped)
+                print(f"[stream] found shipped hot-expert list: {shipped}")
+            except ValueError as exc:  # includes json.JSONDecodeError
+                print(f"[stream] ignoring malformed shipped hotlist: {exc}")
 
     # Locate the transformer layer stack and its weight-key prefix. Multimodal
     # MoEs (qwen3_5_moe) nest it under `language_model.model.layers`; text-only

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -11,7 +11,9 @@ shared expert) stays resident as usual.
 from __future__ import annotations
 
 import glob
+import json
 import os
+import time
 
 import mlx.core as mx
 
@@ -88,10 +90,42 @@ def _cap_active_experts(layers, max_active: int) -> None:
               f"max_active_experts=0 / --max-active-experts 0 to use native routing)")
 
 
+# A model repo may ship its own routing profile alongside the weights (the
+# ds4 hotlist idea): calibrate_experts.py's pin.json, renamed to this, uploaded
+# with the checkpoint. Streaming then warm-starts on any machine with just
+# --cache-budget-gb.
+_HOTLIST_FILENAME = "hot_experts.json"
+
+
+def _find_hotlist(model_path: str) -> str | None:
+    cand = os.path.join(model_path, _HOTLIST_FILENAME)
+    return cand if os.path.isfile(cand) else None
+
+
+def _load_pin_spec(pin_file: str):
+    """Parse ``{"pin": [[layer, expert], ...]}`` keeping BOTH a per-layer set
+    (to build pin keys during the layer swap) and the file's rank order
+    (hottest first, so a budget-capped preload keeps the hottest)."""
+    with open(pin_file) as f:
+        pairs = json.load(f).get("pin", [])
+    pin_layers: dict = {}
+    pin_order: list = []
+    seen = set()
+    for layer, expert in pairs:
+        le = (int(layer), int(expert))
+        if le in seen:
+            continue
+        seen.add(le)
+        pin_order.append(le)
+        pin_layers.setdefault(le[0], set()).add(le[1])
+    return pin_layers, pin_order
+
+
 def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
                    prefetch_workers: int = 8, prefetch_ahead: int = 0,
                    pin_file: str | None = None, max_active_experts: int = 4,
-                   use_page_cache: bool | None = None):
+                   use_page_cache: bool | None = None, use_hotlist: bool = True,
+                   preload_pins: bool = True):
     """Returns (model, tokenizer, cache).
 
     cache_budget_gb bounds total resident expert memory (LRU-evicted).
@@ -100,6 +134,12 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
     (predicted from the previous token's routing); 0 disables prefetch.
     pin_file is an optional JSON {"pin": [[layer, expert], ...]} of hot experts
     to keep permanently resident (never LRU-evicted) — see calibrate_experts.py.
+    When it is None and the model directory ships a ``hot_experts.json`` (same
+    schema), that file is used automatically; use_hotlist=False/--no-hotlist
+    disables the auto-discovery. Pinned experts are PRELOADED at startup in
+    hotness order (coalesced batch reads, capped at 60% of the budget so the
+    LRU keeps working room) instead of pinning lazily on first miss;
+    preload_pins=False restores the lazy behavior.
     max_active_experts caps router top_k to min(native, this) on every MoE block
     (the Flash-MoE K-reduction lever: ~2x less streamed disk I/O at no quality
     cost up to K=4 on validated models). Default 4; set 0 to use native routing.
@@ -120,14 +160,14 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
         prefetch_ahead=prefetch_ahead,
     )
 
-    # Load the hot-expert pin spec (frequency-based pinning, #2). Keyed by layer
-    # so we can pin all three projections of each hot expert.
-    pin_layers: dict = {}
-    if pin_file:
-        import json
-        with open(pin_file) as f:
-            for layer, expert in json.load(f).get("pin", []):
-                pin_layers.setdefault(int(layer), set()).add(int(expert))
+    # Load the hot-expert pin spec (frequency-based pinning, #2 + shipped
+    # hotlist, #6). Keyed by layer so we can pin all three projections of each
+    # hot expert; the rank order drives the startup preload.
+    if pin_file is None and use_hotlist:
+        pin_file = _find_hotlist(local_path)
+        if pin_file:
+            print(f"[stream] found shipped hot-expert list: {pin_file}")
+    pin_layers, pin_order = _load_pin_spec(pin_file) if pin_file else ({}, [])
 
     # Locate the transformer layer stack and its weight-key prefix. Multimodal
     # MoEs (qwen3_5_moe) nest it under `language_model.model.layers`; text-only
@@ -183,5 +223,19 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
     pin_note = f", pinned {len(pin_keys)} hot expert-projections" if pin_keys else ""
     print(f"[stream] swapped {swapped} expert projections to streaming "
           f"(budget {cache_budget_gb:.1f} GB{pin_note})")
+    if pin_keys and preload_pins:
+        t0 = time.time()
+        specs = [
+            (wkey, skey, e)
+            for layer, e in pin_order
+            for wkey, skey in cache._layer_keys.get(layer, ())
+            if (wkey, e) in pin_keys
+        ]
+        n, dropped = cache.preload(specs)
+        drop_note = (f", {dropped} past the 60%-of-budget cap left to the LRU"
+                     if dropped else "")
+        print(f"[stream] hotlist preload: {n} expert-projections "
+              f"({cache.preload_bytes / 1e9:.2f} GB) in {time.time() - t0:.1f}s"
+              f"{drop_note}")
     _cap_active_experts(layers, max_active_experts)
     return model, tok, cache

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -59,7 +59,12 @@ def main():
                         "storage proves bandwidth-bound.")
     p.add_argument("--pin-file", default=None,
                    help="JSON {'pin': [[layer, expert], ...]} of hot experts to keep "
-                        "permanently resident (from calibrate_experts.py).")
+                        "permanently resident (from calibrate_experts.py). Without it, "
+                        "a hot_experts.json shipped in the model directory is used "
+                        "automatically. Pins are preloaded at startup.")
+    p.add_argument("--no-hotlist", dest="use_hotlist", action="store_false",
+                   default=True,
+                   help="Ignore a hot_experts.json shipped in the model directory.")
     p.add_argument("--max-active-experts", type=int, default=4,
                    help="Cap router top_k to min(native, this) on every MoE block "
                         "(Flash-MoE K-reduction: ~2x less streamed disk I/O at no quality "
@@ -101,7 +106,7 @@ def main():
         args.model, cache_budget_gb=args.cache_budget_gb, fast=args.fast,
         prefetch_workers=args.prefetch_workers, prefetch_ahead=args.prefetch_ahead,
         pin_file=args.pin_file, max_active_experts=args.max_active_experts,
-        use_page_cache=args.use_page_cache,
+        use_page_cache=args.use_page_cache, use_hotlist=args.use_hotlist,
     )
     print(f"[stream] loaded in {time.time() - t0:.1f}s | resident RSS={_rss_gb():.2f} GB")
 

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -27,6 +27,14 @@ from turboquant_mlx.kernels.polar_gather_qmv import polar_gather_qmv
 from turboquant_mlx.kernels.polar_multi_gather_qmv import polar_multi_gather_qmv
 from turboquant_mlx.layers.polar_switch_linear import _GATHER_MM_MIN_ROUTINGS
 
+# Startup hotlist preload: pinned experts may occupy at most this fraction of
+# the cache budget — the LRU set needs working room, or every subsequent miss
+# thrashes a sliver of remaining capacity.
+_PRELOAD_BUDGET_FRACTION = 0.6
+# Specs per preload batch (16 hot experts × 3 projections). Also the budget
+# check granularity: rank order caps the overshoot at one chunk.
+_PRELOAD_CHUNK = 48
+
 
 class ExpertCache:
     """Process-wide LRU cache of per-expert (weight, scales) mx.arrays, with
@@ -103,6 +111,9 @@ class ExpertCache:
         self._pin_keys: set = set(pin_keys or ())
         self._pinned: dict = {}              # (wkey, e) -> (w, s, nbytes)
         self._pin_hits = 0
+        # startup hotlist preload (ds4-style shipped hot-expert list)
+        self.preload_experts = 0             # expert-projections read by preload()
+        self.preload_bytes = 0               # bytes read by preload()
 
     # -- speculative prefetch -----------------------------------------
     def register_layer(self, layer_idx: int, proj_keys: list):
@@ -255,6 +266,52 @@ class ExpertCache:
             self._od[ck] = entry
         self.cur += entry[2]
 
+    def preload(self, pin_specs: list) -> tuple:
+        """Read pinned experts into memory *before the first token* (the
+        ds4-style shipped hotlist). ``pin_specs`` is
+        ``[(weight_key, scales_key, expert), ...]`` in hotness rank order.
+
+        Without this, a pinned expert still costs a critical-path miss the
+        first time the router picks it; preloading converts those cold-start
+        misses into coalesced batch reads at startup.
+
+        Pinned bytes are capped at ``_PRELOAD_BUDGET_FRACTION`` of the byte
+        budget so the LRU keeps working room. The cap is checked once per
+        ``_PRELOAD_CHUNK`` of specs — rank order means the hottest experts
+        load first — and everything past it is removed from the pin set
+        entirely, so it ages through the LRU like any other expert instead
+        of pinning lazily over the cap. Returns ``(n_loaded, n_dropped)``
+        in expert-projections.
+        """
+        cap = self.budget * _PRELOAD_BUDGET_FRACTION
+        pinned_bytes = sum(entry[2] for entry in self._pinned.values())
+        loaded = dropped = 0
+        for start in range(0, len(pin_specs), _PRELOAD_CHUNK):
+            if pinned_bytes >= cap:
+                for wkey, _skey, e in pin_specs[start:]:
+                    if (wkey, e) not in self._pinned:
+                        self._pin_keys.discard((wkey, e))
+                        dropped += 1
+                break
+            by_proj: dict = {}
+            for wkey, skey, e in pin_specs[start:start + _PRELOAD_CHUNK]:
+                if (wkey, e) in self._pinned or (wkey, e) in self._od:
+                    continue
+                by_proj.setdefault((wkey, skey), []).append((wkey, skey, e))
+            for pairs in by_proj.values():
+                # keep gather's coalescing stats clean — preload reads are
+                # accounted in the preload_* counters instead
+                runs0, reads0 = self.read_runs, self.expert_reads
+                entries = self._load_coalesced(pairs)
+                self.read_runs, self.expert_reads = runs0, reads0
+                for ck, entry in entries.items():
+                    self._insert(ck, entry)
+                    pinned_bytes += entry[2]
+                    self.preload_bytes += entry[2]
+                    self.preload_experts += 1
+                    loaded += 1
+        return loaded, dropped
+
     def gather(self, wkey: str, skey: str, experts: list[int]):
         """Return stacked (n, out, packed) weight + (n, out, ng) scales for
         ``experts`` (in the given order)."""
@@ -337,6 +394,8 @@ class ExpertCache:
             "prefetch_dropped": self.prefetch_dropped,
             "resident_experts": len(self._od) + len(self._pinned),
             "pinned_experts": len(self._pinned),
+            "preload_experts": self.preload_experts,
+            "preload_gb": self.preload_bytes / 1e9,
             "resident_gb": self.cur / 1e9,
             "bytes_read_gb": self.bytes_read / 1e9,
             "bytes_prefetched_gb": self.bytes_prefetched / 1e9,

--- a/tests/test_stream_hotlist.py
+++ b/tests/test_stream_hotlist.py
@@ -8,6 +8,7 @@ Uses the FakeReader from test_stream_cache so no model or disk is involved.
 import json
 
 import numpy as np
+import pytest
 
 import turboquant_mlx.stream.streaming_switch as ss
 from turboquant_mlx.stream.loader import _find_hotlist, _load_pin_spec
@@ -102,6 +103,20 @@ def test_load_pin_spec_preserves_rank_order_and_dedups(tmp_path):
     pin_layers, pin_order = _load_pin_spec(str(f))
     assert pin_order == [(4, 17), (0, 3), (2, 9)]  # file order, deduped
     assert pin_layers == {4: {17}, 0: {3}, 2: {9}}
+
+
+@pytest.mark.parametrize("payload", [
+    json.dumps([[0, 1]]),                    # flat list, not {"pin": ...}
+    json.dumps({"perm": {"0": [1, 2]}}),     # wrong key
+    json.dumps({"pin": [[0]]}),              # entry too short
+    json.dumps({"pin": [[0, "x"]]}),         # non-int expert
+    json.dumps({"pin": [0, 1]}),             # entries not pairs
+])
+def test_load_pin_spec_rejects_malformed(tmp_path, payload):
+    f = tmp_path / "pin.json"
+    f.write_text(payload)
+    with pytest.raises(ValueError):
+        _load_pin_spec(str(f))
 
 
 def test_preload_stats_exposed():

--- a/tests/test_stream_hotlist.py
+++ b/tests/test_stream_hotlist.py
@@ -8,7 +8,6 @@ Uses the FakeReader from test_stream_cache so no model or disk is involved.
 import json
 
 import numpy as np
-import mlx.core as mx
 
 import turboquant_mlx.stream.streaming_switch as ss
 from turboquant_mlx.stream.loader import _find_hotlist, _load_pin_spec

--- a/tests/test_stream_hotlist.py
+++ b/tests/test_stream_hotlist.py
@@ -1,0 +1,116 @@
+"""Tests for the shipped hot-expert list (ds4 idea #6): startup preload of
+pinned experts into the ExpertCache, plus the loader-side hotlist discovery
+and rank-order-preserving pin-spec parsing.
+
+Uses the FakeReader from test_stream_cache so no model or disk is involved.
+"""
+
+import json
+
+import numpy as np
+import mlx.core as mx
+
+import turboquant_mlx.stream.streaming_switch as ss
+from turboquant_mlx.stream.loader import _find_hotlist, _load_pin_spec
+from turboquant_mlx.stream.streaming_switch import ExpertCache
+
+from tests.test_stream_cache import FakeReader
+
+
+def _specs(layers=(0, 1), experts=(3, 1, 5), projs=("gate", "up", "down")):
+    """Hotlist-ordered specs: for each (layer, expert) pair, one spec per
+    projection — the exact shape load_streaming feeds to preload()."""
+    specs, keys = [], set()
+    for l in layers:
+        for e in experts:
+            for proj in projs:
+                wkey = f"L{l}.{proj}.weight"
+                skey = f"L{l}.{proj}.scales"
+                specs.append((wkey, skey, e))
+                keys.add((wkey, e))
+    return specs, keys
+
+
+def test_preload_pins_everything_and_gather_never_misses():
+    specs, keys = _specs()
+    reader = FakeReader()
+    cache = ExpertCache(reader, budget_bytes=10**9, prefetch_workers=1,
+                        pin_keys=keys)
+    n, dropped = cache.preload(specs)
+    assert n == len(specs)
+    assert dropped == 0
+    assert len(cache._pinned) == len(specs)
+    assert cache.preload_experts == len(specs)
+    assert cache.preload_bytes > 0
+    # gather stats stay clean: preload reads are not misses/coalescing stats
+    assert cache.misses == 0
+    assert cache.read_runs == 0 and cache.expert_reads == 0
+
+    calls_before = reader.read_calls
+    w, s = cache.gather("L0.gate.weight", "L0.gate.scales", [1, 3, 5])
+    assert reader.read_calls == calls_before  # served entirely from memory
+    assert cache.misses == 0
+    assert cache._pin_hits == 3
+
+    # byte-identity with a cold, unpinned cache
+    cold = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=1)
+    w2, s2 = cold.gather("L0.gate.weight", "L0.gate.scales", [1, 3, 5])
+    assert np.array_equal(np.array(w), np.array(w2))
+    assert np.array_equal(np.array(s), np.array(s2))
+
+
+def test_preload_budget_cap_keeps_hottest_and_unpins_rest(monkeypatch):
+    # One expert-projection from FakeReader = 8 uint32 + 8 f16 = 48 bytes.
+    # Budget 240 -> cap 144 -> 3 entries fit. Chunk of 1 spec makes the cap
+    # check exact so the test is deterministic.
+    monkeypatch.setattr(ss, "_PRELOAD_CHUNK", 1)
+    specs, keys = _specs(layers=(0,), experts=(9, 2, 7, 4, 1, 0), projs=("gate",))
+    cache = ExpertCache(FakeReader(), budget_bytes=240, prefetch_workers=1,
+                        pin_keys=set(keys))
+    n, dropped = cache.preload(specs)
+    assert n == 3 and dropped == 3
+    # rank order preserved: the first three (hottest) experts are pinned
+    assert set(cache._pinned) == {("L0.gate.weight", e) for e in (9, 2, 7)}
+    # the dropped ones are no longer pin keys — they age through the LRU
+    for e in (4, 1, 0):
+        assert ("L0.gate.weight", e) not in cache._pin_keys
+    cache.gather("L0.gate.weight", "L0.gate.scales", [4])
+    assert ("L0.gate.weight", 4) in cache._od
+
+
+def test_preload_skips_already_resident():
+    specs, keys = _specs(layers=(0,), experts=(1, 2), projs=("gate",))
+    reader = FakeReader()
+    cache = ExpertCache(reader, budget_bytes=10**9, prefetch_workers=1,
+                        pin_keys=keys)
+    n1, _ = cache.preload(specs)
+    calls = reader.read_calls
+    n2, _ = cache.preload(specs)  # second preload is a no-op
+    assert n1 == 2 and n2 == 0
+    assert reader.read_calls == calls
+
+
+def test_find_hotlist(tmp_path):
+    assert _find_hotlist(str(tmp_path)) is None
+    hot = tmp_path / "hot_experts.json"
+    hot.write_text(json.dumps({"pin": [[0, 3]]}))
+    assert _find_hotlist(str(tmp_path)) == str(hot)
+
+
+def test_load_pin_spec_preserves_rank_order_and_dedups(tmp_path):
+    f = tmp_path / "pin.json"
+    f.write_text(json.dumps({"pin": [[4, 17], [0, 3], [4, 17], [2, 9]]}))
+    pin_layers, pin_order = _load_pin_spec(str(f))
+    assert pin_order == [(4, 17), (0, 3), (2, 9)]  # file order, deduped
+    assert pin_layers == {4: {17}, 0: {3}, 2: {9}}
+
+
+def test_preload_stats_exposed():
+    specs, keys = _specs(layers=(0,), experts=(1,), projs=("gate",))
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=1,
+                        pin_keys=keys)
+    cache.preload(specs)
+    st = cache.stats()
+    assert st["preload_experts"] == 1
+    assert st["preload_gb"] > 0
+    assert st["pinned_experts"] == 1


### PR DESCRIPTION
DwarfStar (ds4) idea #6: a streaming MoE model repo can now ship its own routing profile, and the loader turns it into a warm start.

## What

- **\`ExpertCache.preload(pin_specs)\`** — reads pinned experts into memory *before the first token*. Previously a pinned expert still cost a critical-path miss the first time the router picked it; now the pin list arrives as coalesced batch reads at startup. Rank-ordered (hottest first) and capped at 60% of \`--cache-budget-gb\` so the LRU keeps working room; experts past the cap are un-pinned entirely and age through the LRU like any other. Preload reads are tracked in new \`preload_experts\` / \`preload_gb\` stats so the gather-path miss/coalescing metrics stay honest.
- **\`hot_experts.json\` auto-discovery** — \`load_streaming\` picks up a pin spec shipped in the model directory (same schema as \`calibrate_experts.py analyze\`'s \`pin.json\`), so an HF repo can carry its profile and \`--cache-budget-gb\` alone gets warm-start behavior. \`--no-hotlist\` opts out; explicit \`--pin-file\` still overrides. Wired in \`stream_generate\` and \`turboquant-serve\`.
- \`calibrate_experts.py analyze\` now prints the ship-it hint; pin-spec parsing preserves the file's hotness rank order (dedup included) so a budget-capped preload keeps the hottest experts.

## Validation (Qwen3.6-35B-A3B ternary, 2 GB budget, \`--no-page-cache\`, temp 0, 64 tok)

Profile: 1,500 hot experts (1.1 GB) covering **70% of routed selections** from an 8-prompt calibration trace.

| metric | no hotlist | shipped hotlist |
|---|---|---|
| preload | — | 1.10 GB in 0.3 s |
| effective hit rate | 74.0% | **81.7%** |
| critical-path disk reads | 2.3 GB | **1.6 GB (−30%)** |
| generation | 23.9 tok/s | 24.6 tok/s |

Output byte-identical between runs (greedy). The −30% critical-path reads is the durable win — on the disk-bound mini/122B streaming case those reads are the wall.

## Tests

6 new unit tests (preload pin/serve without misses, budget-cap keeps hottest + un-pins rest, idempotent re-preload, hotlist discovery, rank-order parsing, stats). Full suite: 196 passed.