### PR TITLE
chore: release 0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project are documented in this file. The format
 is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/) and this
 project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [0.15.1] - 2026-07-16
 
 ### Fixed
 
@@ -23,6 +23,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   confident `RESIDENT` verdict — the exact false green light this tool exists to
   prevent. A local path is still planned on request, but now carries a warning
   that the numbers are under-counted.
+
+- **A malformed `model.safetensors.index.json` now degrades instead of raising.**
+  The index is fetched from an arbitrary repo id, so it is untrusted input: a
+  top-level list/string/number, a non-dict `weight_map`, or a non-string shard
+  name each raised an uncaught `AttributeError`/`TypeError` out of the new
+  completeness check. An index that cannot be read no longer gets to vouch for
+  the checkpoint.
 
 ## [0.15.0] - 2026-07-15
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.15.0"
+__version__ = "0.15.1"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.15.0"
+version = "0.15.1"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Patch release for the `turboquant-plan` cache bug fixed in #57.

Shipping this as its own release rather than holding it until the next feature: it's a user-facing break in a tool that has been broken in **every version it has ever shipped in** (0.14.0, 0.14.1, 0.15.0). Anyone who ran `turboquant-plan --model <repo-id>` twice hit it, and the poisoned cache directory persists — so they stay broken until they upgrade or manually clear the cache.

### Fixed

- `turboquant-plan`/`turboquant-doctor` on an HF repo id worked once, then failed forever with `error: no *.safetensors in ...` — the tool poisoned its own cache by fetching `config.json`, which creates a weightless snapshot dir that the next run mistook for a downloaded model.
- A partially downloaded model had its weights summed from only the shards that arrived → a half-fetched 30 GB model reported ~15 GB and a false `RESIDENT` verdict.
- A malformed `model.safetensors.index.json` (untrusted input from an arbitrary repo id) raised uncaught `AttributeError`/`TypeError`.

### Checks

- Version bumped in `pyproject.toml` and `__init__.py`.
- CHANGELOG `[Unreleased]` → `[0.15.1]`, plus the malformed-index entry that landed in #57 but wasn't yet written up.
- 317 tests pass.