### PR TITLE
fix(plan): KV geometry for Mamba hybrids and sliding-window layers

### DIFF
--- a/plan.py
+++ b/plan.py
@@ -135,41 +135,76 @@ def _text_config(cfg: dict) -> dict:
     return cfg.get("text_config", cfg)
 
 
-def kv_bytes_per_token(cfg: dict, kv_bits: int | None = None) -> tuple:
-    """(bytes/token, n_full_attention_layers, n_layers, note).
+def _attention_layers(cfg: dict) -> tuple:
+    """(n_full_attention, n_sliding_attention, n_layers, note).
 
-    Hybrid models (Qwen3.5/3.6 GatedDeltaNet) only grow KV on their
-    full-attention layers — `layer_types` names them; `full_attention_interval`
-    is the fallback. Returns (None, ...) when the config doesn't say enough.
+    Three families, three different ways of saying which layers hold KV:
+
+    * `layer_types` — Qwen3.5/3.6 (`linear_attention` = GatedDeltaNet, fixed-size
+      recurrent state, no KV growth), GPT-OSS and Gemma (`sliding_attention`,
+      whose KV is real but capped at `sliding_window`).
+    * `hybrid_override_pattern` — Nemotron-H's Mamba hybrid, where `*` is an
+      attention layer and `M`/`E` are Mamba/MLP. Only 8 of its 88 layers are
+      attention; reading `num_hidden_layers` instead over-predicts KV by 11x.
+    * `full_attention_interval` — older hybrids.
+
+    Everything else is assumed dense full-attention.
     """
     c = _text_config(cfg)
     n_layers = c.get("num_hidden_layers")
+
+    types = c.get("layer_types")
+    if isinstance(types, list) and types:
+        n_full = sum(1 for t in types if "full" in str(t))
+        n_slide = sum(1 for t in types if "sliding" in str(t))
+        bits = [f"{n_full}/{len(types)} full-attention"]
+        if n_slide:
+            bits.append(f"{n_slide} sliding")
+        return n_full, n_slide, n_layers, "hybrid: " + ", ".join(bits)
+
+    pat = c.get("hybrid_override_pattern")
+    if isinstance(pat, str) and "*" in pat:
+        n_full = pat.count("*")
+        return n_full, 0, n_layers or len(pat), \
+            f"Mamba hybrid: {n_full}/{len(pat)} attention layers"
+
+    if c.get("full_attention_interval") and n_layers:
+        iv = int(c["full_attention_interval"])
+        return n_layers // iv, 0, n_layers, \
+            f"hybrid: every {iv}th layer full-attention"
+
+    return n_layers, 0, n_layers, "all layers full-attention"
+
+
+def kv_bytes(cfg: dict, context: int, kv_bits: int | None = None) -> tuple:
+    """(total_bytes_at_context, effective_bytes_per_token, note).
+
+    Full-attention layers grow with the context; sliding-window layers stop at
+    `sliding_window` tokens, so their cost is bounded — small, but ignoring them
+    under-predicts, and under-predicting is the direction that OOMs.
+    """
+    c = _text_config(cfg)
     n_kv = c.get("num_key_value_heads") or c.get("num_attention_heads")
     head_dim = c.get("head_dim")
     if head_dim is None and c.get("hidden_size") and c.get("num_attention_heads"):
         head_dim = c["hidden_size"] // c["num_attention_heads"]
+    n_full, n_slide, n_layers, note = _attention_layers(cfg)
     if not (n_layers and n_kv and head_dim):
-        return None, None, n_layers, "config lacks KV geometry"
-
-    note = "all layers full-attention"
-    types = c.get("layer_types")
-    if isinstance(types, list) and types:
-        n_full = sum(1 for t in types if "full" in str(t))
-        note = f"hybrid: {n_full}/{len(types)} full-attention layers"
-    elif c.get("full_attention_interval"):
-        iv = int(c["full_attention_interval"])
-        n_full = n_layers // iv
-        note = f"hybrid: every {iv}th layer full-attention"
-    else:
-        n_full = n_layers
+        return None, None, "config lacks KV geometry"
 
     itemsize = 2.0  # fp16 KV
     if kv_bits:
         # TurboQuant KV-quant stores kv_bits/16 of the fp16 payload (+ scales,
         # which are small); --kv-bits 8 halving KV matches the measured 35B.
         itemsize = 2.0 * (kv_bits / 16.0)
-    per_token = 2 * n_kv * head_dim * n_full * itemsize
-    return per_token, n_full, n_layers, note
+    per_layer_token = 2 * n_kv * head_dim * itemsize
+
+    total = n_full * context * per_layer_token
+    if n_slide:
+        window = c.get("sliding_window") or context
+        total += n_slide * min(context, int(window)) * per_layer_token
+        note += f" (window {window})"
+    return total, (total / context if context else 0.0), note
 
 
 def prefill_workspace_bytes(cfg: dict, context: int, step: int) -> float:
@@ -262,8 +297,9 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
     mach = machine(wired_gb, ram_gb)
     c = _text_config(cfg)
 
-    kv_pt, n_full, n_layers, kv_note = kv_bytes_per_token(cfg, kv_bits)
-    kv_total = (kv_pt or 0) * context
+    kv_total, kv_pt, kv_note = kv_bytes(cfg, context, kv_bits)
+    _, _, n_layers, _ = _attention_layers(cfg)
+    kv_total = kv_total or 0
 
     wss = mach["wss_bytes"]
     ram = mach["ram_bytes"]

--- a/plan.py
+++ b/plan.py
@@ -135,6 +135,18 @@ def _text_config(cfg: dict) -> dict:
     return cfg.get("text_config", cfg)
 
 
+def _pos_int(value, fallback):
+    """Config values come from arbitrary HF repos — treat anything that is not a
+    positive integer as 'not set'. Guards the real cases: `sliding_window: -1`
+    (a negative window subtracted KV, under-predicting), and a fractional
+    `full_attention_interval` (int() -> 0 -> ZeroDivisionError)."""
+    try:
+        n = int(value)
+    except (TypeError, ValueError):
+        return fallback
+    return n if n > 0 else fallback
+
+
 def _attention_layers(cfg: dict) -> tuple:
     """(n_full_attention, n_sliding_attention, n_layers, note).
 
@@ -160,7 +172,9 @@ def _attention_layers(cfg: dict) -> tuple:
         bits = [f"{n_full}/{len(types)} full-attention"]
         if n_slide:
             bits.append(f"{n_slide} sliding")
-        return n_full, n_slide, n_layers, "hybrid: " + ", ".join(bits)
+        # layer_types is itself an authoritative layer count
+        return n_full, n_slide, n_layers or len(types), \
+            "hybrid: " + ", ".join(bits)
 
     pat = c.get("hybrid_override_pattern")
     if isinstance(pat, str) and "*" in pat:
@@ -168,8 +182,8 @@ def _attention_layers(cfg: dict) -> tuple:
         return n_full, 0, n_layers or len(pat), \
             f"Mamba hybrid: {n_full}/{len(pat)} attention layers"
 
-    if c.get("full_attention_interval") and n_layers:
-        iv = int(c["full_attention_interval"])
+    iv = _pos_int(c.get("full_attention_interval"), 0)
+    if iv and n_layers:
         return n_layers // iv, 0, n_layers, \
             f"hybrid: every {iv}th layer full-attention"
 
@@ -201,8 +215,11 @@ def kv_bytes(cfg: dict, context: int, kv_bits: int | None = None) -> tuple:
 
     total = n_full * context * per_layer_token
     if n_slide:
-        window = c.get("sliding_window") or context
-        total += n_slide * min(context, int(window)) * per_layer_token
+        # an absent/zero/negative/garbage window means "not windowed" -> full
+        # context. Never let it shrink the total: that under-predicts, and
+        # under-prediction is the direction that OOMs.
+        window = _pos_int(c.get("sliding_window"), context)
+        total += n_slide * min(context, window) * per_layer_token
         note += f" (window {window})"
     return total, (total / context if context else 0.0), note
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -152,6 +152,54 @@ class TestKV:
         assert t8k - total == 2 * 4096 * per_layer_tok   # only full layers grew
 
 
+class TestMalformedConfigs:
+    """config.json comes from arbitrary HF repo ids — untrusted input. Review
+    findings (PR #52): a garbage value must degrade, never under-predict."""
+
+    BASE = {"num_hidden_layers": 4, "num_key_value_heads": 8, "head_dim": 64,
+            "layer_types": ["sliding_attention", "full_attention"] * 2}
+    PER_LAYER_TOK = 2 * 8 * 64 * 2
+
+    def _kv(self, ctx=4096, **over):
+        return kv_bytes({"text_config": {**self.BASE, **over}}, ctx)[0]
+
+    def test_full_window_is_the_floor_not_a_subtraction(self):
+        """`sliding_window: -1` made the sliding layers subtract KV — an
+        under-prediction. Any non-positive/garbage window means 'not windowed'."""
+        full_ctx = 4 * 4096 * self.PER_LAYER_TOK      # all 4 layers, no window
+        for bad in (-1, 0, None, "", "none", 3.4e38):
+            got = self._kv(sliding_window=bad)
+            assert got == full_ctx, f"sliding_window={bad!r} -> {got}"
+
+    def test_a_real_window_still_bounds_the_cost(self):
+        got = self._kv(sliding_window=128)
+        assert got == (2 * 4096 + 2 * 128) * self.PER_LAYER_TOK
+
+    def test_fractional_interval_does_not_divide_by_zero(self):
+        """int(0.5) == 0 -> ZeroDivisionError in the old code."""
+        for bad in (0, 0.5, -3, "x", None):
+            n_full, _, n_layers, _ = _attention_layers(
+                {"text_config": {"num_hidden_layers": 8,
+                                 "full_attention_interval": bad}})
+            assert (n_full, n_layers) == (8, 8)      # falls back to dense
+
+    def test_valid_interval_still_works(self):
+        n_full, _, _, note = _attention_layers(
+            {"text_config": {"num_hidden_layers": 8,
+                             "full_attention_interval": 4}})
+        assert n_full == 2 and "every 4th" in note
+
+    def test_layer_types_supplies_the_layer_count(self):
+        """num_hidden_layers missing: layer_types is itself authoritative, so
+        the projection should still resolve instead of going unknown."""
+        cfg = {"text_config": {k: v for k, v in self.BASE.items()
+                               if k != "num_hidden_layers"}}
+        _, _, n_layers, _ = _attention_layers(cfg)
+        assert n_layers == 4
+        total, per_tok, note = kv_bytes(cfg, 4096)
+        assert total and per_tok and "lacks" not in note
+
+
 class TestWorkspace:
     def test_scales_with_chunk_and_context(self):
         a = prefill_workspace_bytes(Q35, 21000, 2048)

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -16,7 +16,8 @@ from turboquant_mlx.plan import (
     estimate_wss,
     machine,
     footprint,
-    kv_bytes_per_token,
+    _attention_layers,
+    kv_bytes,
     prefill_workspace_bytes,
     read_safetensors_index,
     render,
@@ -92,8 +93,9 @@ class TestFootprint:
 
 class TestKV:
     def test_hybrid_counts_only_full_attention_layers(self):
-        per_tok, n_full, n_layers, note = kv_bytes_per_token(Q35)
-        assert (n_full, n_layers) == (10, 40)
+        n_full, n_slide, n_layers, note = _attention_layers(Q35)
+        assert (n_full, n_slide, n_layers) == (10, 0, 40)
+        _, per_tok, _ = kv_bytes(Q35, 1024)
         # 2 (K+V) * 2 kv-heads * 256 head_dim * 10 layers * 2 bytes
         assert per_tok == 2 * 2 * 256 * 10 * 2
         assert "hybrid" in note
@@ -101,19 +103,53 @@ class TestKV:
     def test_field_measurement_32k(self):
         """Ternary 35B measured 0.62 GB of KV at 32K. Predict within 10%, and
         on the conservative side — a planner that under-predicts is a crash."""
-        per_tok, *_ = kv_bytes_per_token(Q35)
-        pred = per_tok * 32768 / GB
+        total, *_ = kv_bytes(Q35, 32768)
+        pred = total / GB
         assert pred >= 0.62, "planner must not under-predict KV"
         assert abs(pred - 0.62) / 0.62 < 0.10
 
     def test_kv_bits_halves_at_8(self):
-        fp16, *_ = kv_bytes_per_token(Q35)
-        kv8, *_ = kv_bytes_per_token(Q35, kv_bits=8)
+        fp16, *_ = kv_bytes(Q35, 4096)
+        kv8, *_ = kv_bytes(Q35, 4096, kv_bits=8)
         assert kv8 == pytest.approx(fp16 / 2)
 
     def test_missing_geometry_returns_none(self):
-        per_tok, _, _, note = kv_bytes_per_token({"text_config": {}})
-        assert per_tok is None and "lacks" in note
+        total, _, note = kv_bytes({"text_config": {}}, 1024)
+        assert total is None and "lacks" in note
+
+    def test_mamba_hybrid_reads_the_override_pattern(self):
+        """Nemotron-H: only the '*' layers are attention. Counting
+        num_hidden_layers instead over-predicts KV by 11x."""
+        cfg = {"text_config": {
+            "num_hidden_layers": 88, "num_key_value_heads": 2, "head_dim": 128,
+            "hybrid_override_pattern":
+                "MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*EMEMEMEMEM*"
+                "EMEMEMEMEM*EMEMEMEM*EMEMEMEME",
+        }}
+        n_full, _, n_layers, note = _attention_layers(cfg)
+        assert (n_full, n_layers) == (8, 88)
+        assert "Mamba" in note
+        _, per_tok, _ = kv_bytes(cfg, 4096)
+        assert per_tok == 2 * 2 * 128 * 8 * 2      # 8 attention layers, not 88
+
+    def test_sliding_window_layers_are_counted_but_bounded(self):
+        """GPT-OSS/Gemma sliding layers hold real KV capped at the window.
+        Ignoring them under-predicts, which is the direction that OOMs."""
+        cfg = {"text_config": {
+            "num_hidden_layers": 4, "num_key_value_heads": 8, "head_dim": 64,
+            "layer_types": ["sliding_attention", "full_attention"] * 2,
+            "sliding_window": 128,
+        }}
+        n_full, n_slide, _, note = _attention_layers(cfg)
+        assert (n_full, n_slide) == (2, 2)
+        assert "sliding" in note
+        per_layer_tok = 2 * 8 * 64 * 2
+        # at 4096 ctx: 2 full layers grow; 2 sliding stop at 128 tokens
+        total, _, _ = kv_bytes(cfg, 4096)
+        assert total == 2 * 4096 * per_layer_tok + 2 * 128 * per_layer_tok
+        # sliding cost must stop growing once past the window
+        t8k, *_ = kv_bytes(cfg, 8192)
+        assert t8k - total == 2 * 4096 * per_layer_tok   # only full layers grew
 
 
 class TestWorkspace:


### PR DESCRIPTION
Found by sweeping `turboquant-plan` across **all 16 published TurboQuant repos** before pointing model cards at it. It ran on every one — but two families reported wrong KV.

## 1. Nemotron-H: 11× KV over-prediction

`nemotron_h` has no `layer_types`. Its attention layers are in `hybrid_override_pattern`:

```
MEMEMEM*EMEMEMEM*EMEMEMEM*EMEMEMEMEM*...     * = attention, M = Mamba, E = MLP
```

The planner fell through to `num_hidden_layers` and assumed **all 88 layers** were full attention. **Only 8 are.** The 120B looked far heavier than it is.

## 2. GPT-OSS / DiffusionGemma: sliding-window KV ignored (under-prediction)

Both interleave `sliding_attention` layers. Those hold real KV — just capped at `sliding_window` — and we counted only the `full` ones. **Under-prediction is the direction that OOMs.**

## Effect across the fleet

| model | before | after |
|---|---|---|
| Nemotron-H 120B | 88.0 KB/tok | **8.0 KB/tok** |
| DiffusionGemma 26B | 40.0 KB/tok | **65.0 KB/tok** (25 sliding layers, window 1024) |
| GPT-OSS 20B/120B | 36.0 KB/tok | **36.6 KB/tok** (window 128) |
| Qwen3.6-35B *(the calibrated one)* | 20.0 KB/tok | **20.0 KB/tok — unchanged** |

The 35B being bit-for-bit unchanged is the check that matters: the field calibration (0.67 GB predicted vs **0.62 measured** at 32K) still holds.

## Change

`kv_bytes(cfg, context, kv_bits)` returns the **total at a context** rather than a flat per-token rate — sliding layers stop growing at the window, so KV is no longer linear in context. `_attention_layers()` centralises the three ways a config can say which layers hold KV (`layer_types` / `hybrid_override_pattern` / `full_attention_interval`).

## Tests

267 pass. Two new regression tests: the Nemotron pattern (8 of 88, not 88), and sliding-window layers counted but **provably bounded** — the test asserts that going 4K→8K grows only the full-attention layers.

Prereq for pointing the published model cards at `turboquant-plan`: without this, a Nemotron user would be told they need ~11× the KV they actually do.