### PR TITLE
chore: release 0.14.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.14.0] - 2026-07-15
 
 ### Added
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.13.0"
+__version__ = "0.14.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.13.0"
+version = "0.14.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for 0.14.0: `pyproject.toml` + `__init__.py` → 0.14.0, CHANGELOG `[Unreleased]` → `[0.14.0] - 2026-07-15`.

Ships one feature (#50):

**`turboquant-plan` / `turboquant-doctor` — preflight placement projection.** Answers *"will this model run on this Mac, and with what flags?"* before the download, by reading only safetensors headers and `config.json` — no tensors allocated, no engine started. A HF repo id is planned over the network from range requests (**232 KB fetched for a 12.6 GB repo, ~2.5 s**).

Two new console scripts; `--wired-gb`/`--ram-gb` plan for a machine you're not sitting at; `--json` + stable check ids + exit codes for automation.

The projection is calibrated against the 16 GB mini measurements behind 0.13.0, not guessed:

| scenario | plan says | field truth |
|---|---|---|
| ternary 9.4 GB @512 | **10.44 GB**, no sudo | **10.42 GB**, no sudo |
| down4 12.6 GB @8K | sysctl **13721** | works at **13824** |
| down4 @21K | rejects the 2048 chunk | 2048 OOMed; 128 works |

0.13.0's auto-guards fix tight-memory serving at runtime; this predicts it instead — the natural companion to the five-crash story.

265 tests green. After merge: push the `v0.14.0` tag → release.yml builds the sdist and publishes to PyPI (manual `pypi` env approval).