### PR TITLE
serve: auto byte-cap for the in-memory prompt cache (--prompt-cache-max-gb)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **Prompt-cache byte cap on `turboquant-serve`** (`--prompt-cache-max-gb`,
+  default `auto`): mlx-lm's in-memory LRU prompt cache is bounded by entry
+  count only, and an agent-harness conversation retains one KV state per
+  turn — measured on a 16 GB mini serving the resident 12.6 GB down4 35B,
+  8 retained sequences (1.14 GB) paged the system until a prefill command
+  buffer stalled on swap I/O and the Metal watchdog killed the server (GPU
+  Timeout). `auto` computes the byte budget at insert time (working-set
+  headroom excluding the cache's own bytes, minus a 2 GB reserve, floored
+  at 256 MB) and lets the upstream LRU evict down to it; roomy machines
+  stay unbounded. Pair with `--disk-cache`: evicted states restore from
+  disk instead of re-prefilling.
+
 - **Mid-prefill disk-cache checkpoints** (`--disk-cache`, on by default;
   `--disk-cache-no-prefill-checkpoints` opts out): the disk prompt cache now
   also checkpoints every `--disk-cache-save-every` tokens *during* prompt

--- a/README.md
+++ b/README.md
@@ -172,6 +172,17 @@ python -m turboquant_mlx.convert \
     --bits 3 --group-size 64 --ternary-experts --streaming
 # Resident load of a ~53 GB model needs a wired-memory bump on a 64 GB Mac:
 #   sudo sysctl -w iogpu.wired_limit_mb=60416
+
+# Asymmetric experts — ternary up/gate + higher-bit down_proj. The down
+# projection is the SwiGLU write-back into the residual stream, and spending
+# 4 bits on just that one expert matrix is what turns a sub-2-bit build
+# agent-capable: on Qwen3.6-35B-A3B, pure ternary fails an Opencode coding
+# task 0/4 while ternary+down4 passes 3/3 — for +3.2 GB (9.4 -> 12.6 GB),
+# still resident on a 16 GB Mac mini.
+python -m turboquant_mlx.convert \
+    --hf-path Qwen/Qwen3.6-35B-A3B \
+    --mlx-path ./Qwen3.6-35B-A3B-tq3a-tqTe-down4-g64 \
+    --bits 3 --group-size 64 --ternary-experts --expert-down-bits 4
 ```
 
 ### 2. Generate text
@@ -298,6 +309,15 @@ The [Flash-MoE streaming levers](#tuning-the-streaming-reader-v061) ride along:
 with `--kv-*` to compress the growing KV cache of long agentic loops, and
 `--prompt-concurrency 1` since streaming is a single-user path.
 
+`--cache-budget-gb auto` sizes the expert cache from the machine (80% of
+Metal's recommended working set, minus resident weights and a KV reserve),
+and a `hot_experts.json` shipped in the model directory (the pin output of
+`calibrate_experts.py`) is auto-discovered: those experts are pinned **and
+preloaded** at startup — measured on the 35B ternary, a 1.1 GB / 1,500-expert
+profile preloads in 0.3 s and lifts the cache hit rate 74 → 82%, cutting
+critical-path disk reads 30%. `--no-hotlist` opts out; `--wire-memory`
+(opt-in) wires weights + expert cache against memory pressure.
+
 > **Note**: `mlx_lm.server` is intended for development and local use, not
 > production. It does not implement authentication or rate limiting.
 
@@ -319,7 +339,29 @@ to speed up follow-up turns. Each new prompt grows that pool, and once
 caches + model weights + decode workspace exceed Metal's wired-memory
 budget, the next allocation aborts the process.
 
-Two fixes, in order of impact:
+Since 0.13, `turboquant-serve` applies two auto-guards on tight machines
+(both no-ops when working-set headroom is ≥ 8 GB):
+
+- **`--metal-cache-limit-gb auto`** (default) caps MLX's GPU buffer reuse
+  cache after the model loads. During a long chunked prefill the attention
+  workspace has a new, larger shape every chunk, so the unbounded cache
+  grows ~80 MB per 1K prompt tokens — measured on a 16 GB mini serving a
+  resident 12.6 GB 35B, that alone OOM-crashed a 21K-token prefill at 14K
+  while *active* memory stayed flat. With the cap the same prefill runs
+  flat end to end.
+- **`--prompt-cache-max-gb auto`** (default) puts a **byte** budget on the
+  LRU prompt cache, enforced on every insert. Upstream's
+  `--prompt-cache-bytes` exists but is only applied on the *batched*
+  serving path — TurboQuant KV-quant serving is sequential, where an agent
+  conversation retained 8 KV states (1.14 GB) on the mini, paged the
+  system, and got the server killed by the GPU watchdog. Evictions are
+  cheap when `--disk-cache` is on (states restore from disk).
+
+On 16 GB machines also pass **`--prefill-step-size 256`** (or 128 near the
+context ceiling): the *per-chunk* prefill workspace scales with chunk size,
+and mlx-lm's default of 2048 OOMs tight boxes on the first chunk.
+
+For bigger machines serving near the ceiling, the two manual levers:
 
 **1. Raise Metal's wired-memory ceiling** (biggest lever, requires sudo,
 resets on reboot):
@@ -397,6 +439,68 @@ below for how to choose bit-widths and the speed/quality trade-offs.
 > enabling any `--kv-*` flag makes the server serve requests sequentially.
 > That's the right trade-off for a single-user setup; for a multi-client
 > server it means concurrent requests queue rather than batch.
+
+#### Persistent prompt cache across restarts (`--disk-cache`)
+
+`--disk-cache [DIR]` makes the prompt-prefix cache a disk citizen: KV-cache
+checkpoints are written per conversation (background writer, LRU byte-budget
+eviction, default 10 GB) and any later request — including the first one
+after a server **restart or crash** — resumes from the longest saved token
+prefix instead of re-prefilling from scratch. Measured: a 16.3K-token
+conversation's first turn after restart drops **21.1 s → 3.0 s** on a 64 GB
+Mac (6.9×, output byte-identical), and on a 16 GB mini a crashed 21K-token
+prefill resumed from token 18,432 (249 MB checkpoint loaded in 2.3 s).
+
+Checkpoints are also taken **mid-prefill** every `--disk-cache-save-every`
+tokens (default 1024). That ladder is what makes persistence work for
+hybrid GDN/Mamba models whose recurrent state can't be trimmed: chat
+templates re-render the assistant turn differently in history (e.g. Qwen's
+empty `<think>` block), so the end-of-request checkpoint is never an exact
+prefix of the next turn — the ladder restores from the newest checkpoint
+below the divergence instead. Measured on the mini: turn 2 of a 21K
+conversation reused **20,480 of 21,250 tokens** on a non-trimmable cache
+that previously got zero.
+
+#### Agent harnesses on low-bit builds (`--tool-syntax-greedy`)
+
+Agent harnesses need temperature (greedy decoding perseverates across turns
+on low-bit builds), but sampled *structure* is where those builds fabricate
+tool calls. `--tool-syntax-greedy` masks logits to argmax only while the
+generation is inside a `<tool_call>`...`</tool_call>` block — braces, keys,
+tags — and leaves the sampler in charge of JSON value strings and of the
+decision to call a tool at all. Tags are configurable via
+`--tool-syntax-tags "<open>,</close>"`.
+
+#### Recipe: a coding agent on a 16 GB Mac mini
+
+The asymmetric-expert build
+[Qwen3.6-35B-A3B-tq3a-tqTe-down4-g64](https://huggingface.co/manjunathshiva/Qwen3.6-35B-A3B-tq3a-tqTe-down4-g64)
+(ternary up/gate + 4-bit down_proj, 12.6 GB) is the smallest 35B that
+survives an agent loop — validated end-to-end on a base M-series 16 GB
+Mac mini:
+
+```bash
+sudo sysctl -w iogpu.wired_limit_mb=14336   # 14 GiB; 13824 is enough below ~16K context
+
+turboquant-serve \
+    --model manjunathshiva/Qwen3.6-35B-A3B-tq3a-tqTe-down4-g64 \
+    --host 0.0.0.0 --port 8080 \
+    --kv-bits 8 --tool-syntax-greedy --disk-cache \
+    --prefill-step-size 128 \
+    --temp 0.7 --top-p 0.8 --top-k 20 \
+    --chat-template-args '{"enable_thinking": false}' \
+    --prompt-concurrency 1
+```
+
+Measured on the mini (model on an external SSD): **15.2–15.6 tok/s** decode
+at 13.6 GB peak (flat to 1800 generated tokens), 21K-token cold prefill
+~234 s (~90 tok/s), and the Opencode fix-the-failing-test task passes
+**3/3** (3:37 / 2:25 / 1:54 — faster each run as the disk cache warms; the
+identical task fails 0/4 on the pure-ternary build). Practical context
+ceiling is ~16–18K at the default wired cap; the 128-token prefill step +
+14 GiB wired configuration above is what carries 21K+. Point Opencode (or
+any OpenAI-compatible harness) at `http://<host>:8080/v1` with model id
+`default_model`, keep temperature ~0.7, and disable auto-discovered skills.
 
 ---
 

--- a/serve.py
+++ b/serve.py
@@ -288,18 +288,21 @@ def _patch_prompt_cache_bytes(mode) -> None:
     ``max_bytes`` is computed at insert time (the model isn't loaded yet
     when the server constructs the cache, so a static value can't be
     derived up front). The base class enforces the cap on every insert."""
+    import mlx.core as mx
     import mlx_lm.server as _server_mod
     from mlx_lm.models.cache import LRUPromptCache
+
+    # The device working set is static for the server's lifetime; query it
+    # once here instead of on every cache insertion.
+    wss = (mx.device_info()["max_recommended_working_set_size"]
+           if mode == "auto" else None)
 
     class _BudgetLRUPromptCache(LRUPromptCache):
         @property
         def max_bytes(self):
             if mode != "auto":
                 return int(mode * 1024**3)
-            import mlx.core as mx
-
-            wss = mx.device_info()["max_recommended_working_set_size"]
-            active_excl = mx.get_active_memory() - self._n_bytes
+            active_excl = mx.get_active_memory() - self.nbytes
             limit = _auto_prompt_cache_bytes(wss, active_excl)
             return _PROMPT_CACHE_UNBOUNDED if limit is None else limit
 
@@ -322,9 +325,10 @@ def _extract_prompt_cache_max_args(argv):
     parser.add_argument("--prompt-cache-max-gb", dest="limit", default="auto")
     ns, remaining = parser.parse_known_args(argv)
 
-    if ns.limit == "off":
+    limit = ns.limit.lower() if isinstance(ns.limit, str) else ns.limit
+    if limit == "off":
         return None, remaining
-    if ns.limit == "auto":
+    if limit == "auto":
         return "auto", remaining
     try:
         val = float(ns.limit)
@@ -349,9 +353,10 @@ def _extract_metal_cache_limit_args(argv):
     parser.add_argument("--metal-cache-limit-gb", dest="limit", default="auto")
     ns, remaining = parser.parse_known_args(argv)
 
-    if ns.limit == "off":
+    limit = ns.limit.lower() if isinstance(ns.limit, str) else ns.limit
+    if limit == "off":
         return None, remaining
-    if ns.limit == "auto":
+    if limit == "auto":
         return "auto", remaining
     try:
         val = float(ns.limit)

--- a/serve.py
+++ b/serve.py
@@ -128,6 +128,20 @@ or ``off`` to disable. On 16 GB machines pair this with a smaller
 scales with chunk size, and the mlx_lm default of 2048 also OOMs tight
 boxes on its first chunk.
 
+Prompt-cache byte cap (--prompt-cache-max-gb, default: auto)
+------------------------------------------------------------
+mlx_lm.server bounds its in-memory LRU prompt cache by entry count only
+(``--prompt-cache-size``, default 10). An agent-harness conversation retains
+one KV state per turn, and on a tight machine that accumulation pages the
+system until a prefill command buffer stalls on swap I/O and the Metal
+watchdog kills the server (measured: 8 sequences / 1.14 GB on a 16 GB mini
+→ GPU Timeout). ``auto`` computes a byte budget at insert time — working-set
+headroom (excluding the cache's own bytes) minus a 2 GB reserve, floored at
+256 MB — and lets the upstream LRU evict down to it; roomy machines stay
+unbounded. Pass a size in GB to force a cap or ``off`` for stock behavior.
+Pair with ``--disk-cache``: evicted states restore from disk instead of
+re-prefilling.
+
 Prefill keepalive (long cold prefills behind a proxy)
 -----------------------------------------------------
 A streaming agentic client (Claude Code via claude-code-router) aborts a
@@ -238,6 +252,90 @@ def _apply_metal_cache_limit(mode) -> None:
         "during long prefills; pair with --prefill-step-size 256 on 16 GB "
         "machines\n"
     )
+
+
+# In-memory prompt-cache byte cap. mlx_lm.server bounds its LRU prompt cache
+# by ENTRY COUNT only (--prompt-cache-size, default 10); LRUPromptCache's
+# max_bytes parameter exists upstream but is never wired to a flag. On a
+# tight machine an agent-harness conversation accumulates one KV state per
+# turn — measured live on a 16 GB mini serving the resident 12.6 GB 35B:
+# 8 sequences / 1.14 GB retained, the system started paging, a prefill
+# command buffer stalled on swap I/O and the Metal watchdog killed the
+# server (kIOGPUCommandBufferCallbackErrorTimeout). Evicting is cheap when
+# --disk-cache is on (evicted states restore from disk).
+_PROMPT_CACHE_RESERVE_BYTES = 2 * 1024**3
+_PROMPT_CACHE_MIN_BYTES = 256 * 1024**2
+_PROMPT_CACHE_UNBOUNDED = 1 << 62
+
+
+def _auto_prompt_cache_bytes(wss_bytes: int,
+                             active_excl_cache_bytes: int) -> int | None:
+    """Byte budget for the LRU prompt cache; None = leave unbounded.
+
+    ``active_excl_cache_bytes`` is active memory *minus* the cache's own
+    bytes (weights + working state), so the formula stays stable as the
+    cache itself grows and shrinks.
+    """
+    headroom = wss_bytes - active_excl_cache_bytes
+    if headroom >= _CACHE_LIMIT_AMPLE_HEADROOM_BYTES:
+        return None
+    return max(_PROMPT_CACHE_MIN_BYTES,
+               int(headroom - _PROMPT_CACHE_RESERVE_BYTES))
+
+
+def _patch_prompt_cache_bytes(mode) -> None:
+    """Swap ``mlx_lm.server.LRUPromptCache`` for a subclass whose
+    ``max_bytes`` is computed at insert time (the model isn't loaded yet
+    when the server constructs the cache, so a static value can't be
+    derived up front). The base class enforces the cap on every insert."""
+    import mlx_lm.server as _server_mod
+    from mlx_lm.models.cache import LRUPromptCache
+
+    class _BudgetLRUPromptCache(LRUPromptCache):
+        @property
+        def max_bytes(self):
+            if mode != "auto":
+                return int(mode * 1024**3)
+            import mlx.core as mx
+
+            wss = mx.device_info()["max_recommended_working_set_size"]
+            active_excl = mx.get_active_memory() - self._n_bytes
+            limit = _auto_prompt_cache_bytes(wss, active_excl)
+            return _PROMPT_CACHE_UNBOUNDED if limit is None else limit
+
+        @max_bytes.setter
+        def max_bytes(self, value):
+            # The base __init__ assigns a default; the property governs.
+            pass
+
+    _server_mod.LRUPromptCache = _BudgetLRUPromptCache
+
+
+def _extract_prompt_cache_max_args(argv):
+    """Peel ``--prompt-cache-max-gb`` off ``argv``.
+
+    Accepts "auto" (default: cap only when working-set headroom is tight),
+    "off" (stock mlx-lm behavior, unbounded bytes), or a size in GB.
+    Returns ``(mode | None, remaining_argv)``.
+    """
+    parser = argparse.ArgumentParser(add_help=False, allow_abbrev=False)
+    parser.add_argument("--prompt-cache-max-gb", dest="limit", default="auto")
+    ns, remaining = parser.parse_known_args(argv)
+
+    if ns.limit == "off":
+        return None, remaining
+    if ns.limit == "auto":
+        return "auto", remaining
+    try:
+        val = float(ns.limit)
+    except ValueError:
+        raise SystemExit(
+            f"--prompt-cache-max-gb: expected a number in GB, 'auto', or "
+            f"'off' (got {ns.limit!r})"
+        )
+    if val <= 0:
+        raise SystemExit(f"--prompt-cache-max-gb: must be > 0 (got {val})")
+    return val, remaining
 
 
 def _extract_metal_cache_limit_args(argv):
@@ -776,7 +874,10 @@ def main() -> None:
     disk_cache_config, remaining = _extract_disk_cache_args(remaining)
     tool_greedy_config, remaining = _extract_tool_syntax_greedy_args(remaining)
     cache_limit_mode, remaining = _extract_metal_cache_limit_args(remaining)
+    prompt_cache_max_mode, remaining = _extract_prompt_cache_max_args(remaining)
     _patch_loader(stream_config, cache_limit_mode)
+    if prompt_cache_max_mode is not None:
+        _patch_prompt_cache_bytes(prompt_cache_max_mode)
     if tool_greedy_config is not None:
         from turboquant_mlx.tool_syntax_greedy import install as _install_tool_greedy
         _install_tool_greedy(**tool_greedy_config)
@@ -813,6 +914,15 @@ def main() -> None:
             f"[turboquant-serve] Expert streaming: cache_budget={bud_s}, "
             f"max_active_experts={stream_config['max_active_experts']}, "
             f"page_cache={pc}{wired} (single-user; use --prompt-concurrency 1)\n"
+        )
+    if prompt_cache_max_mode is not None:
+        cap_s = ("auto (caps only when working-set headroom is tight)"
+                 if prompt_cache_max_mode == "auto"
+                 else f"{prompt_cache_max_mode:g} GB")
+        sys.stderr.write(
+            f"[turboquant-serve] Prompt-cache byte cap: {cap_s} — bounds "
+            "retained per-conversation KV states; evicted states restore "
+            "from --disk-cache when enabled\n"
         )
     if kv_config is not None:
         if kv_config["tq_bits"] is not None:

--- a/tests/test_prompt_cache_bytes.py
+++ b/tests/test_prompt_cache_bytes.py
@@ -109,3 +109,18 @@ class TestFlagParsing:
             _extract_prompt_cache_max_args(["--prompt-cache-max-gb", "much"])
         with pytest.raises(SystemExit):
             _extract_prompt_cache_max_args(["--prompt-cache-max-gb", "0"])
+
+
+class TestCaseInsensitiveFlags:
+    def test_prompt_cache_max_gb(self):
+        assert _extract_prompt_cache_max_args(
+            ["--prompt-cache-max-gb", "AUTO"])[0] == "auto"
+        assert _extract_prompt_cache_max_args(
+            ["--prompt-cache-max-gb", "Off"])[0] is None
+
+    def test_metal_cache_limit_gb(self):
+        from turboquant_mlx.serve import _extract_metal_cache_limit_args
+        assert _extract_metal_cache_limit_args(
+            ["--metal-cache-limit-gb", "Auto"])[0] == "auto"
+        assert _extract_metal_cache_limit_args(
+            ["--metal-cache-limit-gb", "OFF"])[0] is None

--- a/tests/test_prompt_cache_bytes.py
+++ b/tests/test_prompt_cache_bytes.py
@@ -1,0 +1,111 @@
+"""Tests for the serve prompt-cache byte cap (--prompt-cache-max-gb).
+
+Field failure it guards: an agent-harness conversation retains one KV state
+per turn in mlx_lm.server's LRU prompt cache (entry-count-bounded only);
+8 sequences / 1.14 GB on a 16 GB mini paged the system until the Metal
+watchdog killed a stalled prefill command buffer (GPU Timeout).
+"""
+
+import mlx.core as mx
+import pytest
+
+import mlx_lm.server as server_mod
+from mlx_lm.models.cache import KVCache, LRUPromptCache
+
+from turboquant_mlx.serve import (
+    _CACHE_LIMIT_AMPLE_HEADROOM_BYTES,
+    _PROMPT_CACHE_MIN_BYTES,
+    _PROMPT_CACHE_RESERVE_BYTES,
+    _auto_prompt_cache_bytes,
+    _extract_prompt_cache_max_args,
+    _patch_prompt_cache_bytes,
+)
+
+GB = 1024**3
+MODEL_KEY = ("model-a", None, None)
+
+
+def _kv_cache(n_tokens, dim=64):
+    c = KVCache()
+    c.update_and_fetch(
+        mx.random.normal((1, 1, n_tokens, dim)),
+        mx.random.normal((1, 1, n_tokens, dim)),
+    )
+    return c
+
+
+@pytest.fixture
+def restore_lru():
+    orig = server_mod.LRUPromptCache
+    try:
+        yield
+    finally:
+        server_mod.LRUPromptCache = orig
+
+
+class TestAutoFormula:
+    def test_tight_machine_floors_at_min(self):
+        # Mini field numbers: wss 14.5 GB, weights+working ~12.6 GiB.
+        limit = _auto_prompt_cache_bytes(int(13.5 * GB), int(12.6 * GB))
+        assert limit == _PROMPT_CACHE_MIN_BYTES
+
+    def test_roomy_machine_unbounded(self):
+        assert _auto_prompt_cache_bytes(int(51.5 * GB), int(13.4 * GB)) is None
+
+    def test_mid_headroom(self):
+        wss, active = 20 * GB, 15 * GB
+        assert _auto_prompt_cache_bytes(wss, active) == \
+            (wss - active) - _PROMPT_CACHE_RESERVE_BYTES
+
+    def test_ample_boundary(self):
+        active = 10 * GB
+        assert _auto_prompt_cache_bytes(
+            active + _CACHE_LIMIT_AMPLE_HEADROOM_BYTES, active) is None
+
+
+class TestPatchedLRU:
+    def test_explicit_cap_evicts_lru(self, restore_lru):
+        _patch_prompt_cache_bytes(1e-6)  # ~1 KB budget
+        lru = server_mod.LRUPromptCache(max_size=10)
+        assert isinstance(lru, LRUPromptCache)
+        lru.insert_cache(MODEL_KEY, list(range(100)), [_kv_cache(100)])
+        lru.insert_cache(MODEL_KEY, list(range(200, 300)), [_kv_cache(100)])
+        # Each entry is ~50 KB >> the 1 KB budget: everything evicts down.
+        assert lru.nbytes <= 1e-6 * GB or len(lru) <= 1
+
+    def test_ctor_default_does_not_override_property(self, restore_lru):
+        _patch_prompt_cache_bytes(2.0)
+        lru = server_mod.LRUPromptCache(max_size=10)
+        # Base __init__ assigned max_bytes=1<<63; the property must win.
+        assert lru.max_bytes == int(2.0 * GB)
+
+    def test_auto_mode_reads_device_state(self, restore_lru):
+        _patch_prompt_cache_bytes("auto")
+        lru = server_mod.LRUPromptCache(max_size=10)
+        # Just exercises the dynamic path end-to-end on this machine.
+        assert lru.max_bytes > 0
+        lru.insert_cache(MODEL_KEY, list(range(50)), [_kv_cache(50)])
+        assert len(lru) >= 0
+
+
+class TestFlagParsing:
+    def test_default_auto(self):
+        mode, remaining = _extract_prompt_cache_max_args(["--model", "m"])
+        assert mode == "auto"
+        assert remaining == ["--model", "m"]
+
+    def test_off(self):
+        mode, _ = _extract_prompt_cache_max_args(
+            ["--prompt-cache-max-gb", "off"])
+        assert mode is None
+
+    def test_explicit(self):
+        mode, _ = _extract_prompt_cache_max_args(
+            ["--prompt-cache-max-gb", "0.5"])
+        assert mode == 0.5
+
+    def test_garbage_and_nonpositive_error(self):
+        with pytest.raises(SystemExit):
+            _extract_prompt_cache_max_args(["--prompt-cache-max-gb", "much"])
+        with pytest.raises(SystemExit):
+            _extract_prompt_cache_max_args(["--prompt-cache-max-gb", "0"])


### PR DESCRIPTION
## Problem (found during the 16 GB mini Opencode run)

mlx-lm's LRU prompt cache is bounded by **entry count** only (`--prompt-cache-size`, default 10). An agent-harness conversation retains one KV state per turn; on the mini serving the resident 12.6 GB down4 35B, 8 retained sequences (1.14 GB) pushed the system into paging, a prefill command buffer stalled on swap I/O, and the Metal watchdog killed the server:

```
Prompt Cache: 8 sequences, 1.14 GB
Prompt processing progress: 0/612          # after an 84 s stall
[METAL] ... Caused GPU Timeout Error (kIOGPUCommandBufferCallbackErrorTimeout)
```

## Fix

`--prompt-cache-max-gb` (default `auto`): swap `mlx_lm.server.LRUPromptCache` for a subclass whose `max_bytes` is a **property computed at insert time** — the server constructs the cache before the model loads, so a static value can't be derived up front. Auto = working-set headroom (excluding the cache's own bytes, so the formula is stable as the cache grows/shrinks) − 2 GB reserve, floored at 256 MB; ≥ 8 GB headroom ⇒ unbounded (stock behavior). Upstream's insert path already evicts LRU-first down to `max_bytes` — no eviction logic of our own. With `--disk-cache` on, evicted states restore from disk instead of re-prefilling.

Explicit GB value or `off` override; loud `SystemExit` on garbage.

## Validation

- The crude equivalent (`--prompt-cache-size 2`) validated live: **Opencode fix-the-failing-test 3/3 on the 16 GB mini** (3 min 37 s / 2 min 25 s / 1 min 54 s — faster each run as the disk cache warms), no crash across all runs.
- 11 new tests: auto formula (tight floor / roomy unbounded / mid / boundary), patched-class behavior (explicit cap evicts, ctor default doesn't override the property, auto path runs), flag parsing.
- Full suite: 239 passed.

Last serve fix from the mini validation pass; completes the tight-machine memory story (buffer cache capped, prompt cache capped, per-chunk transient bounded by --prefill-step-size).

🤖 Generated with [Claude Code](https://claude.com/claude-code)