### PR TITLE
chore: release 0.13.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.13.0] - 2026-07-13
 
 ### Added
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.12.4"
+__version__ = "0.13.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.12.4"
+version = "0.13.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for the 0.13.0 release: \`pyproject.toml\` + \`__init__.py\` → 0.13.0, CHANGELOG \`[Unreleased]\` → \`[0.13.0] - 2026-07-13\`.

Ships (all merged + validated on the 16 GB mini):
- \`--prompt-cache-max-gb auto\` — byte cap on mlx-lm's LRU prompt cache (#48)
- \`--metal-cache-limit-gb auto\` + mid-prefill disk-cache checkpoints (#47)
- \`--cache-budget-gb auto\` + \`--wire-memory\` for streaming (#46)
- shipped \`hot_experts.json\` auto-discovery + preload (#45)
- \`--tool-syntax-greedy\` (#44)
- \`convert --expert-down-bits {2,3,4}\` asymmetric experts (#43)
- \`--disk-cache\` persistent prompt cache (#42)

After merge: push the \`v0.13.0\` tag → release.yml builds the sdist and publishes to PyPI (manual \`pypi\` env approval).