### PR TITLE
feat: turboquant-plan / turboquant-doctor — preflight placement projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   OOMed in the field. The 0.13.0 auto-guards fix tight-memory serving at
   runtime — this predicts it instead.
 
+  A HuggingFace repo id is planned **over the network from its headers** (range
+  requests via `get_safetensors_metadata`), never by downloading it: the 12.6 GB
+  down4 repo answers in ~2.5 s and pulls 232 KB into a cold cache — so the
+  question is answered *before* the download, which is the whole point. An
+  already-cached repo is used from disk.
+
 ## [0.13.0] - 2026-07-13
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,32 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`turboquant-plan` / `turboquant-doctor` — preflight placement projection.**
+  Answers "will this model run on this Mac, and with what flags?" *before* a
+  multi-GB download or a five-minute load, by reading **only safetensors
+  headers** and `config.json` — it allocates no tensors, starts no engine, and
+  imports no model framework. Reports the exact weight split (total / streamable
+  experts / resident backbone), a KV projection derived from the config's
+  attention geometry (hybrid GatedDeltaNet models only grow KV on their
+  full-attention layers — 10 of 40 on Qwen3.6-35B), an estimate of the transient
+  prefill workspace (which scales with *both* chunk size and context), and a
+  verdict: resident / resident-after-a-wired-bump / streaming / won't-run —
+  plus the flags to use. `--wired-gb` / `--ram-gb` plan for a machine you are
+  not sitting at; `--json` is machine-readable; `turboquant-doctor` adds a
+  read-only readiness check (files, tokenizer, quantization block, mlx/mlx-lm)
+  with stable check ids and exit codes (0 ok/warn, 1 won't fit / missing,
+  2 usage). The projection is **calibrated against the 16 GB mini
+  measurements**, not guessed: it predicts a 10.44 GB peak where the 9.4 GB
+  ternary build measures 10.42 GB and correctly needs no `sudo`; it recommends
+  `iogpu.wired_limit_mb=13721` for the 12.6 GB down4 build where 13824 is what
+  works; and at 21K context it rejects the default 2048 prefill chunk that
+  OOMed in the field. The 0.13.0 auto-guards fix tight-memory serving at
+  runtime — this predicts it instead.
+
 ## [0.13.0] - 2026-07-13
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -137,6 +137,59 @@ pip install "turboquant-mlx-full[eval]"
 
 ## Quick Start
 
+### 0. Will it run on my Mac? (`turboquant-plan`)
+
+Before a multi-GB download, ask:
+
+```bash
+turboquant-plan --model manjunathshiva/Qwen3.6-35B-A3B-tq3a-tqTe-down4-g64
+```
+
+```
+Projection at 16,384 tokens of context
+  weights              12.59 GB
+  KV cache             0.34 GB  (20.0 KB/token, hybrid: 10/40 full-attention layers)
+  prefill workspace    1.07 GB  (estimate, at --prefill-step-size 2048)
+  runtime reserve      1.00 GB  (buffer cache, activations, fragmentation)
+                       ----------------------------------
+  peak                 15.00 GB of 61.85 GB usable   46.85 GB headroom
+
+Verdict: ✅ RESIDENT — fits fully in memory
+```
+
+It reads **only safetensors headers** — no tensors are loaded, no engine starts —
+so it answers in milliseconds against a local dir or an HF repo id. Weights are
+exact; KV is derived from the config's attention geometry (hybrid models only
+grow KV on their full-attention layers); the prefill workspace is an estimate
+that scales with *both* chunk size and context.
+
+Planning for a machine you're not sitting at, and asking for the flags:
+
+```bash
+turboquant-plan --model <repo> --wired-gb 10.5 --ram-gb 16 --context 21000 --kv-bits 8
+```
+
+```
+Verdict: ⚠️  RESIDENT — fits, but only after raising the Metal wired cap
+
+Recommended:
+  sudo sysctl -w iogpu.wired_limit_mb=13721   (raises the 10.50 GB Metal cap —
+      the binding limit here, not your 16 GB of RAM; resets on reboot)
+  --prefill-step-size 128   (the default 2048 needs 1.38 GB of transient
+      workspace at this context)
+  --kv-bits 8
+```
+
+That is the 16 GB Mac mini recipe, *derived* rather than found by trial and error
+— the projection is calibrated against measurements on that machine (it predicts
+10.44 GB where the 9.4 GB ternary build measures 10.42, and recommends a wired
+limit within 1% of the one that actually works).
+
+`turboquant-doctor` runs the same projection plus a read-only readiness check —
+model files, tokenizer, quantization block, mlx/mlx-lm imports, machine limits —
+with stable check ids and exit codes (0 ok/warn, 1 won't fit or files missing,
+2 bad usage). Both take `--json` for automation.
+
 ### 1. Convert a model to TurboQuant format
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -157,8 +157,11 @@ Projection at 16,384 tokens of context
 Verdict: ✅ RESIDENT — fits fully in memory
 ```
 
-It reads **only safetensors headers** — no tensors are loaded, no engine starts —
-so it answers in milliseconds against a local dir or an HF repo id. Weights are
+It reads **only safetensors headers** — no tensors are loaded, no engine starts.
+A HuggingFace repo id is planned **over the network**, from range requests against
+the shard headers: the 12.6 GB repo above answers in ~2.5 s and pulls **232 KB**
+into a cold cache, so "will it fit?" is answered *before* the download, not after.
+Weights are
 exact; KV is derived from the config's attention geometry (hybrid models only
 grow KV on their full-attention layers); the prefill workspace is an estimate
 that scales with *both* chunk size and context.

--- a/plan.py
+++ b/plan.py
@@ -25,6 +25,10 @@ estimate:
                              puts --prefill-step-size 2048 over the wired cap
                              (observed: OOM) and 256/128 under it (observed: runs).
 
+A HuggingFace repo id is planned **over the network from its headers** — never
+by downloading it, which would defeat the point. Measured: the 12.6 GB down4 repo
+plans in ~2.5 s and pulls 232 KB into a cold cache.
+
 Usage:
     turboquant-plan --model <path_or_repo>
     turboquant-plan --model <path> --context 32768 --kv-bits 8
@@ -80,6 +84,32 @@ def read_safetensors_index(model_path: str) -> dict:
                 continue
             index[name] = (meta["dtype"], tuple(meta["shape"]))
     return index
+
+
+def read_remote_index(repo_id: str) -> dict:
+    """{tensor_name: (dtype, shape)} for an un-downloaded HF repo.
+
+    `get_safetensors_metadata` fetches each shard's header with an HTTP range
+    request — bytes, not gigabytes. This is what makes "plan *before* the
+    download" true rather than a slogan: the 12.6 GB down4 repo answers in
+    ~2.5 s over the network with 2,026 tensors described and nothing cached.
+    """
+    from huggingface_hub import get_safetensors_metadata
+    meta = get_safetensors_metadata(repo_id)
+    index = {}
+    for shard in meta.files_metadata.values():
+        for name, t in shard.tensors.items():
+            index[name] = (t.dtype, tuple(t.shape))
+    if not index:
+        raise FileNotFoundError(f"{repo_id}: no safetensors metadata")
+    return index
+
+
+def read_remote_config(repo_id: str) -> dict:
+    """config.json only — a few KB, not the checkpoint."""
+    from huggingface_hub import hf_hub_download
+    with open(hf_hub_download(repo_id, "config.json")) as f:
+        return json.load(f)
 
 
 def footprint(index: dict) -> dict:
@@ -157,10 +187,32 @@ def prefill_workspace_bytes(cfg: dict, context: int, step: int) -> float:
 # machine
 # --------------------------------------------------------------------------
 
+def estimate_wss(ram_bytes: float | None) -> float | None:
+    """Estimate Metal's default working-set cap from RAM.
+
+    Apple's `recommendedMaxWorkingSetSize` is roughly two-thirds of RAM on small
+    machines and a larger fraction on big ones — measured here: a 16 GB mini
+    reports 10.5 GB (66%), a 68.7 GB M4 Max reports 55.7 GB (81%). A single
+    fraction can't serve both, so this is piecewise and deliberately biased LOW:
+    under-promising the cap costs a user an unnecessary flag, over-promising
+    costs them an OOM.
+    """
+    if not ram_bytes:
+        return None
+    frac = 0.66 if ram_bytes <= 36 * _GB else 0.75
+    return frac * ram_bytes
+
+
 def machine(wired_gb: float | None = None, ram_gb: float | None = None) -> dict:
     """Metal working-set cap + system RAM. Overridable so you can plan for a
-    machine you're not sitting at ("will this run on my 16 GB mini?")."""
-    out = {"assumed": bool(wired_gb or ram_gb)}
+    machine you're not sitting at ("will this run on my 16 GB mini?").
+
+    The two numbers MUST describe the same machine. Reading this device's
+    working set while the caller has assumed someone else's RAM is how you tell
+    a 16 GB mini that a 30 GB model fits — so an assumed --ram-gb estimates the
+    cap from that RAM instead of querying Metal here.
+    """
+    out = {"assumed": bool(wired_gb or ram_gb), "wss_estimated": False}
     if ram_gb:
         out["ram_bytes"] = ram_gb * _GB
     else:
@@ -169,15 +221,23 @@ def machine(wired_gb: float | None = None, ram_gb: float | None = None) -> dict:
                 ["sysctl", "-n", "hw.memsize"]).strip())
         except Exception:
             out["ram_bytes"] = None
+
     if wired_gb:
         out["wss_bytes"] = wired_gb * _GB
+    elif ram_gb:
+        # planning for another machine: this device's cap is irrelevant
+        out["wss_bytes"] = estimate_wss(out["ram_bytes"])
+        out["wss_estimated"] = True
     else:
         try:
             import mlx.core as mx
             out["wss_bytes"] = float(
                 mx.device_info()["max_recommended_working_set_size"])
         except Exception:
-            out["wss_bytes"] = None
+            # no Metal device (Linux/CI): fall back to the RAM estimate rather
+            # than leaving it unknown, which made every verdict "needs a bump"
+            out["wss_bytes"] = estimate_wss(out["ram_bytes"])
+            out["wss_estimated"] = out["wss_bytes"] is not None
     return out
 
 
@@ -187,14 +247,17 @@ def machine(wired_gb: float | None = None, ram_gb: float | None = None) -> dict:
 
 def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None,
                step: int | None = None, wired_gb: float | None = None,
-               ram_gb: float | None = None) -> dict:
-    cfg_path = os.path.join(model_path, "config.json")
-    if not os.path.isfile(cfg_path):
-        raise FileNotFoundError(f"{cfg_path} not found")
-    with open(cfg_path) as f:
-        cfg = json.load(f)
-
-    index = read_safetensors_index(model_path)
+               ram_gb: float | None = None, remote: bool = False) -> dict:
+    if remote:
+        cfg = read_remote_config(model_path)
+        index = read_remote_index(model_path)
+    else:
+        cfg_path = os.path.join(model_path, "config.json")
+        if not os.path.isfile(cfg_path):
+            raise FileNotFoundError(f"{cfg_path} not found")
+        with open(cfg_path) as f:
+            cfg = json.load(f)
+        index = read_safetensors_index(model_path)
     fp = footprint(index)
     mach = machine(wired_gb, ram_gb)
     c = _text_config(cfg)
@@ -292,7 +355,9 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
         "schema": 1,
         "model": {
             "path": model_path,
-            "name": os.path.basename(os.path.abspath(model_path)),
+            "source": "huggingface" if remote else "local",
+            "name": (model_path if remote
+                     else os.path.basename(os.path.abspath(model_path))),
             "type": cfg.get("model_type") or c.get("model_type"),
             "quantization": cfg.get("quantization", {}).get("mode"),
             "bits": cfg.get("quantization", {}).get("bits"),
@@ -403,20 +468,28 @@ def render(p: dict) -> str:
 def run_doctor(model_path: str, plan: dict) -> list:
     """[(check_id, status, message)] with stable ids for automation."""
     checks = []
+    if plan["model"].get("source") == "huggingface":
+        checks.append(("model.remote", "warn",
+                       f"{model_path} planned from remote headers — not "
+                       f"downloaded, so on-disk checks are skipped"))
 
     def add(cid, ok, msg, warn=False):
         checks.append((cid, "warn" if warn and not ok else
                        ("pass" if ok else "fail"), msg))
 
-    add("model.dir", os.path.isdir(model_path), f"model directory {model_path}")
-    add("model.config", os.path.isfile(os.path.join(model_path, "config.json")),
-        "config.json present")
-    shards = glob.glob(os.path.join(model_path, "*.safetensors"))
-    add("model.weights", bool(shards), f"{len(shards)} safetensors shard(s)")
-
-    tok = any(os.path.isfile(os.path.join(model_path, f)) for f in
-              ("tokenizer.json", "tokenizer.model", "tokenizer_config.json"))
-    add("model.tokenizer", tok, "tokenizer files present")
+    local = plan["model"].get("source") != "huggingface"
+    if local:
+        add("model.dir", os.path.isdir(model_path),
+            f"model directory {model_path}")
+    if local:
+        add("model.config",
+            os.path.isfile(os.path.join(model_path, "config.json")),
+            "config.json present")
+        shards = glob.glob(os.path.join(model_path, "*.safetensors"))
+        add("model.weights", bool(shards), f"{len(shards)} safetensors shard(s)")
+        tok = any(os.path.isfile(os.path.join(model_path, f)) for f in
+                  ("tokenizer.json", "tokenizer.model", "tokenizer_config.json"))
+        add("model.tokenizer", tok, "tokenizer files present")
 
     q = plan["model"]["quantization"]
     add("model.turboquant", q == "turboquant",
@@ -450,7 +523,7 @@ def run_doctor(model_path: str, plan: dict) -> list:
         add("fit.projection", plan["verdict"]["runnable"],
             f"placement: {v} — peak {pk} vs working set {_gb(mach['wss_bytes'])}")
 
-    if plan["model"]["is_moe"] and v == "streaming":
+    if local and plan["model"]["is_moe"] and v == "streaming":
         add("fit.hotlist",
             os.path.isfile(os.path.join(model_path, "hot_experts.json")),
             "hot_experts.json (warm-starts the streaming cache)", warn=True)
@@ -461,12 +534,18 @@ def run_doctor(model_path: str, plan: dict) -> list:
 # CLI
 # --------------------------------------------------------------------------
 
-def _resolve(path: str) -> str:
+def _resolve(path: str) -> tuple:
+    """(target, remote). A repo id is planned over the network from its headers —
+    never by downloading it, which would defeat the entire point of the tool.
+    A local cache hit is used directly when one exists."""
     p = os.path.expanduser(path)
     if os.path.isdir(p):
-        return p
-    from turboquant_mlx.generate import resolve_model_path
-    return resolve_model_path(path)
+        return p, False
+    try:                                    # already downloaded? use the cache
+        from huggingface_hub import snapshot_download
+        return snapshot_download(path, local_files_only=True), False
+    except Exception:
+        return path, True                   # plan it remotely, headers only
 
 
 def _common_args(ap):
@@ -492,10 +571,10 @@ def main(argv=None) -> int:
     _common_args(ap)
     args = ap.parse_args(argv)
     try:
-        path = _resolve(args.model)
+        path, remote = _resolve(args.model)
         p = build_plan(path, context=args.context, kv_bits=args.kv_bits,
                        step=args.prefill_step_size, wired_gb=args.wired_gb,
-                       ram_gb=args.ram_gb)
+                       ram_gb=args.ram_gb, remote=remote)
     except FileNotFoundError as e:
         print(f"error: {e}", file=sys.stderr)
         return _EXIT_UNFIT
@@ -514,10 +593,10 @@ def doctor_main(argv=None) -> int:
     _common_args(ap)
     args = ap.parse_args(argv)
     try:
-        path = _resolve(args.model)
+        path, remote = _resolve(args.model)
         p = build_plan(path, context=args.context, kv_bits=args.kv_bits,
                        step=args.prefill_step_size, wired_gb=args.wired_gb,
-                       ram_gb=args.ram_gb)
+                       ram_gb=args.ram_gb, remote=remote)
     except Exception as e:
         if args.json:
             print(json.dumps({"schema": 1, "checks": [

--- a/plan.py
+++ b/plan.py
@@ -1,0 +1,547 @@
+"""Preflight: will this model run on this Mac, and with what flags?
+
+`turboquant-plan` answers that **before** a multi-GB download or a five-minute
+load, by reading only safetensors *headers* and `config.json` — it allocates no
+tensors, starts no engine, and imports no model framework.
+
+Why this exists: the 0.13.0 auto-guards (`--metal-cache-limit-gb auto`,
+`--prompt-cache-max-gb auto`, `--cache-budget-gb auto`) fix tight-memory serving
+*at runtime*. They can't answer the question a user asks first — "will this fit,
+and what do I pass?" Every crash behind those guards was predictable from the
+model headers plus one machine number.
+
+The projection is deliberately explicit about what is exact and what is an
+estimate:
+
+  weights          EXACT   — summed from the safetensors headers
+  KV cache         DERIVED — 2 (K+V) x n_kv_heads x head_dim x full-attn layers
+                             x itemsize x context. Validated on the ternary 35B:
+                             predicts 0.67 GB at 32K vs 0.62 GB measured (+8%,
+                             i.e. conservative, which is what a planner should be).
+  prefill workspace ESTIMATE — chunk x context x n_attn_heads x 2 bytes, the
+                             transient attention scratch that scales with BOTH
+                             the chunk size and the context. Calibrated against
+                             the measured 16 GB mini boundary: at 21K context it
+                             puts --prefill-step-size 2048 over the wired cap
+                             (observed: OOM) and 256/128 under it (observed: runs).
+
+Usage:
+    turboquant-plan --model <path_or_repo>
+    turboquant-plan --model <path> --context 32768 --kv-bits 8
+    turboquant-plan --model <path> --wired-gb 13.5 --ram-gb 16   # plan for ANOTHER Mac
+    turboquant-plan --model <path> --json
+
+Exit codes: 0 = runnable (warnings allowed), 1 = won't fit / missing files,
+2 = bad usage.
+"""
+
+import argparse
+import glob
+import json
+import os
+import struct
+import subprocess
+import sys
+
+_ITEMSIZE = {"F64": 8, "I64": 8, "U64": 8, "F32": 4, "I32": 4, "U32": 4,
+             "F16": 2, "BF16": 2, "I16": 2, "U16": 2, "F8_E4M3": 1,
+             "F8_E5M2": 1, "I8": 1, "U8": 1, "BOOL": 1}
+
+_GB = 1e9
+
+# What we do NOT model line-by-line: the (capped) MLX buffer-reuse cache,
+# per-layer activations, and allocator fragmentation. Calibrated, not guessed:
+# the down4 35B measures a 13.60 GB peak on the mini against 12.59 GB of weights
+# and ~0.1 GB of KV, so the residue is ~0.9 GB. NOTE this is deliberately NOT the
+# 2 GB that serve.py/loader.py reserve — theirs has to *cover* KV and prefill
+# workspace, which this projection already counts explicitly; reusing 2 GB here
+# would double-count and wrongly report "streaming" for models that run resident.
+_RESERVE_BYTES = 1.0 * _GB
+_EXIT_OK, _EXIT_UNFIT, _EXIT_USAGE = 0, 1, 2
+
+
+# --------------------------------------------------------------------------
+# header-only model inspection
+# --------------------------------------------------------------------------
+
+def read_safetensors_index(model_path: str) -> dict:
+    """{tensor_name: (dtype, shape)} from shard headers. Opens each file, reads
+    the 8-byte length + JSON header, closes it. No payload is touched."""
+    shards = sorted(glob.glob(os.path.join(model_path, "*.safetensors")))
+    if not shards:
+        raise FileNotFoundError(f"no *.safetensors in {model_path}")
+    index = {}
+    for shard in shards:
+        with open(shard, "rb") as f:
+            n = struct.unpack("<Q", f.read(8))[0]
+            header = json.loads(f.read(n))
+        for name, meta in header.items():
+            if name == "__metadata__":
+                continue
+            index[name] = (meta["dtype"], tuple(meta["shape"]))
+    return index
+
+
+def footprint(index: dict) -> dict:
+    """Exact byte split: total / streamable experts / always-resident."""
+    total = expert = 0
+    for name, (dtype, shape) in index.items():
+        n = 1
+        for d in shape:
+            n *= d
+        b = n * _ITEMSIZE.get(dtype, 4)
+        total += b
+        # what the streaming swap pages from disk (mirrors
+        # stream/loader.py:_streamed_expert_bytes)
+        if "switch_mlp" in name and (name.endswith(".weight")
+                                     or name.endswith(".scales")):
+            expert += b
+    return {"total_bytes": total, "expert_bytes": expert,
+            "resident_bytes": total - expert}
+
+
+def _text_config(cfg: dict) -> dict:
+    """Multimodal repos nest the LM config under text_config."""
+    return cfg.get("text_config", cfg)
+
+
+def kv_bytes_per_token(cfg: dict, kv_bits: int | None = None) -> tuple:
+    """(bytes/token, n_full_attention_layers, n_layers, note).
+
+    Hybrid models (Qwen3.5/3.6 GatedDeltaNet) only grow KV on their
+    full-attention layers — `layer_types` names them; `full_attention_interval`
+    is the fallback. Returns (None, ...) when the config doesn't say enough.
+    """
+    c = _text_config(cfg)
+    n_layers = c.get("num_hidden_layers")
+    n_kv = c.get("num_key_value_heads") or c.get("num_attention_heads")
+    head_dim = c.get("head_dim")
+    if head_dim is None and c.get("hidden_size") and c.get("num_attention_heads"):
+        head_dim = c["hidden_size"] // c["num_attention_heads"]
+    if not (n_layers and n_kv and head_dim):
+        return None, None, n_layers, "config lacks KV geometry"
+
+    note = "all layers full-attention"
+    types = c.get("layer_types")
+    if isinstance(types, list) and types:
+        n_full = sum(1 for t in types if "full" in str(t))
+        note = f"hybrid: {n_full}/{len(types)} full-attention layers"
+    elif c.get("full_attention_interval"):
+        iv = int(c["full_attention_interval"])
+        n_full = n_layers // iv
+        note = f"hybrid: every {iv}th layer full-attention"
+    else:
+        n_full = n_layers
+
+    itemsize = 2.0  # fp16 KV
+    if kv_bits:
+        # TurboQuant KV-quant stores kv_bits/16 of the fp16 payload (+ scales,
+        # which are small); --kv-bits 8 halving KV matches the measured 35B.
+        itemsize = 2.0 * (kv_bits / 16.0)
+    per_token = 2 * n_kv * head_dim * n_full * itemsize
+    return per_token, n_full, n_layers, note
+
+
+def prefill_workspace_bytes(cfg: dict, context: int, step: int) -> float:
+    """Transient attention scratch for one prefill chunk (ESTIMATE).
+
+    Scales with chunk size AND context — which is why a long agent turn can OOM
+    at a chunk size that was fine when the conversation was short.
+    """
+    c = _text_config(cfg)
+    heads = c.get("num_attention_heads") or 16
+    return float(step) * float(context) * float(heads) * 2.0
+
+
+# --------------------------------------------------------------------------
+# machine
+# --------------------------------------------------------------------------
+
+def machine(wired_gb: float | None = None, ram_gb: float | None = None) -> dict:
+    """Metal working-set cap + system RAM. Overridable so you can plan for a
+    machine you're not sitting at ("will this run on my 16 GB mini?")."""
+    out = {"assumed": bool(wired_gb or ram_gb)}
+    if ram_gb:
+        out["ram_bytes"] = ram_gb * _GB
+    else:
+        try:
+            out["ram_bytes"] = float(subprocess.check_output(
+                ["sysctl", "-n", "hw.memsize"]).strip())
+        except Exception:
+            out["ram_bytes"] = None
+    if wired_gb:
+        out["wss_bytes"] = wired_gb * _GB
+    else:
+        try:
+            import mlx.core as mx
+            out["wss_bytes"] = float(
+                mx.device_info()["max_recommended_working_set_size"])
+        except Exception:
+            out["wss_bytes"] = None
+    return out
+
+
+# --------------------------------------------------------------------------
+# the plan
+# --------------------------------------------------------------------------
+
+def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None,
+               step: int | None = None, wired_gb: float | None = None,
+               ram_gb: float | None = None) -> dict:
+    cfg_path = os.path.join(model_path, "config.json")
+    if not os.path.isfile(cfg_path):
+        raise FileNotFoundError(f"{cfg_path} not found")
+    with open(cfg_path) as f:
+        cfg = json.load(f)
+
+    index = read_safetensors_index(model_path)
+    fp = footprint(index)
+    mach = machine(wired_gb, ram_gb)
+    c = _text_config(cfg)
+
+    kv_pt, n_full, n_layers, kv_note = kv_bytes_per_token(cfg, kv_bits)
+    kv_total = (kv_pt or 0) * context
+
+    wss = mach["wss_bytes"]
+    ram = mach["ram_bytes"]
+    is_moe = fp["expert_bytes"] > 0
+    warnings, flags = [], []
+
+    # The Metal wired cap is NOT fixed — `sysctl iogpu.wired_limit_mb` raises it,
+    # which is exactly what the 16 GB mini does to run a 12.6 GB model resident.
+    # So the hard ceiling is RAM (minus what the OS needs), and the cap is a
+    # knob. Raising it too far starves the OS and can panic a small box, so cap
+    # the recommendation at 90% of RAM — the measured mini runs at 14 GiB / 16 GB
+    # (87.5%).
+    raisable = min(ram * 0.90, ram - 1.5 * _GB) if ram else None
+    ceiling = max(wss or 0, raisable or 0) or wss
+
+    def peak_at(s):
+        # weights + KV + this chunk's transient + a runtime reserve. The reserve
+        # is not slack: MLX's buffer-reuse cache alone grew ~80 MB per 1K prompt
+        # tokens on the mini (~1.7 GB at 21K) before --metal-cache-limit-gb auto
+        # capped it, and activations/fragmentation live here too. Same 2 GB the
+        # auto-guards reserve.
+        return (fp["total_bytes"] + kv_total
+                + prefill_workspace_bytes(cfg, context, s) + _RESERVE_BYTES)
+
+    # Largest chunk whose projection keeps real headroom under the (possibly
+    # raised) ceiling. The 0.95 is deliberate: a chunk size chosen to *just* fit
+    # is the crash we already shipped fixes for, and prefill throughput barely
+    # moves between 512 and 128 while peak transient scales linearly. Bias
+    # conservative — this tool exists to prevent OOMs, not to win benchmarks.
+    steps = [2048, 512, 256, 128] if step is None else [step]
+    chosen = None
+    for s in steps:
+        if step is not None or ceiling is None or peak_at(s) <= ceiling * 0.95:
+            chosen = s
+            break
+    if chosen is None:
+        chosen = steps[-1]
+    peak = peak_at(chosen)
+    workspace = prefill_workspace_bytes(cfg, context, chosen)
+
+    # ---- verdict -------------------------------------------------------
+    needs_bump = False
+    if wss is None and ram is None:
+        mode, ok = "unknown", True
+        warnings.append("no Metal device info — machine limits unknown")
+    elif wss and peak <= wss:
+        mode, ok = "resident", True
+    elif ceiling and peak <= ceiling:
+        mode, ok, needs_bump = "resident", True, True
+    elif is_moe and ceiling and (fp["resident_bytes"] + 0.5 * _GB + kv_total
+                                 + workspace + _RESERVE_BYTES) <= ceiling:
+        mode, ok = "streaming", True
+        needs_bump = bool(wss and (fp["resident_bytes"] + 0.5 * _GB + kv_total
+                                   + workspace + _RESERVE_BYTES) > wss)
+    else:
+        mode, ok = "no-fit", False
+
+    # ---- recommended flags --------------------------------------------
+    if needs_bump and ram:
+        want = min(peak + 0.5 * _GB, raisable)
+        mb = int(want / (1024**2))
+        flags.append(f"sudo sysctl -w iogpu.wired_limit_mb={mb}   "
+                     f"(raises the {_gb(wss)} Metal cap — the binding limit "
+                     f"here, not your {ram/_GB:.0f} GB of RAM; resets on reboot)")
+    if mode == "streaming":
+        flags.append("--streaming   (weights exceed even the raised cap; "
+                     "experts page from disk)")
+        budget = max(0.5, ((ceiling or 0) * 0.8 - fp["resident_bytes"]
+                           - _RESERVE_BYTES) / _GB)
+        flags.append(f"--cache-budget-gb auto   (~{budget:.1f} GB here)")
+    if chosen != 2048:
+        flags.append(f"--prefill-step-size {chosen}   (the default 2048 needs "
+                     f"{_gb(prefill_workspace_bytes(cfg, context, 2048))} of "
+                     f"transient workspace at this context)")
+    if kv_bits:
+        flags.append(f"--kv-bits {kv_bits}")
+    elif kv_total > 1.0 * _GB:
+        flags.append("--kv-bits 8   (KV is over 1 GB at this context; "
+                     "halves it)")
+
+    if mode == "no-fit" and is_moe:
+        warnings.append("even streaming does not fit — the resident backbone "
+                        "alone exceeds what this machine can wire")
+    if mode == "resident" and ceiling and peak > ceiling * 0.93:
+        warnings.append("tight: under ~7% headroom — a longer context or a "
+                        "background app can still push it over")
+
+    return {
+        "schema": 1,
+        "model": {
+            "path": model_path,
+            "name": os.path.basename(os.path.abspath(model_path)),
+            "type": cfg.get("model_type") or c.get("model_type"),
+            "quantization": cfg.get("quantization", {}).get("mode"),
+            "bits": cfg.get("quantization", {}).get("bits"),
+            "group_size": cfg.get("quantization", {}).get("group_size"),
+            "expert_down_bits": cfg.get("quantization", {}).get(
+                "expert_down_bits"),
+            "n_layers": n_layers,
+            "n_experts": c.get("num_experts"),
+            "experts_per_tok": c.get("num_experts_per_tok"),
+            "is_moe": is_moe,
+            **fp,
+        },
+        "machine": mach,
+        "projection": {
+            "context": context,
+            "kv_bits": kv_bits,
+            "kv_bytes_per_token": kv_pt,
+            "kv_bytes": kv_total,
+            "kv_note": kv_note,
+            "prefill_step_size": chosen,
+            "prefill_workspace_bytes": workspace,
+            "runtime_reserve_bytes": _RESERVE_BYTES,
+            "peak_bytes": peak,
+            "ceiling_bytes": ceiling,
+            "headroom_bytes": (ceiling - peak) if ceiling else None,
+        },
+        "verdict": {"mode": mode, "runnable": ok, "needs_wired_bump": needs_bump},
+        "flags": flags,
+        "warnings": warnings,
+    }
+
+
+# --------------------------------------------------------------------------
+# rendering
+# --------------------------------------------------------------------------
+
+def _gb(b) -> str:
+    return "?" if b is None else f"{b / _GB:.2f} GB"
+
+
+def render(p: dict) -> str:
+    m, mach, pr, v = p["model"], p["machine"], p["projection"], p["verdict"]
+    L = []
+    L.append(f"TurboQuant plan — {m['name']}")
+    L.append("")
+    L.append("Model")
+    q = f"{m['quantization']} {m['bits']}-bit g{m['group_size']}" if m[
+        "quantization"] else "unquantized"
+    if m.get("expert_down_bits"):
+        q += f", expert down_proj {m['expert_down_bits']}-bit"
+    L.append(f"  {'type':<20} {m['type']}  ({q})")
+    if m["is_moe"]:
+        L.append(f"  {'MoE':<20} {m['n_experts']} experts, "
+                 f"top-{m['experts_per_tok']}, {m['n_layers']} layers")
+    L.append(f"  {'weights (exact)':<20} {_gb(m['total_bytes'])}")
+    if m["is_moe"]:
+        L.append(f"  {'  experts':<20} {_gb(m['expert_bytes'])}  (streamable)")
+        L.append(f"  {'  resident':<20} {_gb(m['resident_bytes'])}  "
+                 f"(attention, embeddings, routers)")
+    L.append("")
+    L.append("Machine" + ("  (assumed, not this one)" if mach["assumed"] else ""))
+    L.append(f"  {'Metal working set':<20} {_gb(mach['wss_bytes'])}   "
+             f"← the real ceiling")
+    L.append(f"  {'system RAM':<20} {_gb(mach['ram_bytes'])}")
+    L.append("")
+    L.append(f"Projection at {pr['context']:,} tokens of context")
+    L.append(f"  {'weights':<20} {_gb(m['total_bytes'])}")
+    kvb = f"  ({pr['kv_bytes_per_token']/1024:.1f} KB/token, {pr['kv_note']})" \
+        if pr["kv_bytes_per_token"] else f"  ({pr['kv_note']})"
+    L.append(f"  {'KV cache':<20} {_gb(pr['kv_bytes'])}{kvb}")
+    L.append(f"  {'prefill workspace':<20} {_gb(pr['prefill_workspace_bytes'])}"
+             f"  (estimate, at --prefill-step-size {pr['prefill_step_size']})")
+    L.append(f"  {'runtime reserve':<20} {_gb(pr['runtime_reserve_bytes'])}"
+             f"  (buffer cache, activations, fragmentation)")
+    L.append(f"  {'':<20} {'-' * 34}")
+    head = ""
+    if pr["headroom_bytes"] is not None:
+        head = (f"   {_gb(pr['headroom_bytes'])} headroom"
+                if pr["headroom_bytes"] > 0 else
+                f"   OVER by {_gb(-pr['headroom_bytes'])}")
+    L.append(f"  {'peak':<20} {_gb(pr['peak_bytes'])}"
+             f" of {_gb(pr['ceiling_bytes'])} usable{head}")
+    L.append("")
+    icon = {"resident": "✅", "streaming": "⚠️ ", "no-fit": "❌",
+            "unknown": "❔"}[v["mode"]]
+    label = {"resident": "RESIDENT — fits fully in memory",
+             "streaming": "STREAMING — too big to hold; experts page from disk",
+             "no-fit": "WILL NOT RUN on this machine",
+             "unknown": "UNKNOWN — could not read the Metal working set"}[v["mode"]]
+    if v["mode"] == "resident" and v.get("needs_wired_bump"):
+        label = "RESIDENT — fits, but only after raising the Metal wired cap"
+        icon = "⚠️ "
+    L.append(f"Verdict: {icon} {label}")
+    for w in p["warnings"]:
+        L.append(f"  ! {w}")
+    if p["flags"]:
+        L.append("")
+        L.append("Recommended:")
+        for f in p["flags"]:
+            L.append(f"  {f}")
+    return "\n".join(L)
+
+
+# --------------------------------------------------------------------------
+# doctor — readiness, not just arithmetic
+# --------------------------------------------------------------------------
+
+def run_doctor(model_path: str, plan: dict) -> list:
+    """[(check_id, status, message)] with stable ids for automation."""
+    checks = []
+
+    def add(cid, ok, msg, warn=False):
+        checks.append((cid, "warn" if warn and not ok else
+                       ("pass" if ok else "fail"), msg))
+
+    add("model.dir", os.path.isdir(model_path), f"model directory {model_path}")
+    add("model.config", os.path.isfile(os.path.join(model_path, "config.json")),
+        "config.json present")
+    shards = glob.glob(os.path.join(model_path, "*.safetensors"))
+    add("model.weights", bool(shards), f"{len(shards)} safetensors shard(s)")
+
+    tok = any(os.path.isfile(os.path.join(model_path, f)) for f in
+              ("tokenizer.json", "tokenizer.model", "tokenizer_config.json"))
+    add("model.tokenizer", tok, "tokenizer files present")
+
+    q = plan["model"]["quantization"]
+    add("model.turboquant", q == "turboquant",
+        f"quantization: {q}" if q == "turboquant" else
+        f"quantization block: {q or 'none'} — not a TurboQuant model "
+        f"(a plain MLX model runs with mlx_lm, not turboquant)")
+
+    try:
+        import mlx.core as mx
+        add("env.mlx", True, f"mlx {getattr(mx, '__version__', '?')}")
+    except Exception as e:
+        add("env.mlx", False, f"mlx not importable: {e}")
+
+    try:
+        import mlx_lm
+        add("env.mlx_lm", True, f"mlx-lm {getattr(mlx_lm, '__version__', '?')}")
+    except Exception as e:
+        add("env.mlx_lm", False, f"mlx-lm not importable: {e}")
+
+    mach = plan["machine"]
+    add("machine.wss", mach["wss_bytes"] is not None,
+        f"Metal working set {_gb(mach['wss_bytes'])}")
+
+    v = plan["verdict"]["mode"]
+    pk = _gb(plan["projection"]["peak_bytes"])
+    if plan["verdict"].get("needs_wired_bump"):
+        msg = (f"placement: {v} — peak {pk} exceeds the current "
+               f"{_gb(mach['wss_bytes'])} Metal cap; needs the sysctl raise below")
+        add("fit.projection", False, msg, warn=True)
+    else:
+        add("fit.projection", plan["verdict"]["runnable"],
+            f"placement: {v} — peak {pk} vs working set {_gb(mach['wss_bytes'])}")
+
+    if plan["model"]["is_moe"] and v == "streaming":
+        add("fit.hotlist",
+            os.path.isfile(os.path.join(model_path, "hot_experts.json")),
+            "hot_experts.json (warm-starts the streaming cache)", warn=True)
+    return checks
+
+
+# --------------------------------------------------------------------------
+# CLI
+# --------------------------------------------------------------------------
+
+def _resolve(path: str) -> str:
+    p = os.path.expanduser(path)
+    if os.path.isdir(p):
+        return p
+    from turboquant_mlx.generate import resolve_model_path
+    return resolve_model_path(path)
+
+
+def _common_args(ap):
+    ap.add_argument("--model", required=True, help="local dir or HF repo id")
+    ap.add_argument("--context", type=int, default=16384,
+                    help="context length to plan for (default 16384)")
+    ap.add_argument("--kv-bits", type=int, default=None,
+                    help="plan with TurboQuant KV quantization")
+    ap.add_argument("--prefill-step-size", type=int, default=None,
+                    help="force a chunk size instead of picking the largest safe one")
+    ap.add_argument("--wired-gb", type=float, default=None,
+                    help="assume this Metal working set (plan for another Mac)")
+    ap.add_argument("--ram-gb", type=float, default=None,
+                    help="assume this much system RAM")
+    ap.add_argument("--json", action="store_true", help="machine-readable output")
+
+
+def main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="turboquant-plan",
+        description="Will this model run on this Mac, and with what flags? "
+                    "Reads only safetensors headers — no tensors are loaded.")
+    _common_args(ap)
+    args = ap.parse_args(argv)
+    try:
+        path = _resolve(args.model)
+        p = build_plan(path, context=args.context, kv_bits=args.kv_bits,
+                       step=args.prefill_step_size, wired_gb=args.wired_gb,
+                       ram_gb=args.ram_gb)
+    except FileNotFoundError as e:
+        print(f"error: {e}", file=sys.stderr)
+        return _EXIT_UNFIT
+    except Exception as e:
+        print(f"error: {e}", file=sys.stderr)
+        return _EXIT_USAGE
+    print(json.dumps(p, indent=2) if args.json else render(p))
+    return _EXIT_OK if p["verdict"]["runnable"] else _EXIT_UNFIT
+
+
+def doctor_main(argv=None) -> int:
+    ap = argparse.ArgumentParser(
+        prog="turboquant-doctor",
+        description="Read-only readiness check: model files, environment, and "
+                    "whether the projected placement is runnable.")
+    _common_args(ap)
+    args = ap.parse_args(argv)
+    try:
+        path = _resolve(args.model)
+        p = build_plan(path, context=args.context, kv_bits=args.kv_bits,
+                       step=args.prefill_step_size, wired_gb=args.wired_gb,
+                       ram_gb=args.ram_gb)
+    except Exception as e:
+        if args.json:
+            print(json.dumps({"schema": 1, "checks": [
+                ["model.readable", "fail", str(e)]]}, indent=2))
+        else:
+            print(f"✗ model.readable   {e}", file=sys.stderr)
+        return _EXIT_UNFIT
+
+    checks = run_doctor(path, p)
+    if args.json:
+        print(json.dumps({"schema": 1, "verdict": p["verdict"],
+                          "checks": [list(c) for c in checks],
+                          "flags": p["flags"]}, indent=2))
+    else:
+        print(f"turboquant-doctor — {p['model']['name']}\n")
+        icon = {"pass": "✓", "warn": "!", "fail": "✗"}
+        for cid, status, msg in checks:
+            print(f"  {icon[status]} {cid:<20} {msg}")
+        if p["flags"]:
+            print("\nRecommended:")
+            for f in p["flags"]:
+                print(f"  {f}")
+    return _EXIT_OK if not any(s == "fail" for _, s, _ in checks) else _EXIT_UNFIT
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,8 @@ Issues = "https://github.com/manjunathshiva/turboquant-mlx/issues"
 turboquant-convert = "turboquant_mlx.convert:main"
 turboquant-generate = "turboquant_mlx.generate:main"
 turboquant-serve = "turboquant_mlx.serve:main"
+turboquant-plan = "turboquant_mlx.plan:main"
+turboquant-doctor = "turboquant_mlx.plan:doctor_main"
 
 # package-dir trick: the git repo root IS the importable `turboquant_mlx`
 # package, so we map the package name to the current directory and explicitly

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -13,6 +13,8 @@ import pytest
 from turboquant_mlx.plan import (
     _RESERVE_BYTES,
     build_plan,
+    estimate_wss,
+    machine,
     footprint,
     kv_bytes_per_token,
     prefill_workspace_bytes,
@@ -182,6 +184,104 @@ class TestFieldCalibration:
         """The projection counts KV and workspace explicitly, so the reserve
         must be the *residue* (~1 GB measured), not serve.py's 2 GB budget."""
         assert _RESERVE_BYTES == pytest.approx(1.0 * GB)
+
+
+class TestMachineIsOneMachine:
+    """Review findings (PR #50): wss and ram must describe the SAME machine, and
+    an unknown cap must not turn every verdict into 'needs a sudo bump'."""
+
+    def _model(self, tmp_path, gb):
+        n = int(gb * GB / 4)
+        return _write_model(tmp_path, Q35, {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (n,)),
+        })
+
+    def test_assumed_ram_does_not_borrow_this_machines_wss(self, tmp_path):
+        """Planning a 30 GB model for a 16 GB mini must not read the 55 GB
+        working set of the machine running the command."""
+        pl = build_plan(self._model(tmp_path, 30), ram_gb=16)
+        assert pl["machine"]["wss_estimated"]
+        assert pl["machine"]["wss_bytes"] < 12 * GB, \
+            "used the host's working set for an assumed 16 GB machine"
+        assert pl["verdict"]["mode"] == "streaming"
+
+    def test_small_model_is_never_told_to_sudo(self, tmp_path):
+        """A 2 GB model on 16 GB fits the default cap; recommending a wired
+        bump for it is noise."""
+        pl = build_plan(self._model(tmp_path, 2), ram_gb=16)
+        assert pl["verdict"]["mode"] == "resident"
+        assert not pl["verdict"]["needs_wired_bump"]
+        assert not any("sysctl" in f for f in pl["flags"])
+
+    def test_wss_estimate_tracks_the_measured_caps(self):
+        """16 GB mini reports 10.5 GB; 68.7 GB M4 Max reports 55.7 GB. The
+        estimate must be close on small machines and never optimistic."""
+        assert estimate_wss(16 * GB) == pytest.approx(10.5 * GB, abs=0.3 * GB)
+        assert estimate_wss(68.72 * GB) <= 55.66 * GB
+        assert estimate_wss(None) is None
+
+    def test_explicit_wired_gb_wins(self, tmp_path):
+        pl = build_plan(self._model(tmp_path, 2), ram_gb=16, wired_gb=13.5)
+        assert pl["machine"]["wss_bytes"] == pytest.approx(13.5 * GB)
+        assert not pl["machine"]["wss_estimated"]
+
+    def test_no_metal_device_falls_back_to_the_estimate(self, tmp_path, monkeypatch):
+        """On a box with no Metal (CI/Linux) the cap is unknown — estimate it
+        from RAM instead of flagging a bump for everything."""
+        import builtins
+        real = builtins.__import__
+
+        def no_mlx(name, *a, **k):
+            if name == "mlx.core":
+                raise ImportError("no metal here")
+            return real(name, *a, **k)
+
+        monkeypatch.setattr(builtins, "__import__", no_mlx)
+        m = machine()          # no overrides: must not raise, must not be None
+        assert m["wss_bytes"] is None or m["wss_estimated"]
+
+
+class TestRemotePlanning:
+    """A repo id must be planned from headers over the network — downloading it
+    would defeat the entire purpose of a preflight tool."""
+
+    def test_repo_id_uses_remote_headers_not_a_download(self, monkeypatch):
+        import turboquant_mlx.plan as P
+        calls = {"cfg": 0, "idx": 0}
+
+        def fake_cfg(repo):
+            calls["cfg"] += 1
+            return Q35
+
+        def fake_idx(repo):
+            calls["idx"] += 1
+            n = int(9.45 * GB / 4)
+            return {"model.layers.0.mlp.switch_mlp.gate_proj.weight":
+                    ("U32", (n,))}
+
+        monkeypatch.setattr(P, "read_remote_config", fake_cfg)
+        monkeypatch.setattr(P, "read_remote_index", fake_idx)
+        # a downloader in this path would be a bug: make it explode
+        monkeypatch.setattr(P, "read_safetensors_index", lambda p: 1 / 0)
+
+        pl = P.build_plan("org/some-repo", remote=True, wired_gb=10.5, ram_gb=16,
+                          context=512)
+        assert calls == {"cfg": 1, "idx": 1}
+        assert pl["model"]["source"] == "huggingface"
+        assert pl["model"]["name"] == "org/some-repo"
+        assert pl["verdict"]["mode"] == "resident"
+
+    def test_doctor_skips_on_disk_checks_for_a_remote_model(self, monkeypatch):
+        import turboquant_mlx.plan as P
+        monkeypatch.setattr(P, "read_remote_config", lambda r: Q35)
+        monkeypatch.setattr(P, "read_remote_index", lambda r: {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight":
+                ("U32", (int(9.45 * GB / 4),))})
+        pl = P.build_plan("org/repo", remote=True, wired_gb=10.5, ram_gb=16)
+        checks = P.run_doctor("org/repo", pl)
+        ids = {c[0] for c in checks}
+        assert "model.remote" in ids
+        assert "model.dir" not in ids and "model.tokenizer" not in ids
 
 
 class TestOutput:

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -1,0 +1,213 @@
+"""Tests for the preflight planner (turboquant-plan / turboquant-doctor).
+
+The load-bearing tests are the FIELD ones: the projection is calibrated against
+what the 16 GB mini actually did, and those numbers are the whole reason to trust
+the tool. If a refactor drifts the calibration, these fail.
+"""
+
+import json
+import struct
+
+import pytest
+
+from turboquant_mlx.plan import (
+    _RESERVE_BYTES,
+    build_plan,
+    footprint,
+    kv_bytes_per_token,
+    prefill_workspace_bytes,
+    read_safetensors_index,
+    render,
+    run_doctor,
+)
+
+GB = 1e9
+
+# Qwen3.6-35B-A3B geometry (the real one, from the shipped config)
+Q35 = {
+    "model_type": "qwen3_5_moe",
+    "quantization": {"mode": "turboquant", "bits": 3, "group_size": 64},
+    "text_config": {
+        "num_hidden_layers": 40,
+        "hidden_size": 2048,
+        "num_attention_heads": 16,
+        "num_key_value_heads": 2,
+        "head_dim": 256,
+        "num_experts": 256,
+        "num_experts_per_tok": 8,
+        # 10 of 40 layers are full attention (hybrid GatedDeltaNet)
+        "layer_types": (["linear_attention"] * 3 + ["full_attention"]) * 10,
+    },
+}
+
+
+def _write_model(tmp_path, cfg, tensors):
+    """Minimal on-disk model: config.json + one shard whose HEADER is real but
+    whose payload is zero-filled (the planner must never read the payload)."""
+    (tmp_path / "config.json").write_text(json.dumps(cfg))
+    header, off = {}, 0
+    for name, (dtype, shape) in tensors.items():
+        n = 1
+        for d in shape:
+            n *= d
+        size = n * {"U32": 4, "F16": 2, "F32": 4}[dtype]
+        header[name] = {"dtype": dtype, "shape": list(shape),
+                        "data_offsets": [off, off + size]}
+        off += size
+    blob = json.dumps(header).encode()
+    with open(tmp_path / "model.safetensors", "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)
+        # NOTE: no payload written. A planner that reads tensors breaks here.
+    (tmp_path / "tokenizer.json").write_text("{}")
+    return str(tmp_path)
+
+
+class TestFootprint:
+    def test_splits_experts_from_resident(self):
+        idx = {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (256, 768, 96)),
+            "model.layers.0.mlp.switch_mlp.gate_proj.scales": ("F16", (256, 768, 32)),
+            "model.layers.0.self_attn.q_proj.weight": ("U32", (2048, 96)),
+            "model.embed_tokens.weight": ("F16", (150000, 2048)),
+        }
+        fp = footprint(idx)
+        assert fp["expert_bytes"] > 0
+        assert fp["resident_bytes"] > 0
+        assert fp["total_bytes"] == fp["expert_bytes"] + fp["resident_bytes"]
+
+    def test_router_gate_is_not_an_expert(self):
+        # the router must stay resident — it is not a switch_mlp tensor
+        idx = {"model.layers.0.mlp.gate.weight": ("F16", (256, 2048))}
+        assert footprint(idx)["expert_bytes"] == 0
+
+    def test_header_only_never_reads_payload(self, tmp_path):
+        p = _write_model(tmp_path, Q35,
+                         {"model.embed_tokens.weight": ("F16", (1000, 64))})
+        idx = read_safetensors_index(p)          # payload absent from the file
+        assert idx["model.embed_tokens.weight"] == ("F16", (1000, 64))
+
+
+class TestKV:
+    def test_hybrid_counts_only_full_attention_layers(self):
+        per_tok, n_full, n_layers, note = kv_bytes_per_token(Q35)
+        assert (n_full, n_layers) == (10, 40)
+        # 2 (K+V) * 2 kv-heads * 256 head_dim * 10 layers * 2 bytes
+        assert per_tok == 2 * 2 * 256 * 10 * 2
+        assert "hybrid" in note
+
+    def test_field_measurement_32k(self):
+        """Ternary 35B measured 0.62 GB of KV at 32K. Predict within 10%, and
+        on the conservative side — a planner that under-predicts is a crash."""
+        per_tok, *_ = kv_bytes_per_token(Q35)
+        pred = per_tok * 32768 / GB
+        assert pred >= 0.62, "planner must not under-predict KV"
+        assert abs(pred - 0.62) / 0.62 < 0.10
+
+    def test_kv_bits_halves_at_8(self):
+        fp16, *_ = kv_bytes_per_token(Q35)
+        kv8, *_ = kv_bytes_per_token(Q35, kv_bits=8)
+        assert kv8 == pytest.approx(fp16 / 2)
+
+    def test_missing_geometry_returns_none(self):
+        per_tok, _, _, note = kv_bytes_per_token({"text_config": {}})
+        assert per_tok is None and "lacks" in note
+
+
+class TestWorkspace:
+    def test_scales_with_chunk_and_context(self):
+        a = prefill_workspace_bytes(Q35, 21000, 2048)
+        b = prefill_workspace_bytes(Q35, 21000, 128)
+        assert a == pytest.approx(b * 16)          # linear in chunk
+        c = prefill_workspace_bytes(Q35, 42000, 128)
+        assert c == pytest.approx(b * 2)           # linear in context
+
+
+class TestFieldCalibration:
+    """The mini datapoints. These are the reason the tool is trustworthy."""
+
+    def _plan(self, tmp_path, weight_gb, **kw):
+        # one fake expert tensor sized to hit the target total
+        n = int(weight_gb * GB / 4)
+        p = _write_model(tmp_path, Q35, {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (n,)),
+        })
+        return build_plan(p, wired_gb=10.5, ram_gb=16, **kw)
+
+    def test_ternary_9_4gb_short_context_fits_default_cap(self, tmp_path):
+        """Field: 10.42 GB peak at 512 tokens, runs under the DEFAULT wired cap
+        with no sudo. The published model card promises exactly this."""
+        pl = self._plan(tmp_path, 9.45, context=512)
+        assert pl["projection"]["peak_bytes"] / GB == pytest.approx(10.42, abs=0.15)
+        assert pl["verdict"]["mode"] == "resident"
+        assert not pl["verdict"]["needs_wired_bump"], \
+            "must not tell users to sudo for the no-sudo build"
+
+    def test_down4_12_6gb_needs_the_wired_bump(self, tmp_path):
+        """Field: 12.6 GB build needs `sysctl iogpu.wired_limit_mb=13824`, and
+        then runs RESIDENT — it must NOT be told to stream."""
+        pl = self._plan(tmp_path, 12.59, context=8000, kv_bits=8)
+        assert pl["verdict"]["mode"] == "resident"
+        assert pl["verdict"]["needs_wired_bump"]
+        bump = [f for f in pl["flags"] if "iogpu.wired_limit_mb" in f]
+        assert bump, "should recommend the sysctl raise"
+        mb = int(bump[0].split("iogpu.wired_limit_mb=")[1].split()[0])
+        assert 13000 <= mb <= 14500, f"bump {mb} MiB is far from the field's 13824"
+
+    def test_long_agent_context_forces_a_small_prefill_step(self, tmp_path):
+        """Field: 21K context on the mini needs --prefill-step-size 128; the
+        2048 default OOMs."""
+        pl = self._plan(tmp_path, 12.59, context=21000, kv_bits=8)
+        assert pl["projection"]["prefill_step_size"] <= 256
+        assert any("prefill-step-size" in f for f in pl["flags"])
+
+    def test_roomy_machine_keeps_the_fast_default(self, tmp_path):
+        n = int(12.59 * GB / 4)
+        p = _write_model(tmp_path, Q35, {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (n,)),
+        })
+        pl = build_plan(p, wired_gb=55.7, ram_gb=68.7, context=16384)
+        assert pl["verdict"]["mode"] == "resident"
+        assert not pl["verdict"]["needs_wired_bump"]
+        assert pl["projection"]["prefill_step_size"] == 2048
+
+    def test_model_far_past_ram_streams(self, tmp_path):
+        """A 122B-class build on a 16 GB mini: experts page from disk."""
+        pl = self._plan(tmp_path, 30.9, context=4096)
+        assert pl["verdict"]["mode"] == "streaming"
+        assert any("--streaming" in f for f in pl["flags"])
+        assert any("cache-budget-gb" in f for f in pl["flags"])
+
+    def test_reserve_does_not_double_count_kv_and_prefill(self):
+        """The projection counts KV and workspace explicitly, so the reserve
+        must be the *residue* (~1 GB measured), not serve.py's 2 GB budget."""
+        assert _RESERVE_BYTES == pytest.approx(1.0 * GB)
+
+
+class TestOutput:
+    def test_render_and_doctor(self, tmp_path):
+        n = int(9.45 * GB / 4)
+        p = _write_model(tmp_path, Q35, {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (n,)),
+        })
+        pl = build_plan(p, wired_gb=10.5, ram_gb=16, context=512)
+        text = render(pl)
+        assert "Verdict:" in text and "RESIDENT" in text
+        checks = run_doctor(p, pl)
+        ids = {c[0] for c in checks}
+        assert {"model.config", "model.weights", "model.tokenizer",
+                "fit.projection"} <= ids
+        assert all(s in ("pass", "warn", "fail") for _, s, _ in checks)
+
+    def test_json_is_serialisable(self, tmp_path):
+        n = int(9.45 * GB / 4)
+        p = _write_model(tmp_path, Q35, {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (n,)),
+        })
+        pl = build_plan(p, wired_gb=10.5, ram_gb=16)
+        json.dumps(pl)          # must not raise
+        assert pl["schema"] == 1
+
+    def test_missing_config_raises(self, tmp_path):
+        with pytest.raises(FileNotFoundError):
+            build_plan(str(tmp_path))


### PR DESCRIPTION
## Why

The 0.13.0 auto-guards fix tight-memory serving **at runtime**. They can't answer the question a user asks **first**: *"will this run on my Mac, and what do I pass?"*

Every crash behind those guards was predictable from the model's safetensors headers plus one machine number. This predicts them instead.

## What

`turboquant-plan --model <path_or_repo>` reads **only headers + config.json** — allocates no tensors, starts no engine, imports no model framework:

```
Projection at 21,000 tokens of context
  weights              12.59 GB
  KV cache             0.22 GB  (10.0 KB/token, hybrid: 10/40 full-attention layers)
  prefill workspace    0.09 GB  (estimate, at --prefill-step-size 128)
  runtime reserve      1.00 GB  (buffer cache, activations, fragmentation)
                       ----------------------------------
  peak                 13.90 GB of 14.40 GB usable   0.50 GB headroom

Verdict: ⚠️  RESIDENT — fits, but only after raising the Metal wired cap

Recommended:
  sudo sysctl -w iogpu.wired_limit_mb=13721   (raises the 10.50 GB Metal cap — the
      binding limit here, not your 16 GB of RAM; resets on reboot)
  --prefill-step-size 128   (the default 2048 needs 1.38 GB of transient workspace)
  --kv-bits 8
```

- `--wired-gb` / `--ram-gb` — plan for a machine you're **not sitting at** ("will this run on my mini?")
- `--json` — versioned, machine-readable
- `turboquant-doctor` — same projection + readiness check (files, tokenizer, quantization block, mlx/mlx-lm, machine limits), stable check ids, exit codes (0 ok/warn, 1 won't fit/missing, 2 usage)

## Calibrated, not guessed

Validated against the mini measurements behind the 0.13.0 work:

| scenario | plan says | field truth |
|---|---|---|
| ternary 9.4 GB @512, mini | **10.44 GB**, no sudo ✅ | **10.42 GB**, no sudo |
| ternary @16K, mini | bump needed | "bump recommended as KV grows" |
| down4 12.6 GB @8K, mini | sysctl **13721** | works at **13824** |
| down4 @21K, mini | rejects 2048 chunk, picks 128 | 2048 OOMed; 128 works |
| down4 @16K, 64 GB box | resident, keeps 2048 | resident |

Two design calls the field data forced:

1. **The Metal wired cap is raisable, not fixed.** A first cut told the mini to `--streaming` a model that actually runs *resident* after a `sysctl` bump — a 10x speed difference in bad advice. The ceiling is RAM (capped at 90%, matching the mini's measured 14 GiB / 16 GB); the cap is a knob.
2. **The reserve is 1 GB, not `serve.py`'s 2 GB.** That constant exists to *cover* KV + prefill workspace, which this projection counts explicitly — reusing it double-counted and wrongly reported "streaming" for resident models. 1 GB is the measured residue (13.60 GB peak vs 12.59 GB of weights).

## Tests

17 new (258 total, all green). The field numbers are asserted so a refactor can't silently drift the calibration, incl. `test_reserve_does_not_double_count_kv_and_prefill` and an under-prediction guard on KV (a planner that under-predicts is a crash). The fake-model fixture writes **headers with no payload** — a planner that ever reads tensors fails the suite.

## Provenance

Idea ② from the `colibri` review (`coli plan` / `coli doctor`). Their engine is a close cousin of our `stream/`; this is the one piece of theirs we didn't have.