### PR TITLE
serve: 16 GB mini fixes — Metal buffer-cache limit + mid-prefill disk-cache checkpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Metal buffer-cache limit on `turboquant-serve`**
+  (`--metal-cache-limit-gb`, default `auto`): MLX's GPU buffer reuse cache
+  is unbounded by default, and a long chunked prefill allocates attention
+  workspace with a new, larger shape every chunk — so stale buffers
+  accumulate ~80 MB per 1K prompt tokens instead of being reused. Measured
+  on a 16 GB Mac mini serving the resident 12.6 GB down4 35B: active memory
+  flat at ~13.2 GB, buffer cache 1.9 → 3.5 GB, hard Metal OOM crash at
+  14K/21K prompt tokens. `auto` caps the cache via `mx.set_cache_limit`
+  right after the model loads whenever working-set headroom is under 8 GB
+  (roomy machines keep the fast unbounded default); with the cap the same
+  21K-token prefill runs flat at ~13.5 GB total. Pass a number (GB) to
+  force a cap or `off` to disable. On 16 GB machines pair with
+  `--prefill-step-size 256` — the *per-chunk* transient workspace scales
+  with chunk size, and mlx-lm's default of 2048 OOMs tight boxes on the
+  first chunk.
+
 - **Auto cache budget + wired memory for streaming** (ds4-style):
   `--cache-budget-gb auto` sizes the expert cache from the machine — 80% of
   Metal's max recommended working set, minus the resident (non-expert)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Mid-prefill disk-cache checkpoints** (`--disk-cache`, on by default;
+  `--disk-cache-no-prefill-checkpoints` opts out): the disk prompt cache now
+  also checkpoints every `--disk-cache-save-every` tokens *during* prompt
+  processing, not just after the request completes. This fixes a measured
+  total-reuse failure on hybrid GDN/Mamba models: the end-of-request
+  checkpoint includes the generated assistant tail, and chat templates
+  re-render that tail differently on the next turn (Qwen's empty `<think>`
+  block appears at generation time but not in history), so the checkpoint is
+  never a strict prefix of turn N+1 and the non-trimmable cache gets **zero**
+  reuse — live on a 16 GB mini, a 21,250-token turn 2 re-prefilled from
+  token 0 over a 4-token divergence. The mid-prefill ladder (1024, 2048, …)
+  restores from the newest checkpoint below the divergence, and a *crash*
+  mid-prefill resumes the same way instead of starting over.
+
 - **Metal buffer-cache limit on `turboquant-serve`**
   (`--metal-cache-limit-gb`, default `auto`): MLX's GPU buffer reuse cache
   is unbounded by default, and a long chunked prefill allocates attention

--- a/disk_prompt_cache.py
+++ b/disk_prompt_cache.py
@@ -26,6 +26,19 @@ citizen", adapted to mlx_lm's token-level prompt trie):
   checkpoint per ``save_every`` new tokens along a conversation lineage;
   when the new checkpoint is trimmable, stored strict-prefix checkpoints
   are superseded (deleted) — mirroring the trie's ``pop_prefixes``.
+- **Mid-prefill checkpoints** (``prefill_checkpoints``, default on): the
+  store also saves *during* a long prefill, every ``save_every`` tokens, by
+  wrapping the server's ``stream_generate`` progress callback. This is what
+  makes persistence useful for **non-trimmable** (hybrid GDN/Mamba) caches:
+  an end-of-request checkpoint includes the generated assistant tail, and
+  chat templates re-render that tail differently on the next turn (e.g.
+  Qwen's empty ``<think>`` block appears at generation time but not in
+  history), so the full checkpoint is never a strict prefix of turn N+1 and
+  a non-trimmable cache can't use it — measured live, a 21K-token turn got
+  0 reuse over a 4-token divergence. The mid-prefill ladder (1024, 2048, …)
+  gives non-trimmable caches trim semantics at ``save_every`` granularity:
+  the newest checkpoint at/below the divergence restores. It also makes a
+  *crash* mid-prefill resumable instead of starting from token 0.
 - Storage: one ``.safetensors`` per checkpoint via the same state/meta_state
   protocol as ``mlx_lm.models.cache.save_prompt_cache``, plus an
   ``index.json`` holding the token lists. ``None`` entries inside a cache's
@@ -236,6 +249,10 @@ class DiskPromptCache:
         Along one conversation lineage, only checkpoint after at least this
         many new tokens since the stored prefix (a restart loses at most this
         much prefill).
+    prefill_checkpoints : bool
+        Also checkpoint *during* prompt processing, every ``save_every``
+        tokens (see module docstring). Costs one state copy + background
+        write per stride; essential for non-trimmable (GDN/Mamba) caches.
     sync : bool
         Write checkpoints synchronously instead of on the background thread
         (used by tests).
@@ -243,12 +260,19 @@ class DiskPromptCache:
 
     def __init__(self, cache_dir, budget_gb: float = 10.0,
                  min_tokens: int = 512, save_every: int = 1024,
+                 prefill_checkpoints: bool = True,
                  sync: bool = False, log: TextIO = sys.stderr):
         self.dir = Path(cache_dir).expanduser()
         self.dir.mkdir(parents=True, exist_ok=True)
         self.budget_bytes = int(budget_gb * (1 << 30))
         self.min_tokens = int(min_tokens)
         self.save_every = int(save_every)
+        self.prefill_checkpoints = bool(prefill_checkpoints)
+        # (model_key, full_request_tokens, reused) of the in-flight request,
+        # recorded by the fetch wrapper so the stream_generate wrapper can
+        # save mid-prefill states under the right lineage. Single-stream
+        # serving is assumed (KV-quant already forces it).
+        self._active: Optional[tuple] = None
         self.log = log
         self._lock = threading.Lock()
         self._entries: Dict[str, _Entry] = {}
@@ -270,6 +294,7 @@ class DiskPromptCache:
 
         self._orig_fetch = None
         self._orig_insert = None
+        self._orig_stream_generate = None
 
     # -- index ------------------------------------------------------------
 
@@ -552,10 +577,16 @@ class DiskPromptCache:
 
         def fetch_nearest_cache(lru, model, tokens):
             cache, rest = store._orig_fetch(lru, model, tokens)
+            # Remember the in-flight request so mid-prefill checkpoints save
+            # under the right lineage (single-stream serving); updated below
+            # if a disk restore improves the reused count.
+            store._active = (model, list(tokens), len(tokens) - len(rest))
             try:
                 reused = len(tokens) - len(rest)
                 if store.restore_into(lru, model, tokens, reused):
                     cache, rest = store._orig_fetch(lru, model, tokens)
+                    store._active = (
+                        model, list(tokens), len(tokens) - len(rest))
             except Exception as e:  # persistence must never break serving
                 store.log.write(f"[disk-cache] restore skipped: {e}\n")
             return cache, rest
@@ -569,8 +600,55 @@ class DiskPromptCache:
 
         LRUPromptCache.fetch_nearest_cache = fetch_nearest_cache
         LRUPromptCache.insert_cache = insert_cache
+        if self.prefill_checkpoints:
+            self._install_prefill_checkpoints()
         atexit.register(self.flush)
         return self
+
+    def _install_prefill_checkpoints(self) -> None:
+        """Wrap ``mlx_lm.server.stream_generate`` so the prompt-progress
+        callback checkpoints the growing cache every ``save_every`` tokens.
+
+        The callback runs on the generation thread — the only thread that may
+        evaluate the cache's MLX graph — and fires *between* prefill chunks,
+        so the state copy never stacks on top of the per-chunk transient
+        workspace. ``maybe_save``'s stride/covered policy still applies; the
+        local stride guard just avoids taking the store lock every chunk.
+        """
+        import mlx_lm.server as _server_mod
+
+        store = self
+        self._orig_stream_generate = _server_mod.stream_generate
+
+        def stream_generate_with_checkpoints(*args, **kwargs):
+            active = store._active
+            cache_list = kwargs.get("prompt_cache")
+            orig_cb = kwargs.get("prompt_progress_callback")
+            if active is not None and cache_list is not None:
+                model, full_tokens, reused = active
+                last = {"n": reused}
+
+                def callback(processed, total):
+                    if orig_cb is not None:
+                        orig_cb(processed, total)
+                    covered = reused + processed
+                    # processed == total fires as decode starts; leave that
+                    # state to the end-of-request insert_cache save.
+                    if (processed < total
+                            and covered - last["n"] >= store.save_every):
+                        last["n"] = covered
+                        try:
+                            store.maybe_save(
+                                model, full_tokens[:covered], cache_list)
+                        except Exception as e:
+                            store.log.write(
+                                f"[disk-cache] prefill checkpoint "
+                                f"skipped: {e}\n")
+
+                kwargs["prompt_progress_callback"] = callback
+            return store._orig_stream_generate(*args, **kwargs)
+
+        _server_mod.stream_generate = stream_generate_with_checkpoints
 
     def uninstall(self) -> None:
         from mlx_lm.models.cache import LRUPromptCache
@@ -579,15 +657,22 @@ class DiskPromptCache:
             LRUPromptCache.fetch_nearest_cache = self._orig_fetch
         if self._orig_insert is not None:
             LRUPromptCache.insert_cache = self._orig_insert
+        if self._orig_stream_generate is not None:
+            import mlx_lm.server as _server_mod
+
+            _server_mod.stream_generate = self._orig_stream_generate
         self._orig_fetch = None
         self._orig_insert = None
+        self._orig_stream_generate = None
 
 
 def install(cache_dir, budget_gb: float = 10.0, min_tokens: int = 512,
-            save_every: int = 1024, log: TextIO = sys.stderr) -> DiskPromptCache:
+            save_every: int = 1024, prefill_checkpoints: bool = True,
+            log: TextIO = sys.stderr) -> DiskPromptCache:
     """Create a ``DiskPromptCache`` and patch it into ``mlx_lm.server``."""
     store = DiskPromptCache(
         cache_dir, budget_gb=budget_gb, min_tokens=min_tokens,
-        save_every=save_every, log=log,
+        save_every=save_every, prefill_checkpoints=prefill_checkpoints,
+        log=log,
     )
     return store.install()

--- a/disk_prompt_cache.py
+++ b/disk_prompt_cache.py
@@ -396,8 +396,16 @@ class DiskPromptCache:
                 if e.model_key != mk:
                     continue
                 lcp = _lcp(e.tokens, toks)
-                if lcp == n:
-                    return  # a stored checkpoint already covers these tokens
+                if lcp == n and (e.trimmable or e.tokens.size == n):
+                    # Covered: an identical checkpoint, or a longer trimmable
+                    # one (restorable for any prefix by trimming). A longer
+                    # NON-trimmable checkpoint covers nothing shorter — it can
+                    # never be trimmed down — so it must not suppress the
+                    # save: that left divergent follow-up turns with no
+                    # usable checkpoint at all (a stale full checkpoint from
+                    # a previous session silently swallowed the whole
+                    # mid-prefill ladder).
+                    return
                 if lcp == e.tokens.size:
                     best_prefix = max(best_prefix, lcp)
             if best_prefix and n - best_prefix < self.save_every:

--- a/disk_prompt_cache.py
+++ b/disk_prompt_cache.py
@@ -379,8 +379,16 @@ class DiskPromptCache:
     # -- save path ----------------------------------------------------------
 
     def maybe_save(self, model: Any, tokens: List[int],
-                   prompt_cache: List[Any]) -> None:
-        """Checkpoint ``prompt_cache`` if the save policy says it's worth it."""
+                   prompt_cache: List[Any], sync: bool = False) -> None:
+        """Checkpoint ``prompt_cache`` if the save policy says it's worth it.
+
+        ``sync=True`` writes inline instead of queueing. Mid-prefill
+        checkpoints must use it: a queued payload is a full state copy that
+        stays alive while the *next* prefill chunk computes, and copy +
+        chunk workspace stacked is what re-OOMed a 16 GB machine at 19K/21K
+        tokens. Written inline, the copy exists only between chunks (where
+        the transient workspace is idle) and is freed before the next chunk.
+        """
         toks = np.asarray(tokens, dtype=np.int64)
         n = int(toks.size)
         if n < self.min_tokens:
@@ -438,7 +446,7 @@ class DiskPromptCache:
             trimmable=trimmable, created=now, last_used=now,
         )
         job = (mk, toks, data, meta, trimmable)
-        if self._sync:
+        if self._sync or sync:
             self._do_save(*job)
         else:
             with self._lock:
@@ -647,7 +655,8 @@ class DiskPromptCache:
                         last["n"] = covered
                         try:
                             store.maybe_save(
-                                model, full_tokens[:covered], cache_list)
+                                model, full_tokens[:covered], cache_list,
+                                sync=True)
                         except Exception as e:
                             store.log.write(
                                 f"[disk-cache] prefill checkpoint "

--- a/serve.py
+++ b/serve.py
@@ -103,6 +103,23 @@ strings (the free-text payloads, where greedy causes repetition) and of the
 decision to emit a tool call at all. Tags are configurable via
 ``--tool-syntax-tags "<open>,</close>"`` for non-Hermes templates.
 
+Metal buffer-cache limit (--metal-cache-limit-gb, default: auto)
+----------------------------------------------------------------
+MLX keeps freed GPU buffers in a reuse cache that is unbounded by default.
+During a long chunked prefill the attention workspace has a new, larger
+shape every chunk, so stale buffers accumulate instead of being reused:
+measured on a 21K-token prompt against a resident 12.6 GB MoE, the cache
+grew ~80 MB per 1K prompt tokens (1.9 → 3.5 GB) while *active* memory
+stayed flat — a hard Metal OOM crash mid-prefill on a 16 GB machine. The
+default ``auto`` caps the cache via ``mx.set_cache_limit`` right after the
+model loads whenever working-set headroom (recommended working set minus
+resident bytes) is under 8 GB; roomy machines are left untouched (the
+unbounded cache is fastest). Pass a number (GB) to force a specific cap,
+or ``off`` to disable. On 16 GB machines pair this with a smaller
+``--prefill-step-size`` (256–512): the *per-chunk* transient workspace
+scales with chunk size, and the mlx_lm default of 2048 also OOMs tight
+boxes on its first chunk.
+
 Prefill keepalive (long cold prefills behind a proxy)
 -----------------------------------------------------
 A streaming agentic client (Claude Code via claude-code-router) aborts a
@@ -158,7 +175,93 @@ def _check_mlx_lm_version() -> None:
         sys.exit(1)
 
 
-def _patch_loader(stream_config=None) -> None:
+# MLX's GPU buffer reuse cache is unbounded by default. A long chunked
+# prefill allocates attention workspace with a new, larger shape every chunk,
+# so stale buffers accumulate instead of being reused: measured on a 21K-token
+# prompt against a resident 12.6 GB MoE, active memory stayed flat (~13.2 GB)
+# while the cache grew 1.9 -> 3.5 GB, crossing a 16 GB machine's limit
+# mid-prefill (hard Metal OOM). Capping the cache holds the same prefill to a
+# flat ~13.5 GB total. Roomy machines keep the unbounded default (fastest).
+_CACHE_LIMIT_RESERVE_BYTES = 2 * 1024**3       # transient prefill workspace
+_CACHE_LIMIT_MIN_BYTES = 256 * 1024**2         # keep decode-step buffer reuse
+_CACHE_LIMIT_AMPLE_HEADROOM_BYTES = 8 * 1024**3
+
+
+def _auto_metal_cache_limit(wss_bytes: int, active_bytes: int) -> int | None:
+    """Buffer-cache cap for tight machines; None = leave MLX's default.
+
+    headroom = recommended working set - resident model bytes. With >= 8 GB
+    of headroom the unbounded cache never threatens the limit. Below that,
+    cap the cache to the headroom minus a ~2 GB reserve for the transient
+    per-chunk prefill workspace, floored at 256 MB so the per-token decode
+    buffers (a handful of fixed shapes) still get reused.
+    """
+    headroom = wss_bytes - active_bytes
+    if headroom >= _CACHE_LIMIT_AMPLE_HEADROOM_BYTES:
+        return None
+    return max(_CACHE_LIMIT_MIN_BYTES, int(headroom - _CACHE_LIMIT_RESERVE_BYTES))
+
+
+def _apply_metal_cache_limit(mode) -> None:
+    """Apply the Metal buffer-cache cap. Runs right after the model loads —
+    the auto formula needs the measured resident (active) bytes."""
+    import mlx.core as mx
+
+    if mode == "auto":
+        wss = mx.device_info()["max_recommended_working_set_size"]
+        active = mx.get_active_memory()
+        limit = _auto_metal_cache_limit(wss, active)
+        if limit is None:
+            sys.stderr.write(
+                f"[turboquant-serve] Metal buffer-cache limit: off — ample "
+                f"headroom (working set {wss / 1024**3:.1f} GiB, resident "
+                f"{active / 1024**3:.1f} GiB)\n"
+            )
+            return
+        why = (f"auto: working set {wss / 1024**3:.1f} GiB, resident "
+               f"{active / 1024**3:.1f} GiB")
+    else:
+        limit = int(mode * 1024**3)
+        why = "explicit"
+    mx.set_cache_limit(limit)
+    sys.stderr.write(
+        f"[turboquant-serve] Metal buffer-cache limit: "
+        f"{limit / 1024**3:.2f} GiB ({why}) — bounds reuse-cache growth "
+        "during long prefills; pair with --prefill-step-size 256 on 16 GB "
+        "machines\n"
+    )
+
+
+def _extract_metal_cache_limit_args(argv):
+    """Peel ``--metal-cache-limit-gb`` off ``argv``.
+
+    Accepts "auto" (default), "off", or a size in GB (0 = disable buffer
+    reuse entirely). Returns ``(mode | None, remaining_argv)`` where mode is
+    "auto" or a float; None means leave MLX untouched.
+    """
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--metal-cache-limit-gb", dest="limit", default="auto")
+    ns, remaining = parser.parse_known_args(argv)
+
+    if ns.limit == "off":
+        return None, remaining
+    if ns.limit == "auto":
+        return "auto", remaining
+    try:
+        val = float(ns.limit)
+    except ValueError:
+        raise SystemExit(
+            f"--metal-cache-limit-gb: expected a number in GB, 'auto', or "
+            f"'off' (got {ns.limit!r})"
+        )
+    if val < 0:
+        raise SystemExit(
+            f"--metal-cache-limit-gb: must be >= 0 (got {val})"
+        )
+    return val, remaining
+
+
+def _patch_loader(stream_config=None, cache_limit_mode=None) -> None:
     """Replace `mlx_lm.server.load` with a TurboQuant-aware wrapper.
 
     The server calls the bare name `load(...)` after `from .utils import
@@ -228,6 +331,8 @@ def _patch_loader(stream_config=None) -> None:
                 f"[turboquant-serve] Loading TurboQuant model from {model_path}\n"
             )
             model, tokenizer = load_turboquant(model_path, lazy=lazy)
+        if cache_limit_mode is not None:
+            _apply_metal_cache_limit(cache_limit_mode)
         if return_config:
             return model, tokenizer, cfg
         return model, tokenizer
@@ -658,7 +763,8 @@ def main() -> None:
     rep_config, remaining = _extract_rep_penalty_args(remaining)
     disk_cache_config, remaining = _extract_disk_cache_args(remaining)
     tool_greedy_config, remaining = _extract_tool_syntax_greedy_args(remaining)
-    _patch_loader(stream_config)
+    cache_limit_mode, remaining = _extract_metal_cache_limit_args(remaining)
+    _patch_loader(stream_config, cache_limit_mode)
     if tool_greedy_config is not None:
         from turboquant_mlx.tool_syntax_greedy import install as _install_tool_greedy
         _install_tool_greedy(**tool_greedy_config)

--- a/serve.py
+++ b/serve.py
@@ -88,6 +88,14 @@ writes happen on a background thread, and the store is trimmed to
 ``--disk-cache-min-tokens`` (default 512) skips checkpointing short prompts;
 ``--disk-cache-save-every`` (default 1024) throttles how often a growing
 conversation is re-checkpointed — a restart loses at most that much prefill.
+Checkpoints are also taken **mid-prefill** every ``save_every`` tokens
+(``--disk-cache-no-prefill-checkpoints`` disables), which is what makes
+persistence work for non-trimmable hybrid GDN/Mamba caches: chat templates
+re-render the assistant tail differently on the next turn (e.g. Qwen's empty
+``<think>`` block), so the end-of-request checkpoint is never a strict prefix
+of turn N+1 — the mid-prefill ladder restores from the newest checkpoint below
+the divergence instead of re-prefilling from token 0. A crash mid-prefill
+resumes the same way.
 Works with ``--kv-bits``/``--kv-k-bits`` (TurboQuant KV caches serialize) and
 with hybrid-attention models (non-trimmable GDN/Mamba states restore from
 strict-prefix checkpoints). Single server process per cache directory.
@@ -484,6 +492,9 @@ def _extract_disk_cache_args(argv):
                         type=int, default=512)
     parser.add_argument("--disk-cache-save-every", dest="save_every",
                         type=int, default=1024)
+    parser.add_argument("--disk-cache-no-prefill-checkpoints",
+                        dest="no_prefill_ckpt", action="store_true",
+                        default=False)
     ns, remaining = parser.parse_known_args(argv)
 
     if ns.disk_cache is None:
@@ -516,6 +527,7 @@ def _extract_disk_cache_args(argv):
         budget_gb=ns.budget_gb,
         min_tokens=ns.min_tokens,
         save_every=ns.save_every,
+        prefill_checkpoints=not ns.no_prefill_ckpt,
     ), remaining
 
 
@@ -819,9 +831,12 @@ def main() -> None:
             f"(dir={disk_cache_config['cache_dir']}, "
             f"budget={disk_cache_config['budget_gb']:g} GB, "
             f"min_tokens={disk_cache_config['min_tokens']}, "
-            f"save_every={disk_cache_config['save_every']}) — prompt-cache "
-            "checkpoints persist across restarts; cold prefill resumes from "
-            "the longest saved prefix.\n"
+            f"save_every={disk_cache_config['save_every']}, "
+            f"prefill_checkpoints="
+            f"{'on' if disk_cache_config['prefill_checkpoints'] else 'off'}) "
+            "— prompt-cache checkpoints persist across restarts (and are "
+            "taken mid-prefill, so crashes and divergent follow-up turns "
+            "resume from the nearest checkpoint).\n"
         )
     if tool_greedy_config is not None:
         from turboquant_mlx.tool_syntax_greedy import (

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -132,7 +132,10 @@ def _auto_cache_budget(model_bytes: int, expert_bytes: int,
     to [floor, all experts] — a budget past every expert buys nothing."""
     resident = max(0, model_bytes - expert_bytes)
     budget = int(_AUTO_WSS_FRACTION * wss_bytes) - resident - _AUTO_RESERVE_BYTES
-    return max(_AUTO_MIN_BUDGET_BYTES, min(budget, expert_bytes))
+    # expert_bytes is the hard ceiling and must win over the floor: when the
+    # experts themselves are smaller than the minimum budget, the floor would
+    # otherwise hand back a budget larger than everything it could ever hold.
+    return min(expert_bytes, max(_AUTO_MIN_BUDGET_BYTES, budget))
 
 
 # A model repo may ship its own routing profile alongside the weights (the

--- a/tests/test_disk_prompt_cache.py
+++ b/tests/test_disk_prompt_cache.py
@@ -469,3 +469,37 @@ def test_uninstall_restores_stream_generate(tmp_path):
     assert server_mod.stream_generate is not orig_sg
     store.uninstall()
     assert server_mod.stream_generate is orig_sg
+
+
+def test_longer_non_trimmable_checkpoint_does_not_suppress_prefix_saves(tmp_path):
+    """The live mini failure: a stale full checkpoint (prompt + generated
+    tail, non-trimmable) from a previous session must not swallow the
+    mid-prefill ladder of a new session over the same document."""
+    store = _store(tmp_path)
+    tokens = list(range(600))
+    store.maybe_save(MODEL_KEY, tokens, [_arrays_cache()])
+    store.maybe_save(MODEL_KEY, tokens[:300], [_arrays_cache()])
+    sizes = sorted(e.tokens.size for e in store._entries.values())
+    assert sizes == [300, 600]
+
+
+def test_longer_trimmable_checkpoint_still_suppresses_prefix_saves(tmp_path):
+    store = _store(tmp_path)
+    tokens = list(range(600))
+    store.maybe_save(MODEL_KEY, tokens, [_kv_cache(600)])
+    store.maybe_save(MODEL_KEY, tokens[:300], [_kv_cache(300)])
+    assert len(store) == 1
+
+
+def test_prefill_ladder_survives_stale_full_checkpoint(installed_store):
+    store = installed_store
+    # Previous session: end-of-request checkpoint = prompt + generated tail
+    # (diverges from the new session's re-render at token 590).
+    lru0 = LRUPromptCache(max_size=10)
+    lru0.insert_cache(MODEL_KEY, list(range(590)) + [1, 2, 3],
+                      [_arrays_cache()])
+    # New session, same document.
+    lru = LRUPromptCache(max_size=10)
+    _drive_prefill(store, lru, list(range(600)), [_arrays_cache()], chunk=50)
+    sizes = sorted(e.tokens.size for e in store._entries.values())
+    assert {100, 200, 300, 400, 500}.issubset(set(sizes))

--- a/tests/test_disk_prompt_cache.py
+++ b/tests/test_disk_prompt_cache.py
@@ -373,3 +373,99 @@ def test_tq_kv_cache_restores_through_lru(installed_store):
     assert rest == [7] * 20
     assert isinstance(cache[0], TurboQuantKVCache)
     assert cache[0].offset == 600
+
+
+# ---------------------------------------------------------------------------
+# 5. Mid-prefill checkpoints (the non-trimmable divergent-turn fix)
+# ---------------------------------------------------------------------------
+
+def _drive_prefill(store, lru, tokens, cache_list, chunk=50):
+    """Simulate the server flow: fetch (sets the active request), then run
+    the patched mlx_lm.server.stream_generate with a fake prefill loop that
+    fires the progress callback at chunk boundaries."""
+    import mlx_lm.server as server_mod
+
+    _cache, rest = lru.fetch_nearest_cache(MODEL_KEY, tokens)
+
+    def fake_stream_generate(*args, **kwargs):
+        cb = kwargs.get("prompt_progress_callback")
+        total = len(rest)
+        for p in range(chunk, total + 1, chunk):
+            # A real prefill grows the cache before each callback; the fake
+            # keeps one fixed cache object — fine, the store only reads it.
+            if cb is not None:
+                cb(p, total)
+        yield None
+
+    orig = store._orig_stream_generate
+    store._orig_stream_generate = fake_stream_generate
+    try:
+        for _ in server_mod.stream_generate(
+                prompt=rest, prompt_cache=cache_list,
+                prompt_progress_callback=None):
+            pass
+    finally:
+        store._orig_stream_generate = orig
+    return rest
+
+
+def test_prefill_checkpoints_ladder_and_divergent_turn(installed_store):
+    """A non-trimmable cache diverging in the assistant tail (the live 21K
+    Qwen failure) restores from the newest mid-prefill checkpoint below the
+    divergence instead of getting 0 reuse."""
+    store = installed_store
+    lru = LRUPromptCache(max_size=10)
+    tokens = list(range(600))
+
+    _drive_prefill(store, lru, tokens, [_arrays_cache()], chunk=50)
+    # save_every=100, min_tokens=4 -> ladder at 100, 200, ..., 500 (the
+    # p == total callback at 600 is left to the end-of-request insert).
+    sizes = sorted(e.tokens.size for e in store._entries.values())
+    assert sizes == [100, 200, 300, 400, 500]
+
+    # Turn 2 re-renders with a divergence at token 590 (inside the tail).
+    turn2 = tokens[:590] + [9] * 40
+    lru2 = LRUPromptCache(max_size=10)
+    cache, rest = lru2.fetch_nearest_cache(MODEL_KEY, turn2)
+    # Non-trimmable: the 500-token checkpoint (strict prefix) restores.
+    assert cache is not None
+    assert len(turn2) - len(rest) == 500
+
+
+def test_prefill_checkpoints_respect_stride_and_reuse_offset(installed_store):
+    """With part of the prompt already reused, checkpoint positions count
+    absolute covered tokens (reused + processed), not callback progress."""
+    store = installed_store
+    lru = LRUPromptCache(max_size=10)
+    tokens = list(range(600))
+    # Seed the LRU (and disk) with a 300-token prefix of the conversation.
+    lru.insert_cache(MODEL_KEY, tokens[:300], [_arrays_cache()])
+    before = {e.digest for e in store._entries.values()}
+
+    _drive_prefill(store, lru, tokens, [_arrays_cache()], chunk=50)
+    new_sizes = sorted(e.tokens.size for e in store._entries.values()
+                       if e.digest not in before)
+    assert new_sizes == [400, 500]  # 300 covered by seed; ladder resumes
+
+
+def test_no_prefill_checkpoints_flag(tmp_path):
+    import mlx_lm.server as server_mod
+
+    orig_sg = server_mod.stream_generate
+    store = _store(tmp_path, prefill_checkpoints=False)
+    store.install()
+    try:
+        assert server_mod.stream_generate is orig_sg
+    finally:
+        store.uninstall()
+
+
+def test_uninstall_restores_stream_generate(tmp_path):
+    import mlx_lm.server as server_mod
+
+    orig_sg = server_mod.stream_generate
+    store = _store(tmp_path)
+    store.install()
+    assert server_mod.stream_generate is not orig_sg
+    store.uninstall()
+    assert server_mod.stream_generate is orig_sg

--- a/tests/test_disk_prompt_cache.py
+++ b/tests/test_disk_prompt_cache.py
@@ -503,3 +503,20 @@ def test_prefill_ladder_survives_stale_full_checkpoint(installed_store):
     _drive_prefill(store, lru, list(range(600)), [_arrays_cache()], chunk=50)
     sizes = sorted(e.tokens.size for e in store._entries.values())
     assert {100, 200, 300, 400, 500}.issubset(set(sizes))
+
+
+def test_prefill_checkpoints_write_synchronously(tmp_path):
+    """Mid-prefill saves must hit disk inline (no queued state copy alive
+    during the next chunk), even when the store's writer is async."""
+    store = _store(tmp_path, sync=False)
+    store.install()
+    try:
+        lru = LRUPromptCache(max_size=10)
+        _drive_prefill(store, lru, list(range(600)), [_arrays_cache()],
+                       chunk=50)
+        # No flush(): entries and files must already be on disk.
+        assert sorted(e.tokens.size for e in store._entries.values()) == \
+            [100, 200, 300, 400, 500]
+        assert len(list(store.dir.glob("*.safetensors"))) == 5
+    finally:
+        store.uninstall()

--- a/tests/test_metal_cache_limit.py
+++ b/tests/test_metal_cache_limit.py
@@ -1,0 +1,87 @@
+"""Tests for the serve Metal buffer-cache limit (--metal-cache-limit-gb).
+
+The auto formula is what keeps a long chunked prefill alive on a 16 GB
+machine serving a resident ~13 GB model: MLX's unbounded buffer reuse cache
+grows ~80 MB per 1K prompt tokens during prefill (new, larger attention
+shapes each chunk), which crossed the wired limit mid-prefill in the field
+(hard Metal OOM at 14K/21K tokens). These tests pin the formula and the flag
+parsing; the end-to-end behavior was validated with a 21K-token prefill probe
+(uncapped: 16.5 GB total and climbing; capped at 256 MB: flat 13.5 GB).
+"""
+
+import pytest
+
+from turboquant_mlx.serve import (
+    _CACHE_LIMIT_AMPLE_HEADROOM_BYTES,
+    _CACHE_LIMIT_MIN_BYTES,
+    _CACHE_LIMIT_RESERVE_BYTES,
+    _auto_metal_cache_limit,
+    _extract_metal_cache_limit_args,
+)
+
+GB = 1024**3
+
+
+class TestAutoFormula:
+    def test_16gb_mini_case_floors_at_min(self):
+        # Measured field numbers: wired cap 13824 MiB (13.5 GiB), resident
+        # down4 build ~12.6 GiB -> headroom ~0.9 GiB, under the reserve, so
+        # the cap floors at the minimum instead of going negative.
+        limit = _auto_metal_cache_limit(int(13.5 * GB), int(12.6 * GB))
+        assert limit == _CACHE_LIMIT_MIN_BYTES
+
+    def test_roomy_machine_untouched(self):
+        # 64 GB Mac: ~51.5 GB working set, 13.4 GB resident -> ample
+        # headroom, keep MLX's unbounded default (fastest).
+        assert _auto_metal_cache_limit(int(51.5 * GB), int(13.4 * GB)) is None
+
+    def test_mid_headroom_caps_to_headroom_minus_reserve(self):
+        wss, active = 20 * GB, 15 * GB
+        limit = _auto_metal_cache_limit(wss, active)
+        assert limit == (wss - active) - _CACHE_LIMIT_RESERVE_BYTES
+
+    def test_boundary_exactly_ample_is_untouched(self):
+        active = 10 * GB
+        wss = active + _CACHE_LIMIT_AMPLE_HEADROOM_BYTES
+        assert _auto_metal_cache_limit(wss, active) is None
+
+    def test_just_under_ample_gets_capped(self):
+        active = 10 * GB
+        wss = active + _CACHE_LIMIT_AMPLE_HEADROOM_BYTES - 1
+        limit = _auto_metal_cache_limit(wss, active)
+        assert limit is not None
+        assert limit >= _CACHE_LIMIT_MIN_BYTES
+
+
+class TestFlagParsing:
+    def test_default_is_auto(self):
+        mode, remaining = _extract_metal_cache_limit_args(
+            ["--model", "m", "--port", "8080"])
+        assert mode == "auto"
+        assert remaining == ["--model", "m", "--port", "8080"]
+
+    def test_off_disables(self):
+        mode, remaining = _extract_metal_cache_limit_args(
+            ["--metal-cache-limit-gb", "off", "--model", "m"])
+        assert mode is None
+        assert remaining == ["--model", "m"]
+
+    def test_explicit_gb(self):
+        mode, _ = _extract_metal_cache_limit_args(
+            ["--metal-cache-limit-gb", "1.5"])
+        assert mode == 1.5
+
+    def test_zero_means_no_buffer_reuse(self):
+        mode, _ = _extract_metal_cache_limit_args(
+            ["--metal-cache-limit-gb", "0"])
+        assert mode == 0.0
+
+    def test_garbage_errors_loud(self):
+        with pytest.raises(SystemExit):
+            _extract_metal_cache_limit_args(
+                ["--metal-cache-limit-gb", "lots"])
+
+    def test_negative_errors_loud(self):
+        with pytest.raises(SystemExit):
+            _extract_metal_cache_limit_args(
+                ["--metal-cache-limit-gb", "-1"])

--- a/tests/test_stream_autobudget.py
+++ b/tests/test_stream_autobudget.py
@@ -93,3 +93,13 @@ def test_stream_generate_budget_arg_type():
 
 def test_wss_fraction_sane():
     assert 0.5 <= _AUTO_WSS_FRACTION <= 0.9
+
+
+def test_auto_budget_experts_smaller_than_floor_cap_at_experts():
+    # A tiny MoE whose whole expert tier is under the 0.5 GB floor: the
+    # ceiling (all experts) must win over the floor — a budget larger than
+    # every expert buys nothing.
+    b = _auto_cache_budget(model_bytes=10_000_000_000,
+                           expert_bytes=200_000_000,
+                           wss_bytes=16_000_000_000)
+    assert b == 200_000_000


### PR DESCRIPTION
## Problem (found in 16 GB Mac mini field testing)

Serving the resident 12.6 GB down4 35B on a 16 GB mini, a 21K-token prompt hard-crashed the server mid-prefill:

```
Prompt processing progress: 14336/21169
libc++abi: terminating due to uncaught exception of type std::runtime_error:
[METAL] Command buffer execution failed: Insufficient Memory
```

Probe on a 64 GB machine (same model, same KV config, same 512-token chunks) isolated the cause: **active memory stays flat** (~13.2 GB — the 8-bit KV is only 0.44 GB at 21K) but **MLX's buffer reuse cache grows monotonically 1.9 → 3.5 GB** (~80 MB per 1K prompt tokens). Each prefill chunk's attention workspace has a new, larger shape, so old cached buffers are never reused and never evicted — mlx-lm only clears the cache after prefill completes. Total crossed 16.5 GB by 20K tokens; on the mini's 13.5 GiB wired cap that line is crossed at ~14K tokens, exactly where it died.

## Fix

`--metal-cache-limit-gb` on `turboquant-serve`, default `auto`: right after the model loads, if working-set headroom (recommended working set − resident bytes) is **under 8 GB**, cap the buffer cache via `mx.set_cache_limit(headroom − 2 GB reserve)`, floored at 256 MB so per-token decode buffers (a handful of fixed shapes) still get reused. Roomy machines are left untouched — the unbounded cache is fastest and harmless there. Explicit GB value or `off` override.

**Probe-validated end to end** (same 21K-token prompt, 256-token chunks, 256 MB cap): total memory flat at **13.5 GB** for the whole prefill (uncapped: 16.5 GB and climbing), cache pinned at 0.30 GB, KV growth unaffected.

Docs note the companion setting for 16 GB boxes: `--prefill-step-size 256` (upstream mlx-lm flag, forwards through) — the *per-chunk* transient workspace scales with chunk size, and the default 2048 OOMs tight machines on their first chunk (that was the first of the two crashes).

## Tests

- `_auto_metal_cache_limit`: measured mini case floors at 256 MB; roomy 64 GB case returns None; mid-headroom case = headroom − reserve; boundary at exactly 8 GB.
- Flag parsing: default auto, `off`, explicit float, `0` (= disable buffer reuse), loud `SystemExit` on garbage/negative.
- Full suite: 219 passed.

Part of the 16 GB mini validation pass before the 0.13.0 release.