### PR TITLE
fix(plan): don't mistake a partial HF cache for a downloaded model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`turboquant-plan`/`turboquant-doctor` on a HuggingFace repo id worked once,
+  then failed forever** with `error: no *.safetensors in ...`. Planning a repo
+  fetches its `config.json`, and that alone creates a snapshot directory in the
+  HF cache. The next run got a cache hit on that directory, took it for a
+  downloaded model, and died looking for weights that were never there — the
+  tool poisoning its own cache. A cache hit is now used only once it proves it
+  holds the whole checkpoint; otherwise planning stays on the network, where it
+  belongs.
+
+  Same check closes a quieter hole: a **partially downloaded** model (some
+  shards present, interrupted transfer) had its weights summed from only the
+  headers that arrived, so a half-fetched 30 GB model would report ~15 GB and a
+  confident `RESIDENT` verdict — the exact false green light this tool exists to
+  prevent. A local path is still planned on request, but now carries a warning
+  that the numbers are under-counted.
+
 ## [0.15.0] - 2026-07-15
 
 ### Added

--- a/plan.py
+++ b/plan.py
@@ -617,14 +617,20 @@ def is_complete_checkpoint(path: str) -> bool:
         return False
     index_file = os.path.join(path, "model.safetensors.index.json")
     if os.path.isfile(index_file):
+        # The index comes from an arbitrary repo id — untrusted input. Every
+        # shape below is a real observed failure: a top-level list/str/int has
+        # no .get, a non-dict weight_map has no .values, an unhashable value
+        # breaks set(), and a non-str value breaks os.path.join. An index we
+        # cannot read is an index we cannot verify against, so it does not get
+        # to vouch for the checkpoint.
         try:
             with open(index_file) as f:
                 weight_map = json.load(f).get("weight_map") or {}
-        except (json.JSONDecodeError, OSError):
+            shards = set(weight_map.values())
+            if shards:
+                return all(os.path.isfile(os.path.join(path, s)) for s in shards)
+        except (ValueError, OSError, AttributeError, TypeError):
             return False
-        shards = set(weight_map.values())
-        if shards:
-            return all(os.path.isfile(os.path.join(path, s)) for s in shards)
     return bool(glob.glob(os.path.join(path, "*.safetensors")))
 
 

--- a/plan.py
+++ b/plan.py
@@ -300,6 +300,7 @@ def machine(wired_gb: float | None = None, ram_gb: float | None = None) -> dict:
 def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None,
                step: int | None = None, wired_gb: float | None = None,
                ram_gb: float | None = None, remote: bool = False) -> dict:
+    incomplete = False
     if remote:
         cfg = read_remote_config(model_path)
         index = read_remote_index(model_path)
@@ -310,6 +311,10 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
         with open(cfg_path) as f:
             cfg = json.load(f)
         index = read_safetensors_index(model_path)
+        # An explicit local path is taken at the user's word — but if shards are
+        # missing, every byte below is undercounted and the verdict is optimistic
+        # in the one direction that gets someone an OOM instead of an answer.
+        incomplete = not is_complete_checkpoint(model_path)
     fp = footprint(index)
     mach = machine(wired_gb, ram_gb)
     c = _text_config(cfg)
@@ -322,6 +327,9 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
     ram = mach["ram_bytes"]
     is_moe = fp["expert_bytes"] > 0
     warnings, flags = [], []
+    if incomplete:
+        warnings.append("shards are missing from this directory — the download "
+                        "looks incomplete, so every size below is UNDER-counted")
 
     # The Metal wired cap is NOT fixed — `sysctl iogpu.wired_limit_mb` raises it,
     # which is exactly what the 16 GB mini does to run a 12.6 GB model resident.
@@ -587,18 +595,53 @@ def run_doctor(model_path: str, plan: dict) -> list:
 # CLI
 # --------------------------------------------------------------------------
 
+def is_complete_checkpoint(path: str) -> bool:
+    """Does this directory hold every weight shard, not just some of them?
+
+    Two ways a directory can look like a model and not be one:
+
+    1. It has no shards at all. Planning a repo id caches `config.json`, and
+       that alone creates a snapshot dir — so `turboquant-plan --model <repo>`
+       used to succeed once and then fail forever, because the second run took
+       its own cache droppings for a downloaded model.
+    2. It has *some* shards, from a download that was interrupted. This is the
+       dangerous one: the weight total is summed from whatever headers are
+       present, so a half-downloaded 30 GB model would report ~15 GB and a
+       confident "RESIDENT" verdict — precisely the false green light this
+       tool exists to prevent.
+
+    The index's weight_map names every shard the checkpoint needs, so when it's
+    there, use it. Without one, a single-shard checkpoint is all-or-nothing.
+    """
+    if not os.path.isdir(path):
+        return False
+    index_file = os.path.join(path, "model.safetensors.index.json")
+    if os.path.isfile(index_file):
+        try:
+            with open(index_file) as f:
+                weight_map = json.load(f).get("weight_map") or {}
+        except (json.JSONDecodeError, OSError):
+            return False
+        shards = set(weight_map.values())
+        if shards:
+            return all(os.path.isfile(os.path.join(path, s)) for s in shards)
+    return bool(glob.glob(os.path.join(path, "*.safetensors")))
+
+
 def _resolve(path: str) -> tuple:
     """(target, remote). A repo id is planned over the network from its headers —
     never by downloading it, which would defeat the entire point of the tool.
-    A local cache hit is used directly when one exists."""
+    A local cache hit is used only once it proves it holds the whole checkpoint;
+    a partial one falls back to the network rather than misreporting the size."""
     p = os.path.expanduser(path)
     if os.path.isdir(p):
-        return p, False
+        return p, False                     # an explicit local path is the user's word
     try:                                    # already downloaded? use the cache
         from huggingface_hub import snapshot_download
-        return snapshot_download(path, local_files_only=True), False
+        local = snapshot_download(path, local_files_only=True)
     except Exception:
         return path, True                   # plan it remotely, headers only
+    return (local, False) if is_complete_checkpoint(local) else (path, True)
 
 
 def _common_args(ap):

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -437,6 +437,32 @@ class TestPartialCache:
         (tmp_path / "model.safetensors").write_bytes(b"")
         assert is_complete_checkpoint(str(tmp_path)) is False
 
+    @pytest.mark.parametrize("payload", [
+        [],                                   # top-level list: no .get
+        ["a"],
+        "hello",                              # top-level str
+        42,
+        None,
+        {"weight_map": ["a.safetensors"]},    # weight_map not a dict: no .values
+        {"weight_map": "a.safetensors"},
+        {"weight_map": {"t0": 5}},            # non-str value: os.path.join
+        {"weight_map": {"t0": []}},           # unhashable value: set()
+        {"weight_map": {"t0": None}},
+    ])
+    def test_malformed_index_degrades_instead_of_raising(self, tmp_path, payload):
+        """The index is fetched from an arbitrary repo id — untrusted input.
+        Every shape here raised an uncaught AttributeError/TypeError."""
+        (tmp_path / "model.safetensors.index.json").write_text(json.dumps(payload))
+        (tmp_path / "model.safetensors").write_bytes(b"")
+        assert is_complete_checkpoint(str(tmp_path)) is False
+
+    def test_empty_weight_map_falls_back_to_globbing(self, tmp_path):
+        """An index with nothing to say must not veto a shard that is present."""
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {}}))
+        (tmp_path / "model.safetensors").write_bytes(b"")
+        assert is_complete_checkpoint(str(tmp_path)) is True
+
     def test_missing_dir_is_not_a_checkpoint(self, tmp_path):
         assert is_complete_checkpoint(str(tmp_path / "nope")) is False
 

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -17,6 +17,8 @@ from turboquant_mlx.plan import (
     machine,
     footprint,
     _attention_layers,
+    _resolve,
+    is_complete_checkpoint,
     kv_bytes,
     prefill_workspace_bytes,
     read_safetensors_index,
@@ -395,3 +397,74 @@ class TestOutput:
     def test_missing_config_raises(self, tmp_path):
         with pytest.raises(FileNotFoundError):
             build_plan(str(tmp_path))
+
+
+class TestPartialCache:
+    """Planning a repo id caches config.json, which creates a snapshot dir with
+    no shards in it. Trusting that dir made `turboquant-plan --model <repo>`
+    work once and then fail forever — it took its own cache droppings for a
+    downloaded model. A cache hit now has to prove it holds the weights."""
+
+    def _index(self, tmp_path, shards):
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps({"weight_map": {f"t{i}": s for i, s in enumerate(shards)}}))
+
+    def test_config_only_snapshot_is_not_a_checkpoint(self, tmp_path):
+        (tmp_path / "config.json").write_text("{}")
+        self._index(tmp_path, ["model-00001-of-00002.safetensors"])
+        assert is_complete_checkpoint(str(tmp_path)) is False
+
+    def test_interrupted_download_is_not_a_checkpoint(self, tmp_path):
+        """The dangerous case: some shards present. Sizes would be summed from
+        only those headers, so a half-downloaded model reports half its weight
+        and a falsely confident RESIDENT verdict."""
+        self._index(tmp_path, ["a.safetensors", "b.safetensors"])
+        (tmp_path / "a.safetensors").write_bytes(b"")
+        assert is_complete_checkpoint(str(tmp_path)) is False
+
+    def test_all_shards_present_is_a_checkpoint(self, tmp_path):
+        self._index(tmp_path, ["a.safetensors", "b.safetensors"])
+        (tmp_path / "a.safetensors").write_bytes(b"")
+        (tmp_path / "b.safetensors").write_bytes(b"")
+        assert is_complete_checkpoint(str(tmp_path)) is True
+
+    def test_single_shard_without_index_is_a_checkpoint(self, tmp_path):
+        (tmp_path / "model.safetensors").write_bytes(b"")
+        assert is_complete_checkpoint(str(tmp_path)) is True
+
+    def test_corrupt_index_is_not_a_checkpoint(self, tmp_path):
+        (tmp_path / "model.safetensors.index.json").write_text("{not json")
+        (tmp_path / "model.safetensors").write_bytes(b"")
+        assert is_complete_checkpoint(str(tmp_path)) is False
+
+    def test_missing_dir_is_not_a_checkpoint(self, tmp_path):
+        assert is_complete_checkpoint(str(tmp_path / "nope")) is False
+
+    def test_partial_cache_hit_falls_back_to_remote(self, tmp_path, monkeypatch):
+        """The regression itself: a snapshot with no shards must send the repo
+        id back to the network, not be planned as a local model."""
+        (tmp_path / "config.json").write_text("{}")
+        import huggingface_hub
+        monkeypatch.setattr(huggingface_hub, "snapshot_download",
+                            lambda *a, **k: str(tmp_path))
+        target, remote = _resolve("some/repo")
+        assert (target, remote) == ("some/repo", True)
+
+    def test_complete_cache_hit_is_used_locally(self, tmp_path, monkeypatch):
+        (tmp_path / "model.safetensors").write_bytes(b"")
+        import huggingface_hub
+        monkeypatch.setattr(huggingface_hub, "snapshot_download",
+                            lambda *a, **k: str(tmp_path))
+        assert _resolve("some/repo") == (str(tmp_path), False)
+
+    def test_explicit_local_path_warns_when_shards_are_missing(self, tmp_path):
+        """A local path is the user's word, so it is planned — but the numbers
+        are undercounted and the plan has to say so."""
+        n = int(9.45 * GB / 4)
+        p = _write_model(tmp_path, Q35, {
+            "model.layers.0.mlp.switch_mlp.gate_proj.weight": ("U32", (n,)),
+        })
+        self._index(tmp_path, ["model.safetensors", "missing.safetensors"])
+        pl = build_plan(p, wired_gb=10.5, ram_gb=16)
+        assert any("UNDER-counted" in w for w in pl["warnings"])
+        assert "UNDER-counted" in render(pl)


### PR DESCRIPTION
## The bug

`turboquant-plan --model <repo-id>` works the first time and **fails forever after**:

```
$ turboquant-plan --model manjunathshiva/Qwen3.6-35B-A3B-tq3a-tqTe-down4-g64
error: no *.safetensors in ~/.cache/huggingface/hub/models--...--down4-g64/snapshots/7719cde...
```

Reproduced from a cold cache — run 1 prints a plan, run 2 of the identical command errors.

The tool poisons its own cache. Planning a repo id calls `read_remote_config` → `hf_hub_download(repo, "config.json")`, which **creates a snapshot directory containing no weights**. The next run's `_resolve` calls `snapshot_download(local_files_only=True)`, gets a cache hit on that directory, treats it as a complete local model, and dies looking for shards.

Shipped in 0.14.0, 0.14.1 and 0.15.0 — i.e. every release that has ever had this tool. On my machine 16 of 17 cached TurboQuant repos are already in the poisoned state.

## The quieter hole

The same `_resolve` gap let a **partially downloaded** model through — an interrupted transfer leaves some shards present, and `footprint` sums whatever headers exist. A half-downloaded 30 GB model reports ~15 GB and a confident `RESIDENT` verdict: the exact false green light this tool exists to prevent, failing in the one direction that costs someone an OOM instead of an answer.

## The fix

`is_complete_checkpoint(path)` — a cache hit is trusted only once it proves it holds every shard the index's `weight_map` names (falling back to "any shard present" for single-shard checkpoints without an index). A partial hit resolves back to remote header planning.

An explicit local path is still planned at the user's word — we can't fall back to a network we have no repo id for — but it now carries a warning that the sizes are under-counted.

## Verification

- The failing command now works, and reports 12.59 GB of weights — matching the down4 build's known size exactly.
- Run 2 and run 3 against the already-poisoned cache both plan correctly.
- `turboquant-doctor` shares `_resolve`, so it's fixed too (verified).
- 9 new tests, including the regression itself; **306 pass**.