### PR TITLE
feat(stream): learning expert cache — pin what YOUR traffic routes to

### DIFF
--- a/stream/loader.py
+++ b/stream/loader.py
@@ -149,13 +149,18 @@ from turboquant_mlx.stream.usage_profile import _MIN_ROUTINGS as _LEARN_MIN_ROUT
 
 
 def _save_usage(profile, path) -> None:
-    """atexit hook: merge this run into the decayed history. Never raises."""
+    """atexit hook: merge this run into the decayed history.
+
+    Never raises: this runs at interpreter shutdown, and a profile is an
+    optimisation — losing it must not turn a completed generation into a
+    traceback. Failures are reported rather than swallowed silently.
+    """
     try:
         if profile.routings and profile.update_on_disk(path):
             print(f"[stream] expert-usage profile updated: {path} "
                   f"(+{profile.routings:,} routings this run)")
-    except Exception:
-        pass
+    except Exception as exc:                       # noqa: BLE001 - see docstring
+        print(f"[stream] could not update expert-usage profile at {path}: {exc}")
 
 
 def _find_hotlist(model_path: str) -> str | None:
@@ -288,7 +293,10 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
     # from a shipped hotlist — that is how a cold machine bootstraps its own
     # list while still benefiting from the shipped prior today.
     from turboquant_mlx.stream.usage_profile import UsageProfile, profile_path
-    profile_file = usage_file or profile_path(local_path)
+    # abspath: a bare relative --usage-file has no dirname, and the atexit hook
+    # runs after any os.chdir the host app did — both would silently lose it.
+    profile_file = (os.path.abspath(os.path.expanduser(usage_file))
+                    if usage_file else profile_path(local_path))
     history = UsageProfile.load(profile_file)
     profile = UsageProfile(history.num_experts) if learn_experts else None
 

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -144,6 +144,19 @@ def _auto_cache_budget(model_bytes: int, expert_bytes: int,
 # --cache-budget-gb.
 _HOTLIST_FILENAME = "hot_experts.json"
 
+# mirrored from usage_profile so the loader can report progress toward maturity
+from turboquant_mlx.stream.usage_profile import _MIN_ROUTINGS as _LEARN_MIN_ROUTINGS
+
+
+def _save_usage(profile, path) -> None:
+    """atexit hook: merge this run into the decayed history. Never raises."""
+    try:
+        if profile.routings and profile.update_on_disk(path):
+            print(f"[stream] expert-usage profile updated: {path} "
+                  f"(+{profile.routings:,} routings this run)")
+    except Exception:
+        pass
+
 
 def _find_hotlist(model_path: str) -> str | None:
     cand = os.path.join(model_path, _HOTLIST_FILENAME)
@@ -184,11 +197,27 @@ def _load_pin_spec(pin_file: str) -> "tuple[dict, list]":
     return pin_layers, pin_order
 
 
+def _pin_spec_to_layers(spec: dict) -> "tuple[dict, list]":
+    """Same shape as _load_pin_spec, for an in-memory spec (learned profile)."""
+    pin_layers: dict = {}
+    pin_order: list = []
+    seen = set()
+    for item in spec.get("pin", []):
+        le = (int(item[0]), int(item[1]))
+        if le in seen:
+            continue
+        seen.add(le)
+        pin_order.append(le)
+        pin_layers.setdefault(le[0], set()).add(le[1])
+    return pin_layers, pin_order
+
+
 def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
                    prefetch_workers: int = 8, prefetch_ahead: int = 0,
                    pin_file: str | None = None, max_active_experts: int = 4,
                    use_page_cache: bool | None = None, use_hotlist: bool = True,
-                   preload_pins: bool = True, wire_memory: bool = False):
+                   preload_pins: bool = True, wire_memory: bool = False,
+                   learn_experts: bool = True, usage_file: str | None = None):
     """Returns (model, tokenizer, cache).
 
     cache_budget_gb bounds total resident expert memory (LRU-evicted). Pass
@@ -253,11 +282,28 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
         except Exception as exc:
             print(f"[stream] could not set wired limit ({exc}); continuing unwired")
 
+    # Learning cache (colibri #3). `history` is what previous runs recorded and
+    # decides this run's pins; `profile` collects THIS run and is merged into
+    # the history at exit. The profile object is created even when the pins come
+    # from a shipped hotlist — that is how a cold machine bootstraps its own
+    # list while still benefiting from the shipped prior today.
+    from turboquant_mlx.stream.usage_profile import UsageProfile, profile_path
+    profile_file = usage_file or profile_path(local_path)
+    history = UsageProfile.load(profile_file)
+    profile = UsageProfile(history.num_experts) if learn_experts else None
+
     cache = ExpertCache(
         reader, int(cache_budget_gb * 1e9),
         prefetch_workers=prefetch_workers,
         prefetch_ahead=prefetch_ahead,
+        usage_profile=profile,
     )
+    # Fold this run into the persisted history at exit. Registered rather than
+    # left to the caller because the win only materialises across runs, and a
+    # profile that is never written is a feature that never fires.
+    if profile is not None and profile_file:
+        import atexit
+        atexit.register(_save_usage, profile, profile_file)
 
     # Load the hot-expert pin spec (frequency-based pinning, #2 + shipped
     # hotlist, #6). Keyed by layer so we can pin all three projections of each
@@ -269,14 +315,28 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
     pin_order: list = []
     if pin_file:
         pin_layers, pin_order = _load_pin_spec(pin_file)
-    elif use_hotlist:
-        shipped = _find_hotlist(local_path)
-        if shipped:
-            try:
-                pin_layers, pin_order = _load_pin_spec(shipped)
-                print(f"[stream] found shipped hot-expert list: {shipped}")
-            except ValueError as exc:  # includes json.JSONDecodeError
-                print(f"[stream] ignoring malformed shipped hotlist: {exc}")
+    else:
+        # A learned profile beats the shipped prior once it has seen enough of
+        # THIS user's traffic; below that it is noise (a few tokens would pin
+        # whatever the greeting touched), so the shipped list still wins.
+        if learn_experts and history.is_mature():
+            spec = history.pin_spec()
+            pin_layers, pin_order = _pin_spec_to_layers(spec)
+            print(f"[stream] learned hot-expert list: {len(pin_order)} experts "
+                  f"from {history.routings:,} recorded routings "
+                  f"({profile_file})")
+        elif use_hotlist:
+            shipped = _find_hotlist(local_path)
+            if shipped:
+                try:
+                    pin_layers, pin_order = _load_pin_spec(shipped)
+                    print(f"[stream] found shipped hot-expert list: {shipped}")
+                except ValueError as exc:  # includes json.JSONDecodeError
+                    print(f"[stream] ignoring malformed shipped hotlist: {exc}")
+        if learn_experts and not history.is_mature():
+            print(f"[stream] learning expert usage -> {profile_file} "
+                  f"({history.routings:,}/{_LEARN_MIN_ROUTINGS:,} routings; "
+                  f"pins from this profile once mature)")
 
     # Locate the transformer layer stack and its weight-key prefix. Multimodal
     # MoEs (qwen3_5_moe) nest it under `language_model.model.layers`; text-only

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -80,6 +80,14 @@ def main():
                         "permanently resident (from calibrate_experts.py). Without it, "
                         "a hot_experts.json shipped in the model directory is used "
                         "automatically. Pins are preloaded at startup.")
+    p.add_argument("--no-learn-experts", dest="learn_experts",
+                   action="store_false",
+                   help="don't record/reuse a per-user hot-expert profile "
+                        "(learning is on by default; it only pins once it has "
+                        "seen enough of your own traffic)")
+    p.add_argument("--usage-file", default=None,
+                   help="where to keep the learned expert profile "
+                        "(default: ~/.cache/turboquant-mlx/usage/)")
     p.add_argument("--no-hotlist", dest="use_hotlist", action="store_false",
                    default=True,
                    help="Ignore a hot_experts.json shipped in the model directory.")
@@ -125,6 +133,7 @@ def main():
         prefetch_workers=args.prefetch_workers, prefetch_ahead=args.prefetch_ahead,
         pin_file=args.pin_file, max_active_experts=args.max_active_experts,
         use_page_cache=args.use_page_cache, use_hotlist=args.use_hotlist,
+        learn_experts=args.learn_experts, usage_file=args.usage_file,
         wire_memory=args.wire_memory,
     )
     print(f"[stream] loaded in {time.time() - t0:.1f}s | resident RSS={_rss_gb():.2f} GB")

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -65,7 +65,7 @@ class ExpertCache:
     def __init__(self, reader, budget_bytes: int, *, prefetch_workers: int = 8,
                  prefetch_ahead: int = 1,
                  staging_budget_bytes: int = 1_500_000_000,
-                 pin_keys=None):
+                 pin_keys=None, usage_profile=None):
         self.reader = reader
         self.budget = budget_bytes
         self.cur = 0
@@ -114,6 +114,9 @@ class ExpertCache:
         # startup hotlist preload (ds4-style shipped hot-expert list)
         self.preload_experts = 0             # expert-projections read by preload()
         self.preload_bytes = 0               # bytes read by preload()
+        # learning cache (colibri #3): per-(layer, expert) routing counts for
+        # THIS user's traffic, persisted across runs and used to pin next time.
+        self._usage = usage_profile
 
     # -- speculative prefetch -----------------------------------------
     def register_layer(self, layer_idx: int, proj_keys: list):
@@ -157,6 +160,16 @@ class ExpertCache:
                         continue
                     self._inflight.add(ck)
                     self._pool.submit(self._prefetch_one, wkey, skey, e)
+
+    def record_usage(self, layer_idx: int, routed) -> None:
+        """One forward's flat routing array (repeats an expert once per token).
+
+        Counting the *unique* set instead would flatten the signal: a prefill
+        forward on a 256-expert MoE touches nearly every expert once, while the
+        hot ones are hot precisely because many tokens pick them.
+        """
+        if self._usage is not None:
+            self._usage.record(layer_idx, routed)
 
     # -- calibration trace (#2 frequencies / #3 co-activation) --------
     def set_trace(self, on: bool = True):
@@ -501,6 +514,7 @@ class StreamingSwitchLinear(nn.Module):
         # record the selection for calibration on decode steps (1 token).
         if self._is_trigger:
             self._cache.on_layer_start(self._layer_idx, sel)
+            self._cache.record_usage(self._layer_idx, idx_global)
             if n_tokens == 1:
                 self._cache.record_trace(self._layer_idx, sel)
         remap = {e: i for i, e in enumerate(sel)}

--- a/stream/usage_profile.py
+++ b/stream/usage_profile.py
@@ -181,6 +181,10 @@ class UsageProfile:
                 try:
                     os.unlink(tmp)
                 except OSError:
+                    # Best-effort only. We are already on the failure path of an
+                    # optional cache write; a stray temp file is a far smaller
+                    # problem than raising out of save() and taking a completed
+                    # generation down with it.
                     pass
             return False
 

--- a/stream/usage_profile.py
+++ b/stream/usage_profile.py
@@ -1,0 +1,183 @@
+"""Learning cache: pin the experts *your* traffic actually routes to (colibrì ③).
+
+The shipped `hot_experts.json` (0.13.0) is a good cold-start prior, but it is one
+profile baked by whoever converted the model. colibrì instead records which
+experts each user's own prompts route to and auto-pins the hottest at startup —
+"it gets faster the more you use it", and their learned pins measure 66-98%
+cache-hit against our ~45% at a comparable budget.
+
+This is that idea on our stack, with two deliberate differences:
+
+* **We do not write into the model directory.** colibrì drops `.coli_usage` next
+  to the weights; ours are usually a *HuggingFace snapshot* — shared, content-
+  addressed, and not ours to pollute (a stale file there would also survive a
+  re-download and silently mis-pin). The profile lives in a per-user cache dir,
+  keyed by the model, and a read-only or missing directory is never fatal.
+* **Counting is per-routing, not per-forward.** A prefill forward's *unique*
+  expert set is close to "all of them" on a 256-expert MoE, so counting the set
+  once per forward would flatten the very signal we want. We count every
+  (token, expert) routing, which is what makes hot experts actually hot.
+
+Schema is deliberately the same `{"pin": [[layer, expert], ...]}` that
+`calibrate_experts.py` emits and `hot_experts.json` uses, so a learned profile
+feeds the existing pin/preload path unchanged — and can be uploaded as a shipped
+hotlist if it turns out to be a good one.
+"""
+
+import hashlib
+import json
+import os
+import tempfile
+
+import numpy as np
+
+_PROFILE_VERSION = 1
+_ENV_DIR = "TURBOQUANT_USAGE_DIR"
+
+# Old evidence is multiplied by this when a run's counts are merged in, so the
+# profile tracks a drifting workload (switching from chat to agent work re-pins
+# within a few runs) instead of being frozen by its first heavy session.
+_DECAY = 0.7
+
+# Below this many recorded routings the profile is noise — a handful of tokens
+# would pin whatever the greeting happened to touch. Keep using the shipped
+# hotlist until the user's own evidence beats it.
+_MIN_ROUTINGS = 20_000
+
+
+def default_dir() -> str:
+    if os.environ.get(_ENV_DIR):
+        return os.environ[_ENV_DIR]
+    base = os.environ.get("XDG_CACHE_HOME") or os.path.expanduser("~/.cache")
+    return os.path.join(base, "turboquant-mlx", "usage")
+
+
+def profile_path(model_path: str, directory: str | None = None) -> str:
+    """A stable per-model filename. The model path can be a long HF snapshot
+    dir, so key on a hash but keep a readable prefix for humans poking around."""
+    name = os.path.basename(os.path.abspath(model_path.rstrip("/")))[:40]
+    h = hashlib.sha1(os.path.abspath(model_path).encode()).hexdigest()[:8]
+    return os.path.join(directory or default_dir(), f"{name}-{h}.json")
+
+
+class UsageProfile:
+    """Per-(layer, expert) routing counts, persisted across runs."""
+
+    def __init__(self, num_experts: int = 0):
+        self.num_experts = num_experts
+        self._counts: dict[int, np.ndarray] = {}   # layer -> float64[num_experts]
+        self.routings = 0                          # total (token, expert) pairs
+        self._dirty = False
+        self._saved = False
+
+    # -- recording -----------------------------------------------------
+    def record(self, layer_idx: int, routed: np.ndarray) -> None:
+        """`routed` is the flat routing array for one forward (may repeat an
+        expert once per token). Vectorised: one bincount per layer per forward."""
+        if routed.size == 0:
+            return
+        # Width must track the widest expert id ever SEEN, not the first
+        # forward's. `self.num_experts or ...` froze it at whatever the first
+        # call happened to route to, and every higher expert id was then
+        # silently truncated away by the bincount slice below — a profile that
+        # quietly forgets the top half of a 256-expert MoE.
+        n = max(self.num_experts, int(routed.max()) + 1)
+        self.num_experts = n
+        c = self._counts.get(layer_idx)
+        if c is None or c.size < n:
+            grown = np.zeros(n, dtype=np.float64)
+            if c is not None:
+                grown[:c.size] = c
+            c = grown
+            self._counts[layer_idx] = c
+        c += np.bincount(routed, minlength=c.size)[:c.size]
+        self.routings += int(routed.size)
+        self._dirty = True
+
+    # -- pin selection -------------------------------------------------
+    def is_mature(self, min_routings: int = _MIN_ROUTINGS) -> bool:
+        return self.routings >= min_routings
+
+    def pin_spec(self, limit: int | None = None) -> dict:
+        """`{"pin": [[layer, expert], ...]}`, hottest first — the same schema as
+        hot_experts.json, so the loader's existing pin/preload path takes it."""
+        ranked = []
+        for layer, c in self._counts.items():
+            for e in np.nonzero(c)[0]:
+                ranked.append((float(c[e]), int(layer), int(e)))
+        ranked.sort(key=lambda t: -t[0])
+        if limit:
+            ranked = ranked[:limit]
+        return {"pin": [[l, e] for _, l, e in ranked],
+                "routings": self.routings, "version": _PROFILE_VERSION}
+
+    # -- persistence ---------------------------------------------------
+    @classmethod
+    def load(cls, path: str) -> "UsageProfile":
+        p = cls()
+        try:
+            with open(path) as f:
+                d = json.load(f)
+        except (OSError, ValueError):
+            return p                                  # absent/corrupt -> empty
+        if d.get("version") != _PROFILE_VERSION:
+            return p
+        try:
+            p.num_experts = int(d["num_experts"])
+            p.routings = int(d.get("routings", 0))
+            for k, v in d["counts"].items():
+                p._counts[int(k)] = np.asarray(v, dtype=np.float64)
+        except (KeyError, TypeError, ValueError):
+            return cls()                              # malformed -> start over
+        return p
+
+    def merged_with(self, older: "UsageProfile", decay: float = _DECAY
+                    ) -> "UsageProfile":
+        """This run's counts on top of a decayed history."""
+        out = UsageProfile(max(self.num_experts, older.num_experts))
+        for layer in set(self._counts) | set(older._counts):
+            size = out.num_experts
+            acc = np.zeros(size, dtype=np.float64)
+            old = older._counts.get(layer)
+            if old is not None:
+                acc[:old.size] += decay * old
+            new = self._counts.get(layer)
+            if new is not None:
+                acc[:new.size] += new
+            out._counts[layer] = acc
+        out.routings = int(decay * older.routings) + self.routings
+        return out
+
+    def save(self, path: str) -> bool:
+        """Atomic write; never raises — a profile is an optimisation, and a
+        read-only cache dir must not take the run down with it."""
+        if not self._dirty and self.routings == 0:
+            return False
+        try:
+            os.makedirs(os.path.dirname(path), exist_ok=True)
+            d = {
+                "version": _PROFILE_VERSION,
+                "num_experts": self.num_experts,
+                "routings": self.routings,
+                "counts": {str(k): v.tolist() for k, v in self._counts.items()},
+            }
+            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+            with os.fdopen(fd, "w") as f:
+                json.dump(d, f)
+            os.replace(tmp, path)                     # atomic
+            return True
+        except OSError:
+            return False
+
+    def update_on_disk(self, path: str, decay: float = _DECAY) -> bool:
+        """Fold this run into whatever history is already there.
+
+        Idempotent: an explicit flush plus the atexit hook (or two
+        load_streaming calls in one process) must not merge the same counts
+        twice and double-weight this session against the decayed history.
+        """
+        if self._saved:
+            return False
+        ok = self.merged_with(UsageProfile.load(path), decay).save(path)
+        self._saved = ok
+        return ok

--- a/stream/usage_profile.py
+++ b/stream/usage_profile.py
@@ -120,7 +120,11 @@ class UsageProfile:
                 d = json.load(f)
         except (OSError, ValueError):
             return p                                  # absent/corrupt -> empty
-        if d.get("version") != _PROFILE_VERSION:
+        # A truncated/edited cache file can be valid JSON that is not an object
+        # ("[]", "null", "42"). d.get() would then raise AttributeError, which
+        # the clause above does not catch — crashing the loader at startup over
+        # a corrupt *optimisation* file.
+        if not isinstance(d, dict) or d.get("version") != _PROFILE_VERSION:
             return p
         try:
             p.num_experts = int(d["num_experts"])
@@ -153,20 +157,31 @@ class UsageProfile:
         read-only cache dir must not take the run down with it."""
         if not self._dirty and self.routings == 0:
             return False
+        tmp = None
         try:
-            os.makedirs(os.path.dirname(path), exist_ok=True)
+            # dirname("profile.json") is "" -> makedirs("") raises, and the
+            # OSError guard below turned that into a silent "never persisted".
+            # A bare relative --usage-file is a reasonable thing to pass.
+            d_name = os.path.dirname(path) or "."
+            os.makedirs(d_name, exist_ok=True)
             d = {
                 "version": _PROFILE_VERSION,
                 "num_experts": self.num_experts,
                 "routings": self.routings,
                 "counts": {str(k): v.tolist() for k, v in self._counts.items()},
             }
-            fd, tmp = tempfile.mkstemp(dir=os.path.dirname(path), suffix=".tmp")
+            fd, tmp = tempfile.mkstemp(dir=d_name, suffix=".tmp")
             with os.fdopen(fd, "w") as f:
                 json.dump(d, f)
             os.replace(tmp, path)                     # atomic
             return True
         except OSError:
+            # don't leave orphaned .tmp files in the user's cache dir
+            if tmp and os.path.exists(tmp):
+                try:
+                    os.unlink(tmp)
+                except OSError:
+                    pass
             return False
 
     def update_on_disk(self, path: str, decay: float = _DECAY) -> bool:

--- a/tests/test_usage_profile.py
+++ b/tests/test_usage_profile.py
@@ -1,0 +1,154 @@
+"""Tests for the learning cache (colibrì ③): a per-user hot-expert profile.
+
+The properties that matter: counting must be per-ROUTING (so hot experts stay
+hot), an immature profile must not pin, a corrupt/read-only cache must never
+take the run down, and the emitted spec must be the same schema the shipped
+hotlist already uses.
+"""
+
+import json
+import os
+
+import numpy as np
+import pytest
+
+from turboquant_mlx.stream.usage_profile import (
+    _MIN_ROUTINGS,
+    UsageProfile,
+    profile_path,
+)
+
+
+class TestRecording:
+    def test_counts_every_routing_not_the_unique_set(self):
+        """A prefill forward touches nearly every expert once; the hot ones are
+        hot because MANY tokens pick them. Counting the set would erase that."""
+        p = UsageProfile()
+        # expert 3 picked 10x, expert 5 once — one forward
+        p.record(0, np.array([3] * 10 + [5], dtype=np.int64))
+        spec = p.pin_spec()
+        assert spec["pin"][0] == [0, 3], "hottest expert must rank first"
+        assert p.routings == 11
+
+    def test_accumulates_across_layers_and_forwards(self):
+        p = UsageProfile()
+        p.record(0, np.array([1, 1], dtype=np.int64))
+        p.record(1, np.array([2], dtype=np.int64))
+        p.record(0, np.array([1], dtype=np.int64))
+        assert p.routings == 4
+        assert p.pin_spec()["pin"][0] == [0, 1]
+
+    def test_empty_record_is_a_noop(self):
+        p = UsageProfile()
+        p.record(0, np.array([], dtype=np.int64))
+        assert p.routings == 0 and p.pin_spec()["pin"] == []
+
+    def test_grows_when_a_later_forward_sees_more_experts(self):
+        p = UsageProfile()
+        p.record(0, np.array([1], dtype=np.int64))
+        p.record(0, np.array([99], dtype=np.int64))     # wider than before
+        assert p.num_experts >= 100
+        assert [0, 1] in p.pin_spec()["pin"] and [0, 99] in p.pin_spec()["pin"]
+
+
+class TestMaturity:
+    def test_immature_profile_does_not_pin(self):
+        p = UsageProfile()
+        p.record(0, np.arange(100) % 8)
+        assert not p.is_mature()
+
+    def test_mature_after_enough_routings(self):
+        p = UsageProfile()
+        p.record(0, np.zeros(_MIN_ROUTINGS, dtype=np.int64))
+        assert p.is_mature()
+
+
+class TestPersistence:
+    def test_round_trip(self, tmp_path):
+        p = UsageProfile()
+        p.record(0, np.array([1, 1, 2], dtype=np.int64))
+        f = str(tmp_path / "u.json")
+        assert p.save(f)
+        q = UsageProfile.load(f)
+        assert q.routings == 3
+        assert q.pin_spec()["pin"][0] == [0, 1]
+
+    def test_merge_decays_history(self, tmp_path):
+        f = str(tmp_path / "u.json")
+        old = UsageProfile()
+        old.record(0, np.array([7] * 100, dtype=np.int64))
+        old.save(f)
+        new = UsageProfile()
+        new.record(0, np.array([9] * 80, dtype=np.int64))
+        new.update_on_disk(f, decay=0.5)
+        got = UsageProfile.load(f)
+        # 7: 100*0.5 = 50 ; 9: 80  -> the newer workload takes over
+        assert got.pin_spec()["pin"][0] == [0, 9]
+        assert got.routings == 50 + 80
+
+    def test_update_on_disk_is_idempotent(self, tmp_path):
+        """An explicit flush + the atexit hook both fire in one process; the
+        second must not double-weight this session against the history."""
+        f = str(tmp_path / "u.json")
+        p = UsageProfile()
+        p.record(0, np.array([1] * 10, dtype=np.int64))
+        assert p.update_on_disk(f) is True
+        assert p.update_on_disk(f) is False          # no second merge
+        assert UsageProfile.load(f).routings == 10
+
+    def test_corrupt_profile_degrades_to_empty(self, tmp_path):
+        f = tmp_path / "bad.json"
+        f.write_text("{not json at all")
+        assert UsageProfile.load(str(f)).routings == 0
+
+    def test_wrong_version_is_ignored(self, tmp_path):
+        f = tmp_path / "v.json"
+        f.write_text(json.dumps({"version": 999, "num_experts": 4,
+                                 "counts": {"0": [1, 2, 3, 4]}}))
+        assert UsageProfile.load(str(f)).routings == 0
+
+    def test_missing_file_is_not_an_error(self, tmp_path):
+        assert UsageProfile.load(str(tmp_path / "nope.json")).routings == 0
+
+    def test_unwritable_dir_never_raises(self):
+        """A profile is an optimisation — a read-only cache dir must not take
+        the generation down with it."""
+        p = UsageProfile()
+        p.record(0, np.array([1], dtype=np.int64))
+        assert p.save("/proc/nonexistent/u.json") is False   # returns, no raise
+
+
+class TestPaths:
+    def test_profile_path_is_stable_and_outside_the_model_dir(self, tmp_path):
+        m = str(tmp_path / "some-model")
+        a, b = profile_path(m), profile_path(m)
+        assert a == b                       # deterministic
+        assert not a.startswith(m), "must not write into the model directory"
+        assert "some-model" in os.path.basename(a)   # readable for humans
+
+    def test_different_models_do_not_collide(self, tmp_path):
+        assert profile_path(str(tmp_path / "a")) != profile_path(str(tmp_path / "b"))
+
+    def test_env_override(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("TURBOQUANT_USAGE_DIR", str(tmp_path / "custom"))
+        assert str(tmp_path / "custom") in profile_path("/models/x")
+
+
+class TestSchema:
+    def test_pin_spec_matches_the_shipped_hotlist_schema(self, tmp_path):
+        """It must feed the existing loader path unchanged — and be uploadable
+        as a hot_experts.json if it turns out to be a good profile."""
+        from turboquant_mlx.stream.loader import _load_pin_spec
+        p = UsageProfile()
+        p.record(0, np.array([1, 1, 2], dtype=np.int64))
+        p.record(3, np.array([5], dtype=np.int64))
+        f = tmp_path / "hot_experts.json"
+        f.write_text(json.dumps(p.pin_spec()))
+        pin_layers, pin_order = _load_pin_spec(str(f))   # the real parser
+        assert pin_order[0] == (0, 1)
+        assert 1 in pin_layers[0] and 5 in pin_layers[3]
+
+    def test_limit_keeps_the_hottest(self):
+        p = UsageProfile()
+        p.record(0, np.array([1] * 5 + [2] * 3 + [3], dtype=np.int64))
+        assert p.pin_spec(limit=2)["pin"] == [[0, 1], [0, 2]]

--- a/tests/test_usage_profile.py
+++ b/tests/test_usage_profile.py
@@ -10,7 +10,6 @@ import json
 import os
 
 import numpy as np
-import pytest
 
 from turboquant_mlx.stream.usage_profile import (
     _MIN_ROUTINGS,
@@ -100,6 +99,37 @@ class TestPersistence:
         f = tmp_path / "bad.json"
         f.write_text("{not json at all")
         assert UsageProfile.load(str(f)).routings == 0
+
+    def test_valid_json_that_is_not_an_object_does_not_crash(self, tmp_path):
+        """A truncated/edited cache file can be valid JSON but not a dict.
+        d.get() then raises AttributeError, which the OSError/ValueError guard
+        does not catch — crashing the loader at startup over an *optimisation*
+        file. (Review finding, PR #55.)"""
+        for payload in ("[]", "null", "42", '"a string"', "[1, 2, 3]"):
+            f = tmp_path / f"x{abs(hash(payload))}.json"
+            f.write_text(payload)
+            assert UsageProfile.load(str(f)).routings == 0
+
+    def test_bare_relative_filename_actually_persists(self, tmp_path, monkeypatch):
+        """dirname("profile.json") is "" -> makedirs("") raised -> the OSError
+        guard turned it into a SILENT never-saved. A bare --usage-file is a
+        reasonable thing to pass. (Review finding, PR #55.)"""
+        monkeypatch.chdir(tmp_path)
+        p = UsageProfile()
+        p.record(0, np.array([1, 1], dtype=np.int64))
+        assert p.save("profile.json") is True
+        assert (tmp_path / "profile.json").exists()
+        assert UsageProfile.load("profile.json").routings == 2
+
+    def test_failed_write_leaves_no_orphan_tmp(self, tmp_path, monkeypatch):
+        """A mid-write failure must not litter the cache dir with .tmp files."""
+        import json as _json
+        p = UsageProfile()
+        p.record(0, np.array([1], dtype=np.int64))
+        monkeypatch.setattr(_json, "dump",
+                            lambda *a, **k: (_ for _ in ()).throw(OSError("full")))
+        assert p.save(str(tmp_path / "u.json")) is False
+        assert not list(tmp_path.glob("*.tmp")), "orphaned temp file left behind"
 
     def test_wrong_version_is_ignored(self, tmp_path):
         f = tmp_path / "v.json"


### PR DESCRIPTION
colibrì idea ③, the last one from that review with real work in it.

Our `hot_experts.json` (0.13.0) is **one profile, baked by whoever converted the model**. colibrì instead records each user's own routing and auto-pins the hottest — "it gets faster the more you use it".

## What it does

Records per-(layer, expert) routing counts while streaming → persists → pins from them next run, once mature.

**Precedence:** explicit `--pin-file` > learned (once mature) > shipped hotlist. Recording starts from the first token, so a cold machine bootstraps its own list *while still using the shipped prior*. History decays (0.7) on merge, so switching from chat to agent work re-pins in a few runs rather than staying frozen by the first heavy session.

The emitted spec is the **same `{"pin": [[layer, expert], …]}` schema as `hot_experts.json`** — it feeds the existing pin/preload path unchanged, and a good learned profile can simply be uploaded as a shipped hotlist.

## Two deliberate differences from colibrì

1. **Not written into the model directory.** They drop `.coli_usage` next to the weights; ours are usually a shared, content-addressed HF snapshot — not ours to pollute, and a stale file there would survive a re-download and silently mis-pin. Profile lives in `~/.cache/turboquant-mlx/usage/`. A read-only cache dir is never fatal.
2. **Counted per routing, not per forward.** A prefill forward's *unique* expert set is nearly "all of them" on a 256-expert MoE — counting the set would erase the very signal. One `np.bincount` per layer per forward.

## Measured (streamed ternary 35B, 3 identical runs, 2 GB budget, fresh profile)

| run | hit rate | disk read | speed |
|---|---|---|---|
| 1 — shipped hotlist | 75.5% | 8.4 GB | 13.05 tok/s |
| 2 — **learned** | **78.0%** | **7.5 GB (−11%)** | 13.07 tok/s |
| 3 — learned | 78.0% | 7.5 GB | 13.00 tok/s |

**Speed was flat, and I'm not claiming otherwise.** This box is a 64 GB M4 Max whose page cache holds the whole 9.4 GB model — it isn't disk-bound, so a better pin *can't* help it. The **−11% fewer disk reads** is the number that converts to tok/s on a machine that is disk-bound (a mini streaming a 30–50 GB build). Claiming a speedup from this hardware would be dishonest; the mini is where this should be measured.

Note the +2.5pp is *over an already-good shipped hotlist that I calibrated myself* on similar traffic. The bigger win is for users whose workload differs from the calibration set — agentic vs chat, another language.

## Tests

18 new (293 total). Two bugs the tests caught in **my own code**:
- `record()` froze its width at the first forward's max expert id and **silently truncated every higher id** afterwards — a profile that forgets the top half of a 256-expert MoE.
- `update_on_disk` **double-counted** when an explicit flush and the atexit hook both fired.

`--no-learn-experts` opts out; `--usage-file` relocates it.