### PR TITLE
test: pin the decode/prefill kernel invariant + document step-size reproducibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,26 @@ That is the 16 GB Mac mini recipe, *derived* rather than found by trial and erro
 10.44 GB where the 9.4 GB ternary build measures 10.42, and recommends a wired
 limit within 1% of the one that actually works).
 
+### A note on reproducibility and `--prefill-step-size`
+
+Changing the prefill chunk size can change a greedy answer by a token — measured
+on a ~3.9K-token prompt, `--prefill-step-size 2048` produced "...which *explains
+why* the sky reads blue" where 512/256/128 produced "...which *is why* the sky
+reads blue". Both are valid argmax continuations; the chunk size only changes the
+order the GPU reduces in, and fp16 rounding occasionally lands on the other side
+of a near-tie.
+
+**This is a property of chunked prefill on Metal, not of TurboQuant.** The same
+test on stock `mlx-community/Llama-3.2-1B-Instruct-4bit` — plain mlx-lm, plain
+affine 4-bit, none of our kernels — forks the same way. Our own decode and
+prefill MoE kernels are *bit-identical* to each other
+(`tests/test_kernel_determinism.py`), which is what keeps `--disk-cache`
+checkpoint restores consistent.
+
+Practical upshot: for byte-reproducible greedy output, hold `--prefill-step-size`
+fixed across runs. Everything else — quality, correctness, coherence — is
+unaffected.
+
 `turboquant-doctor` runs the same projection plus a read-only readiness check —
 model files, tokenizer, quantization block, mlx/mlx-lm imports, machine limits —
 with stable check ids and exit codes (0 ok/warn, 1 won't fit or files missing,

--- a/tests/test_kernel_determinism.py
+++ b/tests/test_kernel_determinism.py
@@ -52,9 +52,11 @@ def test_decode_and_prefill_kernels_are_bit_identical(bits, group_size, ternary)
         layer.weight, layer.scales, layer.codebook, x, idx,
         layer.bits, layer.group_size, trit=layer.trit)
 
-    # the prefill kernel sees one row per (token, expert) routing
-    x_rows = mx.broadcast_to(x.reshape(1, -1), (k, layer.input_dims))
-    x_rows = mx.array(x_rows.tolist(), dtype=mx.float16)
+    # The prefill kernel sees one row per (token, expert) routing. Materialise
+    # the broadcast: at the real call site x_rows comes from a reshape of a real
+    # tensor, so a strided view would be testing a shape we never actually pass.
+    x_rows = mx.contiguous(
+        mx.broadcast_to(x.reshape(1, -1), (k, layer.input_dims)))
     prefill = polar_multi_gather_qmv(
         layer.weight, layer.scales, layer.codebook, x_rows, idx,
         layer.bits, layer.group_size, trit=layer.trit)

--- a/tests/test_kernel_determinism.py
+++ b/tests/test_kernel_determinism.py
@@ -1,0 +1,68 @@
+"""The decode/prefill kernel pair must agree bit-for-bit.
+
+Background (colibrì issue #100): their shape-dependent int kernels make a batched
+forward round differently from the single-token path, forking greedy output on
+3/5 prompts with zero speculation. We dispatch four MoE kernels *by shape*, so
+the same (token, expert) routing can be computed by a different kernel purely
+because of how many tokens are in the forward.
+
+Audited 2026-07-15 (`scripts/kernel_determinism/`). Result: `polar_gather_qmv`
+(decode) and `polar_multi_gather_qmv` (prefill) are **bit-identical** — which is
+the pair that matters, because 0.13.0's disk-cache checkpoint ladder restores a
+state built on the prefill path and then continues on the decode path. This test
+pins that invariant so a kernel refactor can't quietly break it.
+
+(`polar_gather_qmm` reduces in a batch-size-dependent order and differs by
+~1e-4..4e-3 — inherent to tiled GEMM, and NOT asserted here. The end-to-end
+consequence is documented in the README: it is a property of chunked prefill on
+Metal, reproduced on stock mlx-lm with none of our code in the loop.)
+"""
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.kernels.polar_gather_qmv import polar_gather_qmv
+from turboquant_mlx.kernels.polar_multi_gather_qmv import polar_multi_gather_qmv
+from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
+
+
+def _layer(bits, group_size, ternary=False, num_experts=8, out_dims=128,
+           in_dims=256):
+    mx.random.seed(0)
+    w = mx.random.normal((num_experts, out_dims, in_dims)).astype(mx.float16)
+    return PolarQuantizedSwitchLinear.from_switch_linear(
+        None, bits=bits, group_size=group_size, seed=7, float_weight=w,
+        ternary=ternary,
+    )
+
+
+@pytest.mark.parametrize("bits,group_size,ternary", [
+    (2, 32, False), (3, 64, False), (4, 64, False), (2, 64, True),
+])
+def test_decode_and_prefill_kernels_are_bit_identical(bits, group_size, ternary):
+    """One token routed to k experts: the decode kernel and the prefill kernel
+    must produce the same bytes, not merely similar floats."""
+    layer = _layer(bits, group_size, ternary)
+    mx.random.seed(1)
+    k = 8
+    x = mx.random.normal((layer.input_dims,)).astype(mx.float16)
+    idx = mx.array([0, 1, 2, 3, 4, 5, 6, 7][:k], dtype=mx.uint32)
+
+    decode = polar_gather_qmv(
+        layer.weight, layer.scales, layer.codebook, x, idx,
+        layer.bits, layer.group_size, trit=layer.trit)
+
+    # the prefill kernel sees one row per (token, expert) routing
+    x_rows = mx.broadcast_to(x.reshape(1, -1), (k, layer.input_dims))
+    x_rows = mx.array(x_rows.tolist(), dtype=mx.float16)
+    prefill = polar_multi_gather_qmv(
+        layer.weight, layer.scales, layer.codebook, x_rows, idx,
+        layer.bits, layer.group_size, trit=layer.trit)
+
+    mx.eval(decode, prefill)
+    assert decode.shape == prefill.shape
+    assert float(mx.abs(decode - prefill).max()) == 0.0, (
+        "decode and prefill kernels disagree — the disk-cache checkpoint "
+        "ladder restores a prefill-built state and continues on decode, so "
+        "these two must stay bit-identical"
+    )


### PR DESCRIPTION
Audit of colibrì idea ④ (their [issue #100](https://github.com/JustVugg/colibri/issues/100): shape-dependent kernels fork greedy output). We dispatch **four MoE kernels by shape**, and 0.13.0's checkpoint ladder restores a prefill-built state then continues on decode — so the question was live.

## What the audit found

**1. The pair that matters is bit-identical.** `polar_gather_qmv` (decode) vs `polar_multi_gather_qmv` (prefill): **max|Δ| = 0.0** across 2/3/4-bit and ternary. Now pinned by a test, because the checkpoint ladder depends on it.

**2. `polar_gather_qmm` reduces in a batch-size-dependent order** (~1e-4..4e-3 vs the qmv path; the dequant+gather_mm fallback ~3e-2). All within ~0.05% of scale, and each sits closer to an fp32 reference than to the others.

**3. It surfaces end-to-end.** Same prompt, greedy, only the chunk size changed:

```
step 2048: "...which explains why the sky reads blue"
step  512: "...which is why the sky reads blue"     (diverges at token 48/80)
```

1 of 2 prompts — the same prompt-dependent pattern colibrì saw. **Not academic**: `turboquant-plan` now *recommends* `--prefill-step-size 128` on tight machines, so a mini and a 64 GB Mac can answer the same prompt slightly differently.

**4. The control that decides it.** Stock `mlx-community/Llama-3.2-1B-Instruct-4bit` — plain mlx-lm, plain affine 4-bit, **zero TurboQuant code** — forks on chunk size the same way.

## Verdict: no code change

This is **inherent to chunked prefill on Metal**, not something we introduced, and not a kernel to "fix". Every token stays a valid argmax of a valid forward; only the reduction order moves. Chasing bit-exactness across chunk sizes would mean giving up tiled GEMM for a cosmetic property.

So: ship the **invariant test** (guards the decode/prefill pair) + an **honest README note** (hold `--prefill-step-size` fixed for byte-reproducible greedy output; quality/correctness unaffected).

## Note on the harness

My first e2e attempt used 22- and 41-token prompts — **shorter than the smallest chunk size** — so every run prefilled in one chunk and it "passed" while testing nothing. The committed harness uses ~3.9K-token prompts, where step 2048 takes 2 chunks and step 128 takes ~31.

280 tests green.