### PR TITLE
chore: release 0.14.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,41 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.14.1] - 2026-07-15
+
+### Fixed
+
+- **`turboquant-plan`: KV geometry for Mamba hybrids and sliding-window
+  layers.** Found by sweeping the planner across all 16 published TurboQuant
+  repos. It ran on every one, but two families were wrong:
+  - **Nemotron-H** (`nemotron_h`) has no `layer_types` — its attention layers
+    live in `hybrid_override_pattern` (`MEMEMEM*EMEM…`, `*` = attention,
+    `M` = Mamba, `E` = MLP). The planner fell through to `num_hidden_layers`
+    and assumed all 88 layers were full attention. **Only 8 are** — an 11x KV
+    over-prediction that made the 120B look far heavier than it is
+    (88.0 → **8.0 KB/token**).
+  - **GPT-OSS and Gemma/DiffusionGemma** interleave `sliding_attention`
+    layers, which hold real KV capped at `sliding_window`. Only `full` layers
+    were counted — an **under-prediction**, the direction that OOMs.
+    DiffusionGemma 40.0 → **65.0 KB/token** (25 sliding layers, window 1024);
+    gpt-oss 36.0 → 36.6 (window 128).
+
+  `kv_bytes(cfg, context, kv_bits)` now returns the total at a context rather
+  than a flat per-token rate, since sliding layers stop growing at the window;
+  `_attention_layers()` centralises the three ways a config declares which
+  layers hold KV. The calibrated Qwen3.6-35B path is unchanged at exactly
+  20.0 KB/token, so the field validation (0.67 GB predicted vs 0.62 measured
+  at 32K) still holds.
+
+- **`turboquant-plan`: hardened config parsing.** `config.json` comes from
+  whatever HF repo id the caller passes, so a malformed value must degrade
+  rather than quietly under-predict. `sliding_window: -1` made sliding layers
+  *subtract* KV; a fractional `full_attention_interval` raised
+  `ZeroDivisionError` (`int(0.5)` → 0); and a config with `layer_types` but no
+  `num_hidden_layers` lost its projection unnecessarily. Anything that is not
+  a positive integer now means "not set". All 16 published repos re-swept
+  byte-identical — the guards touch only malformed configs.
+
 ## [0.14.0] - 2026-07-15
 
 ### Added

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.14.0"
+__version__ = "0.14.1"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.14.0"
+version = "0.14.1"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release: `pyproject.toml` + `__init__.py` → 0.14.1, CHANGELOG `[0.14.1] - 2026-07-15`.

Ships #52 — two `turboquant-plan` KV bugs found by sweeping the planner across **all 16 published TurboQuant repos** before pointing their model cards at it:

| model | before | after |
|---|---|---|
| Nemotron-H 120B | 88.0 KB/tok | **8.0 KB/tok** (11× over-predicted — only 8 of 88 layers are attention) |
| DiffusionGemma 26B | 40.0 KB/tok | **65.0 KB/tok** (25 sliding layers were uncounted → under-prediction) |
| GPT-OSS 20B/120B | 36.0 KB/tok | 36.6 KB/tok |
| Qwen3.6-35B *(calibrated)* | 20.0 KB/tok | **20.0 KB/tok — unchanged** |

Plus config-parsing hardening (`plan.py` parses `config.json` from arbitrary HF repo ids — untrusted input): a negative `sliding_window` made sliding layers *subtract* KV, and a fractional `full_attention_interval` raised `ZeroDivisionError`.

272 tests green. All 16 repos re-swept byte-identical after the hardening.

**Why a release now:** the published model cards are about to point users at `turboquant-plan`. Without this, a Nemotron user is told they need ~11× the KV they actually do.

After merge: push `v0.14.1` → release.yml → PyPI (manual `pypi` env approval).