### PR TITLE
feat: auto cache budget + wired-memory expert cache for streaming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Auto cache budget + wired memory for streaming** (ds4-style):
+  `--cache-budget-gb auto` sizes the expert cache from the machine — 80% of
+  Metal's max recommended working set, minus the resident (non-expert)
+  weights (computed from the safetensors index, nothing loaded), minus a
+  2 GB KV/prefill reserve, clamped to [0.5 GB, all experts]. On a 16 GB mini
+  with the 122B ternary this lands on ~4.2 GB, matching the hand-tuned
+  known-good value. `--wire-memory` (opt-in) raises MLX's wired-memory limit
+  to resident + budget + reserve so weights and the expert cache stay
+  resident under memory pressure — the MLX-native equivalent of ds4's
+  mlock'd cache chunks. Off by default: on a roomy machine the OS page cache
+  already keeps re-reads warm, and wiring takes memory from other apps.
+
 - **Shipped hot-expert list for streaming** (ds4-style): a model repo can
   now carry its own routing profile — drop `calibrate_experts.py`'s pin
   output into the model directory as `hot_experts.json` and the streaming

--- a/serve.py
+++ b/serve.py
@@ -34,7 +34,10 @@ Passing ``--cache-budget-gb`` routes the loader through
 ``turboquant_mlx.stream.load_streaming`` instead of the resident loader, so a
 MoE whose weights exceed RAM (e.g. a 122B on a 16 GB Mac mini) can be *served*
 over the OpenAI API — only the router-selected experts are paged from disk per
-token. The Flash-MoE streaming levers come with it: ``--max-active-experts``
+token. ``--cache-budget-gb auto`` sizes the expert cache from the machine
+(80% of Metal's recommended working set minus the resident weights and a KV
+reserve), and ``--wire-memory`` keeps weights + cache resident under memory
+pressure (for constrained machines). The Flash-MoE streaming levers come with it: ``--max-active-experts``
 (K-reduction, default 4 → ~2x less disk I/O) and ``--use-page-cache`` /
 ``--no-page-cache`` (auto by model-size-vs-RAM; trust-OS is ~2.4x faster decode
 when the model fits free RAM, F_NOCACHE otherwise). Hot-expert pinning:
@@ -211,9 +214,11 @@ def _patch_loader(stream_config=None) -> None:
             )
 
         if stream_config is not None:
+            bud = stream_config["cache_budget_gb"]
+            bud_s = bud if isinstance(bud, str) else f"{bud} GB"
             sys.stderr.write(
                 f"[turboquant-serve] Streaming TurboQuant model from {model_path} "
-                f"(cache_budget={stream_config['cache_budget_gb']} GB)\n"
+                f"(cache_budget={bud_s})\n"
             )
             # load_streaming returns (model, tok, cache); the cache stays alive
             # via the StreamingSwitchLinear modules that reference it.
@@ -288,7 +293,10 @@ def _extract_stream_args(argv):
     flags are no-ops without a budget (and are documented as such).
     """
     parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
-    parser.add_argument("--cache-budget-gb", type=float, default=None)
+    # str, not float: accepts 'auto' (machine-sized budget); load_streaming
+    # parses numeric strings itself.
+    parser.add_argument("--cache-budget-gb", type=str, default=None)
+    parser.add_argument("--wire-memory", action="store_true")
     parser.add_argument("--max-active-experts", type=int, default=4)
     parser.add_argument("--prefetch-workers", type=int, default=8)
     parser.add_argument("--prefetch-ahead", type=int, default=0)
@@ -304,14 +312,27 @@ def _extract_stream_args(argv):
     if ns.cache_budget_gb is None:
         return None, remaining
 
+    budget = ns.cache_budget_gb
+    if budget.lower() == "auto":
+        budget = "auto"
+    else:
+        try:
+            budget = float(budget)
+        except ValueError:
+            raise SystemExit(
+                f"--cache-budget-gb expects a number of GB or 'auto', "
+                f"got {budget!r}"
+            ) from None
+
     stream_config = dict(
-        cache_budget_gb=ns.cache_budget_gb,
+        cache_budget_gb=budget,
         max_active_experts=ns.max_active_experts,
         use_page_cache=ns.use_page_cache,
         prefetch_workers=ns.prefetch_workers,
         prefetch_ahead=ns.prefetch_ahead,
         pin_file=ns.pin_file,
         use_hotlist=ns.use_hotlist,
+        wire_memory=ns.wire_memory,
     )
     return stream_config, remaining
 
@@ -667,11 +688,13 @@ def main() -> None:
     if stream_config is not None:
         pc = "auto" if stream_config["use_page_cache"] is None else (
             "on" if stream_config["use_page_cache"] else "off")
+        bud = stream_config["cache_budget_gb"]
+        bud_s = bud if isinstance(bud, str) else f"{bud} GB"
+        wired = ", wire_memory=on" if stream_config["wire_memory"] else ""
         sys.stderr.write(
-            f"[turboquant-serve] Expert streaming: cache_budget="
-            f"{stream_config['cache_budget_gb']} GB, "
+            f"[turboquant-serve] Expert streaming: cache_budget={bud_s}, "
             f"max_active_experts={stream_config['max_active_experts']}, "
-            f"page_cache={pc} (single-user; use --prompt-concurrency 1)\n"
+            f"page_cache={pc}{wired} (single-user; use --prompt-concurrency 1)\n"
         )
     if kv_config is not None:
         if kv_config["tq_bits"] is not None:

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -41,15 +41,22 @@ def _total_ram_bytes() -> int:
         return int(subprocess.check_output(["sysctl", "-n", "hw.memsize"]))
 
 
+def _model_file_bytes(model_path: str) -> int:
+    """Total bytes of the model's safetensors (0 when none are found).
+
+    glob.escape so a model_path with [ ] etc. still matches."""
+    files = glob.glob(os.path.join(glob.escape(model_path), "model*.safetensors"))
+    return sum(os.path.getsize(f) for f in files)
+
+
 def _auto_page_cache(model_path: str) -> bool:
     """True iff the model's safetensors fit comfortably in RAM (page cache helps)."""
     try:
-        # glob.escape so a model_path with [ ] etc. still matches; no files ->
-        # we can't size the model, so fail safe to F_NOCACHE rather than 0 bytes.
-        files = glob.glob(os.path.join(glob.escape(model_path), "model*.safetensors"))
-        if not files:
+        # No files -> we can't size the model, so fail safe to F_NOCACHE
+        # rather than treating it as 0 bytes.
+        model_bytes = _model_file_bytes(model_path)
+        if not model_bytes:
             return False
-        model_bytes = sum(os.path.getsize(f) for f in files)
         ram = _total_ram_bytes()
     except Exception:
         return False  # any uncertainty -> the always-safe F_NOCACHE path
@@ -88,6 +95,44 @@ def _cap_active_experts(layers, max_active: int) -> None:
         print(f"[stream] K-reduction: capped router top_k {changed[0]}->{min(changed[0], max_active)} "
               f"on {len(changed)} MoE blocks (~2x less disk I/O; pass "
               f"max_active_experts=0 / --max-active-experts 0 to use native routing)")
+
+
+# Auto cache budget (ds4-style): size the expert cache from what the GPU can
+# actually keep resident — a fraction of Metal's max recommended working set,
+# minus the resident (non-expert) weights, minus a reserve for the KV cache
+# and the transient prefill workspace — instead of a fixed guess.
+_AUTO_WSS_FRACTION = 0.8
+_AUTO_RESERVE_BYTES = int(2.0e9)
+_AUTO_MIN_BUDGET_BYTES = int(0.5e9)
+
+_SAFETENSORS_ITEMSIZE = {"U32": 4, "I32": 4, "F32": 4, "F16": 2, "BF16": 2,
+                         "U8": 1}
+
+
+def _streamed_expert_bytes(reader) -> int:
+    """Total on-disk bytes of the tensors the streaming swap pages from disk
+    (MoE switch_mlp weight/scales) — everything else stays resident."""
+    total = 0
+    for key, loc in reader._index.items():
+        if "switch_mlp" not in key:
+            continue
+        if not (key.endswith(".weight") or key.endswith(".scales")):
+            continue
+        n = 1
+        for d in loc.shape:
+            n *= d
+        total += n * _SAFETENSORS_ITEMSIZE.get(loc.dtype, 4)
+    return total
+
+
+def _auto_cache_budget(model_bytes: int, expert_bytes: int,
+                       wss_bytes: int) -> int:
+    """Pure budget math (unit-testable without a model): what's left of the
+    working-set fraction after the resident weights and the reserve, clamped
+    to [floor, all experts] — a budget past every expert buys nothing."""
+    resident = max(0, model_bytes - expert_bytes)
+    budget = int(_AUTO_WSS_FRACTION * wss_bytes) - resident - _AUTO_RESERVE_BYTES
+    return max(_AUTO_MIN_BUDGET_BYTES, min(budget, expert_bytes))
 
 
 # A model repo may ship its own routing profile alongside the weights (the
@@ -136,14 +181,23 @@ def _load_pin_spec(pin_file: str) -> "tuple[dict, list]":
     return pin_layers, pin_order
 
 
-def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
+def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
                    prefetch_workers: int = 8, prefetch_ahead: int = 0,
                    pin_file: str | None = None, max_active_experts: int = 4,
                    use_page_cache: bool | None = None, use_hotlist: bool = True,
-                   preload_pins: bool = True):
+                   preload_pins: bool = True, wire_memory: bool = False):
     """Returns (model, tokenizer, cache).
 
-    cache_budget_gb bounds total resident expert memory (LRU-evicted).
+    cache_budget_gb bounds total resident expert memory (LRU-evicted). Pass
+    the string ``"auto"`` to size it from the machine instead: 80% of Metal's
+    max recommended working set, minus the resident (non-expert) weights,
+    minus a 2 GB reserve for KV + prefill workspace, clamped to
+    [0.5 GB, all experts].
+    wire_memory=True (--wire-memory) additionally raises MLX's wired-memory
+    limit to resident + budget + reserve (capped at the working set) so the
+    weights and the expert cache stay resident under memory pressure — the
+    ds4 mlock idea. Opt-in: on a roomy machine the OS page cache already
+    keeps re-reads warm, and wiring takes memory from other apps.
     prefetch_workers parallelizes per-layer expert reads (1 = serial baseline).
     prefetch_ahead speculatively prefetches this many upcoming layers' experts
     (predicted from the previous token's routing); 0 disables prefetch.
@@ -169,6 +223,33 @@ def load_streaming(model_path, cache_budget_gb: float = 3.0, fast: bool = False,
         use_page_cache = _auto_page_cache(local_path)
     model, tok = load_turboquant(local_path, lazy=True, fast=fast)
     reader = SafetensorsExpertReader(local_path, use_page_cache=use_page_cache)
+
+    expert_bytes = _streamed_expert_bytes(reader)
+    resident_bytes = max(0, _model_file_bytes(local_path) - expert_bytes)
+    auto = isinstance(cache_budget_gb, str) and cache_budget_gb.lower() == "auto"
+    if isinstance(cache_budget_gb, str) and not auto:
+        cache_budget_gb = float(cache_budget_gb)
+    if auto:
+        wss = mx.device_info()["max_recommended_working_set_size"]
+        budget_bytes = _auto_cache_budget(resident_bytes + expert_bytes,
+                                          expert_bytes, wss)
+        cache_budget_gb = budget_bytes / 1e9
+        print(f"[stream] auto budget: {_AUTO_WSS_FRACTION:.0%} × working set "
+              f"{wss / 1e9:.1f} GB − resident {resident_bytes / 1e9:.1f} GB − "
+              f"reserve {_AUTO_RESERVE_BYTES / 1e9:.1f} GB -> cache "
+              f"{cache_budget_gb:.1f} GB (experts on disk: "
+              f"{expert_bytes / 1e9:.1f} GB)")
+    if wire_memory:
+        wss = mx.device_info()["max_recommended_working_set_size"]
+        want = int(min(wss, resident_bytes + cache_budget_gb * 1e9
+                       + _AUTO_RESERVE_BYTES))
+        try:
+            mx.set_wired_limit(want)
+            print(f"[stream] wired-memory limit {want / 1e9:.1f} GB — weights "
+                  "and expert cache stay resident under memory pressure")
+        except Exception as exc:
+            print(f"[stream] could not set wired limit ({exc}); continuing unwired")
+
     cache = ExpertCache(
         reader, int(cache_budget_gb * 1e9),
         prefetch_workers=prefetch_workers,

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -39,6 +39,18 @@ def _rss_gb() -> float:
     return int(out) / 1024 / 1024
 
 
+def _budget_arg(v: str):
+    """--cache-budget-gb accepts a float or the literal 'auto'."""
+    if v.lower() == "auto":
+        return "auto"
+    try:
+        return float(v)
+    except ValueError:
+        raise argparse.ArgumentTypeError(
+            f"expected a number of GB or 'auto', got {v!r}"
+        ) from None
+
+
 def main():
     p = argparse.ArgumentParser(
         description="Stream-generate from a TurboQuant MoE model (experts paged from disk)."
@@ -47,8 +59,14 @@ def main():
     p.add_argument("--prompt", default="Why is the sky blue?")
     p.add_argument("--max-tokens", type=int, default=256)
     p.add_argument("--temp", type=float, default=0.7)
-    p.add_argument("--cache-budget-gb", type=float, default=3.0,
-                   help="Max resident expert memory (LRU-evicted). Lower = less RAM, more disk reads.")
+    p.add_argument("--cache-budget-gb", type=_budget_arg, default=3.0,
+                   help="Max resident expert memory (LRU-evicted). Lower = less RAM, "
+                        "more disk reads. Pass 'auto' to size it from the machine "
+                        "(80%% of Metal's working set minus resident weights).")
+    p.add_argument("--wire-memory", action="store_true",
+                   help="Raise MLX's wired-memory limit so weights + expert cache "
+                        "stay resident under memory pressure (for constrained "
+                        "machines; roomy ones don't need it).")
     p.add_argument("--prefetch-workers", type=int, default=8,
                    help="Threads for parallel per-layer expert reads. 1 = serial baseline.")
     p.add_argument("--prefetch-ahead", type=int, default=0,
@@ -107,6 +125,7 @@ def main():
         prefetch_workers=args.prefetch_workers, prefetch_ahead=args.prefetch_ahead,
         pin_file=args.pin_file, max_active_experts=args.max_active_experts,
         use_page_cache=args.use_page_cache, use_hotlist=args.use_hotlist,
+        wire_memory=args.wire_memory,
     )
     print(f"[stream] loaded in {time.time() - t0:.1f}s | resident RSS={_rss_gb():.2f} GB")
 

--- a/tests/test_stream_autobudget.py
+++ b/tests/test_stream_autobudget.py
@@ -1,0 +1,95 @@
+"""Tests for the auto cache budget + wired-memory flags (ds4 idea #5).
+
+The budget math is a pure function, so it tests without a model; the CLI
+plumbing is tested through serve's argv extractor and stream_generate's
+argparse type.
+"""
+
+import argparse
+
+import pytest
+
+from turboquant_mlx.stream.loader import (
+    _AUTO_MIN_BUDGET_BYTES,
+    _AUTO_RESERVE_BYTES,
+    _AUTO_WSS_FRACTION,
+    _auto_cache_budget,
+    _streamed_expert_bytes,
+)
+
+
+def test_auto_budget_mini_case():
+    # 16 GB mini serving the 122B ternary: model ~31 GB of which ~28 GB is
+    # experts, working set ~11.5 GB. Expected: 0.8*11.5 - 3 - 2 = ~4.2 GB —
+    # matching the hand-tuned known-good --cache-budget-gb 4.
+    b = _auto_cache_budget(model_bytes=31_000_000_000,
+                           expert_bytes=28_000_000_000,
+                           wss_bytes=11_500_000_000)
+    assert b == int(0.8 * 11_500_000_000) - 3_000_000_000 - _AUTO_RESERVE_BYTES
+    assert 3.5e9 < b < 5e9
+
+
+def test_auto_budget_clamps_to_all_experts_on_roomy_machine():
+    # 64 GB box streaming a 9.4 GB model: the working-set slice dwarfs the
+    # experts, so the budget caps at "every expert resident".
+    b = _auto_cache_budget(model_bytes=9_400_000_000,
+                           expert_bytes=8_600_000_000,
+                           wss_bytes=55_000_000_000)
+    assert b == 8_600_000_000
+
+
+def test_auto_budget_floor_when_squeezed():
+    # Pathologically tight machine: never go below the floor (the LRU needs
+    # some working room to make progress at all).
+    b = _auto_cache_budget(model_bytes=31_000_000_000,
+                           expert_bytes=28_000_000_000,
+                           wss_bytes=6_000_000_000)
+    assert b == _AUTO_MIN_BUDGET_BYTES
+
+
+def test_streamed_expert_bytes_counts_only_switch_tensors():
+    class Loc:
+        def __init__(self, dtype, shape):
+            self.dtype = dtype
+            self.shape = shape
+
+    class R:
+        _index = {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": Loc("U32", (4, 8, 2)),
+            "model.layers.0.mlp.switch_mlp.gate_proj.scales": Loc("F16", (4, 8, 1)),
+            "model.layers.0.mlp.switch_mlp.gate_proj.codebook": Loc("F16", (3,)),
+            "model.layers.0.self_attn.q_proj.weight": Loc("U32", (64, 64)),
+        }
+
+    assert _streamed_expert_bytes(R()) == 4 * 8 * 2 * 4 + 4 * 8 * 1 * 2
+
+
+def test_serve_extractor_accepts_auto_and_wire_memory():
+    from turboquant_mlx.serve import _extract_stream_args
+
+    cfg, rem = _extract_stream_args(
+        ["--cache-budget-gb", "auto", "--wire-memory", "--model", "m"])
+    assert cfg["cache_budget_gb"] == "auto"
+    assert cfg["wire_memory"] is True
+    assert rem == ["--model", "m"]
+    cfg, _ = _extract_stream_args(["--cache-budget-gb", "4"])
+    assert cfg["cache_budget_gb"] == 4.0  # numerics parsed in the extractor
+    assert cfg["wire_memory"] is False
+    cfg, _ = _extract_stream_args(["--model", "m"])
+    assert cfg is None  # no budget -> resident loader
+    with pytest.raises(SystemExit):
+        _extract_stream_args(["--cache-budget-gb", "lots"])
+
+
+def test_stream_generate_budget_arg_type():
+    from turboquant_mlx.stream.stream_generate import _budget_arg
+
+    assert _budget_arg("auto") == "auto"
+    assert _budget_arg("AUTO") == "auto"
+    assert _budget_arg("3.5") == 3.5
+    with pytest.raises(argparse.ArgumentTypeError):
+        _budget_arg("lots")
+
+
+def test_wss_fraction_sane():
+    assert 0.5 <= _AUTO_WSS_FRACTION <= 0.9


### PR DESCRIPTION
DwarfStar (ds4) idea #5: size the streaming expert cache from the machine instead of a guess, and optionally wire it against memory pressure.

## What

- **\`--cache-budget-gb auto\`** — budget = 80% of Metal's max recommended working set (\`mx.device_info()\`), minus the resident (non-expert) weight bytes (computed from the safetensors index without loading anything), minus a 2 GB reserve for KV + transient prefill workspace, clamped to [0.5 GB, all experts]. Numeric values keep working exactly as before; a bad value now gets a clean error from serve's extractor instead of a deep failure.
- **\`--wire-memory\`** (opt-in) — raises MLX's wired-memory limit (\`mx.set_wired_limit\`) to resident + budget + reserve, capped at the working set, so weights and the expert cache stay resident under memory pressure. This is the MLX-native equivalent of ds4's mlock'd cache chunks: our cached experts are Metal buffers, so \`mlock(2)\` doesn't apply, but the wired limit achieves the same guarantee through the allocator. Off by default — the trust-OS A/B (0.11) showed the page cache is a *feature* on roomy machines, and wiring takes memory from other apps.

## Validation

- **35B ternary, auto + wire:** working set 55.7 GB − resident 1.9 GB − reserve 2 GB → clamped to all 7.5 GB of experts; wired limit 11.4 GB accepted; clean generation.
- **122B ternary, auto:** resident 3.9 GB → clamped to all 27.0 GB of experts; clean generation.
- **Mini case (unit-tested):** 11.5 GB working set + the 122B's 31 GB/28 GB split → **4.2 GB**, matching the hand-tuned known-good \`--cache-budget-gb 4\` from the mini streaming-serve work.

## Tests

8 new unit tests (budget math: mini/roomy-clamp/floor; expert-byte accounting; serve extractor: auto + wire-memory + numeric + garbage rejection; stream_generate arg type). Full suite: 208 passed.