### PR TITLE
feat: fused KV decode+attend Metal kernel (opt-in)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,28 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Fused KV decode+attend Metal kernel** (`turboquant_mlx.kernels.kv_decode_attend`,
+  opt-in via `layers.enable_fused_attend`). At each decode token it reads the
+  **packed** TurboQuant KV cache directly and runs a FlashAttention-style
+  online-softmax pass — decoding K/V on the fly instead of materializing the
+  fp16 tensors that `dequantize -> scaled_dot_product_attention` builds. The
+  inverse-Hadamard rotation is kept outside the kernel via an orthonormal
+  identity (rotate the query once, un-rotate the output once), so the
+  per-token rotation collapses too. Numerically equivalent to the dequant path
+  (cosine 1.0; same fp16 rounding). Split-K / flash-decoding layout keeps the
+  GPU saturated at long context. Measured end-to-end decode speedup **over the
+  standard TQ-KV path**, byte-identical greedy output: **1.49×** on Llama-3.2-1B
+  at 4.2K (70.5 → 105.2 t/s), 1.09× on the hybrid Qwen3.6-35B-A3B (only 10/40
+  layers are full-attention); the isolated attention-layer win reaches ≈10× at
+  32K. Scope: decode-only (`S_q=1`), batch 1, single-tier
+  (`min_tokens_before_quant=0`), bit-packed K/V, equal K/V head dims that are a
+  multiple of 32; prefill and non-applicable steps fall back to the standard
+  path. Plain causal attention only — enabling it on an attention-sink /
+  sliding-window model raises rather than returning wrong output. Not yet wired
+  into `turboquant-serve`. Parity + guard tests in `tests/test_fused_kv_attend.py`.
+
 ### Documentation
 
 - Recorded the **measured** learning-cache result on a genuinely disk-bound 122B

--- a/README.md
+++ b/README.md
@@ -679,6 +679,56 @@ The penalty also **grows with context** on small-KV models. A community long-con
 
 The fp16 decode advantage *widens* with context — 1.14× at 65 tokens → 1.35× at 2.5K → 2.75× at 14.5K → **6.6× at 63K**. So on small-active MoEs, use KV compression to *fit* longer contexts in less RAM (2.08 GB saved at 63K) — not to speed them up. The flip to *faster* shows up only on **GPT-OSS-120B** (8.7 vs 6.4 t/s). The similarly-sized **Qwen3.5-122B does *not* flip** — run resident on a 64 GB M4 Max, fp16 KV beats mixed K8/V3 at every context (1.07× at 256 → 1.20× at 4096; [#19](https://github.com/manjunathshiva/turboquant-mlx/pull/19)) — so the speed-up isn't a general 120B-class property; it's specific to GPT-OSS-120B's KV geometry.
 
+### Fused decode+attend kernel (experimental)
+
+The "speed flip" penalty above is almost entirely the **dequantize** step: at
+each decode token the compressed cache is expanded to fp16 before
+`scaled_dot_product_attention` runs, and at long context that materialization —
+not the attention math — is the wall. The fused kernel removes it.
+
+`turboquant_mlx.kernels.kv_decode_attend` is a hand-written Metal kernel that
+reads the **packed** cache directly and runs a FlashAttention-style
+online-softmax pass, decoding K/V on the fly and never building the fp16
+tensors. The inverse-Hadamard rotation is kept outside the kernel via an
+orthonormal identity (rotate the query once, un-rotate the output once), so the
+per-token rotation cost collapses too. It is numerically equivalent to the
+dequantize+SDPA path (cosine 1.0 vs it, same fp16-rounding error as always).
+
+Opt in per prompt-cache — it patches the model's SDPA seam and flips a flag on
+each `TurboQuantKVCache`:
+
+```python
+from turboquant_mlx.layers import convert_cache_to_turboquant, enable_fused_attend
+from mlx_lm.models.cache import make_prompt_cache
+
+cache = convert_cache_to_turboquant(make_prompt_cache(model),
+                                    k_bits=8, v_bits=3, group_size=64)
+enable_fused_attend(cache)          # decode steps now use the fused kernel
+```
+
+Measured decode speedup **over the standard TQ-KV (dequant+SDPA) path**, greedy,
+byte-identical output:
+
+| Model | Context | TQ-KV shipped | TQ-KV fused | Speedup |
+|-------|---------|--------------:|------------:|--------:|
+| Llama-3.2-1B (D=64, full-attn) | 4.2K | 70.5 t/s | 105.2 t/s | **1.49×** |
+| Qwen3.6-35B-A3B (hybrid, 10/40 full-attn) | 2.1K | 40.2 t/s | 43.9 t/s | 1.09× |
+
+The isolated attention-layer speedup grows with context (≈10× over the shipped
+dequant path at 32K in a per-layer microbenchmark); the end-to-end gain scales
+with the full-attention-layer fraction × context length, so hybrid MoEs
+(Qwen3.5's GatedDeltaNet layers are untouched) see less than dense models.
+
+**Scope / limits.** Decode only (`S_q=1`), batch 1, single-tier
+(`min_tokens_before_quant=0`, no fp16 sink window), bit-packed K/V, and equal
+K/V head dims that are a multiple of 32. Prefill and any non-applicable step
+transparently fall back to the standard path. The kernel performs plain causal
+attention, so it is **not** compatible with attention sinks or a sliding-window
+mask — enabling it on such a model raises a clear error rather than returning
+wrong output. (Sink/sliding layers use `RotatingKVCache` and never convert to
+`TurboQuantKVCache` anyway; the guard covers the GPT-OSS full-attention-with-sinks
+case.) Not yet wired into `turboquant-serve`.
+
 ### Compatibility
 
 | Feature | Supported | Notes |
@@ -688,6 +738,7 @@ The fp16 decode advantage *widens* with context — 1.14× at 65 tokens → 1.35
 | Linear attention | Yes | `ArraysCache` (Qwen3.5 GatedDeltaNet) is left untouched |
 | Hybrid architectures | Yes | Per-layer cache type is preserved |
 | Prompt-first conversion | Yes | Process prompt with FP16, convert before generation |
+| Fused decode+attend | Experimental | Opt-in `enable_fused_attend`; standard causal decode only (see above) |
 
 ---
 

--- a/kernels/kv_decode_attend.py
+++ b/kernels/kv_decode_attend.py
@@ -1,0 +1,234 @@
+"""Fused KV decode+attend Metal kernel for the TurboQuant KV cache.
+
+Single-token decode (S_q=1) attention that reads the *packed* TurboQuant KV
+cache directly — decoding keys/values on the fly inside a FlashAttention-style
+online-softmax pass, never materializing the fp16 K/V tensors that the standard
+``dequantize -> scaled_dot_product_attention`` path builds.
+
+The inverse-Hadamard rotation is kept OUTSIDE the kernel via the orthonormal
+identity: since H is orthonormal + symmetric,
+    q . k_hat = H(q (x) signs_k) . k_ds        (rotate the query once)
+    out = signs_v (x) H(sum_s p_s v_ds[s])      (rotate the output once)
+so the kernel operates purely in the rotated domain (per-dim decode + dot +
+online softmax) and the caller applies ``_rotate`` to q and ``_unrotate`` to the
+output. This removes the per-key WHT that dominates the dequantize path.
+
+Design (flash-decoding / split-K): grid = (n_q_heads * n_chunks) simdgroups of
+32 lanes; each lane owns D/32 dims. Each (q_head, chunk) simdgroup emits a
+partial (m, l, acc); a second Metal kernel merges the partials with the standard
+online-softmax combine. Bit-packed K and V only (2/3/4/8-bit); ``D`` must be a
+multiple of 32.
+
+Scope: B=1, S_q=1, single-tier (no fp16 attention-sink window), no sliding-window
+mask, no attention sinks. Callers must check applicability before dispatching.
+"""
+
+import math
+
+import mlx.core as mx
+
+_kernel_cache: dict[tuple, object] = {}
+
+WARP = 32
+
+
+def _extract(prefix: str, bits: int, var: str) -> str:
+    elems = 32 // bits
+    mask = (1 << bits) - 1
+    return f"""
+            uint {var}_pcol = d / {elems}u;
+            uint {var}_bpos = (d % {elems}u) * {bits}u;
+            uint {var}_word = {prefix}[{prefix}_base + {var}_pcol];
+            uint {var}_idx  = ({var}_word >> {var}_bpos) & {mask}u;"""
+
+
+def _build_partial_source(k_bits, v_bits, gs_k, gs_v, D, chunk):
+    n_codes_k = 1 << k_bits
+    n_codes_v = 1 << v_bits
+    dpl = D // WARP
+    scale = 1.0 / math.sqrt(D)
+    ext_k = _extract("packed_k", k_bits, "k")
+    ext_v = _extract("packed_v", v_bits, "v")
+    return f"""
+    uint lane = thread_position_in_threadgroup.x;         // 0..31
+    uint work = threadgroup_position_in_grid.x;           // q_head*n_chunks+chunk
+    uint n_q_heads = q_rot_shape[0];
+    uint n_kv_heads = packed_k_shape[0];
+    uint S_kv   = packed_k_shape[1];
+    uint n_chunks = (S_kv + {chunk}u - 1u) / {chunk}u;
+    if (work >= n_q_heads * n_chunks) return;
+
+    uint q_head = work / n_chunks;
+    uint chunk  = work % n_chunks;
+    uint s0 = chunk * {chunk}u;
+    uint s1 = min(s0 + {chunk}u, S_kv);
+
+    uint pk_cols = packed_k_shape[2];
+    uint pv_cols = packed_v_shape[2];
+    uint ngk = scales_k_shape[2];
+    uint ngv = scales_v_shape[2];
+    const uint D = {D}u;
+    const uint DPL = {dpl}u;
+
+    uint kv_head = q_head / (n_q_heads / n_kv_heads);
+
+    float cbk[{n_codes_k}];
+    for (uint i = 0; i < {n_codes_k}u; i++) cbk[i] = float(codebook_k[i]);
+    float cbv[{n_codes_v}];
+    for (uint i = 0; i < {n_codes_v}u; i++) cbv[i] = float(codebook_v[i]);
+
+    float qd[DPL];
+    for (uint i = 0; i < DPL; i++) qd[i] = float(q_rot[q_head * D + lane + i * 32u]);
+
+    float acc[DPL];
+    for (uint i = 0; i < DPL; i++) acc[i] = 0.0f;
+    float run_m = -INFINITY;
+    float run_l = 0.0f;
+
+    uint pk_hbase = kv_head * S_kv * pk_cols;
+    uint sk_hbase = kv_head * S_kv * ngk;
+    uint pv_hbase = kv_head * S_kv * pv_cols;
+    uint sv_hbase = kv_head * S_kv * ngv;
+
+    for (uint s = s0; s < s1; s++) {{
+        uint packed_k_base = pk_hbase + s * pk_cols;
+        uint sk_base = sk_hbase + s * ngk;
+        float pdot = 0.0f;
+        for (uint i = 0; i < DPL; i++) {{
+            uint d = lane + i * 32u;{ext_k}
+            float sc = float(scales_k[sk_base + d / {gs_k}u]);
+            pdot += qd[i] * (cbk[k_idx] * sc);
+        }}
+        float score = simd_sum(pdot) * {scale}f;
+        float new_m = max(run_m, score);
+        float corr = exp(run_m - new_m);
+        float p = exp(score - new_m);
+        run_l = run_l * corr + p;
+        run_m = new_m;
+
+        uint packed_v_base = pv_hbase + s * pv_cols;
+        uint sv_base = sv_hbase + s * ngv;
+        for (uint i = 0; i < DPL; i++) {{
+            uint d = lane + i * 32u;{ext_v}
+            float sc = float(scales_v[sv_base + d / {gs_v}u]);
+            acc[i] = acc[i] * corr + p * (cbv[v_idx] * sc);
+        }}
+    }}
+
+    uint acc_base = (q_head * n_chunks + chunk) * D;
+    for (uint i = 0; i < DPL; i++) {{
+        uint d = lane + i * 32u;
+        partial_acc[acc_base + d] = partial_acc_t(acc[i]);
+    }}
+    if (lane == 0) {{
+        partial_m[q_head * n_chunks + chunk] = run_m;
+        partial_l[q_head * n_chunks + chunk] = run_l;
+    }}
+"""
+
+
+def _build_combine_source(D):
+    dpl = D // WARP
+    return f"""
+    uint lane = thread_position_in_threadgroup.x;
+    uint q_head = threadgroup_position_in_grid.x;
+    uint n_q_heads = partial_m_shape[0];
+    if (q_head >= n_q_heads) return;
+    uint n_chunks = partial_m_shape[1];
+    const uint D = {D}u;
+    const uint DPL = {dpl}u;
+
+    uint pm_base = q_head * n_chunks;
+    uint pa_base = q_head * n_chunks * D;
+
+    float m = -INFINITY;
+    for (uint j = 0; j < n_chunks; j++) m = max(m, partial_m[pm_base + j]);
+
+    float num[DPL];
+    for (uint i = 0; i < DPL; i++) num[i] = 0.0f;
+    float l = 0.0f;
+    for (uint j = 0; j < n_chunks; j++) {{
+        float w = exp(partial_m[pm_base + j] - m);
+        l += w * partial_l[pm_base + j];
+        uint pa = pa_base + j * D;
+        for (uint i = 0; i < DPL; i++)
+            num[i] += w * float(partial_acc[pa + lane + i * 32u]);
+    }}
+    float inv_l = 1.0f / l;
+    for (uint i = 0; i < DPL; i++)
+        out[q_head * D + lane + i * 32u] = out_t(num[i] * inv_l);
+"""
+
+
+def _get_partial_kernel(k_bits, v_bits, gs_k, gs_v, D, chunk):
+    key = ("partial", k_bits, v_bits, gs_k, gs_v, D, chunk)
+    if key not in _kernel_cache:
+        _kernel_cache[key] = mx.fast.metal_kernel(
+            name=f"kv_da_k{k_bits}v{v_bits}_gk{gs_k}gv{gs_v}_d{D}_c{chunk}",
+            input_names=["q_rot", "packed_k", "scales_k", "codebook_k",
+                         "packed_v", "scales_v", "codebook_v"],
+            output_names=["partial_acc", "partial_m", "partial_l"],
+            source=_build_partial_source(k_bits, v_bits, gs_k, gs_v, D, chunk),
+            ensure_row_contiguous=True,
+        )
+    return _kernel_cache[key]
+
+
+def _get_combine_kernel(D):
+    key = ("combine", D)
+    if key not in _kernel_cache:
+        _kernel_cache[key] = mx.fast.metal_kernel(
+            name=f"kv_da_combine_d{D}",
+            input_names=["partial_acc", "partial_m", "partial_l"],
+            output_names=["out"],
+            source=_build_combine_source(D),
+            ensure_row_contiguous=True,
+        )
+    return _kernel_cache[key]
+
+
+def _adaptive_chunk(S_kv, target_chunks=32):
+    raw = max(1.0, S_kv / target_chunks)
+    p2 = 1 << int(round(math.log2(raw)))
+    return min(max(p2, 256), 2048)
+
+
+def kv_decode_attend(q_rot, packed_k, scales_k, codebook_k,
+                     packed_v, scales_v, codebook_v,
+                     k_bits, v_bits, gs_k, gs_v, chunk=None):
+    """Fused decode+attend.
+
+    q_rot: (n_q_heads, D) — query already rotated (H(q (x) signs_k)) and
+        pre-scaled so the kernel's baked 1/sqrt(D) yields the model's scale.
+    packed_k/scales_k/codebook_k: (n_kv_heads, S_kv, pk_cols) uint32 /
+        (n_kv_heads, S_kv, n_groups) f16 / (2^k_bits,) f16.
+    packed_v/... : likewise for V.
+    Returns (n_q_heads, D) in the rotated-V domain (caller un-rotates).
+    """
+    n_q_heads, D = q_rot.shape
+    S_kv = packed_k.shape[1]
+    if chunk is None:
+        chunk = _adaptive_chunk(S_kv)
+    n_chunks = (S_kv + chunk - 1) // chunk
+
+    partial = _get_partial_kernel(k_bits, v_bits, gs_k, gs_v, D, chunk)
+    partial_acc, partial_m, partial_l = partial(
+        inputs=[q_rot, packed_k, scales_k, codebook_k,
+                packed_v, scales_v, codebook_v],
+        template=[("partial_acc_t", q_rot.dtype)],
+        grid=(n_q_heads * n_chunks * WARP, 1, 1),
+        threadgroup=(WARP, 1, 1),
+        output_shapes=[(n_q_heads, n_chunks, D),
+                       (n_q_heads, n_chunks), (n_q_heads, n_chunks)],
+        output_dtypes=[q_rot.dtype, mx.float32, mx.float32],
+    )
+    combine = _get_combine_kernel(D)
+    out = combine(
+        inputs=[partial_acc, partial_m, partial_l],
+        template=[("out_t", q_rot.dtype)],
+        grid=(n_q_heads * WARP, 1, 1),
+        threadgroup=(WARP, 1, 1),
+        output_shapes=[(n_q_heads, D)],
+        output_dtypes=[q_rot.dtype],
+    )
+    return out[0]

--- a/layers/__init__.py
+++ b/layers/__init__.py
@@ -4,4 +4,6 @@ from turboquant_mlx.layers.polar_kv_cache import (
     TurboQuantKVCache,
     make_turboquant_cache,
     convert_cache_to_turboquant,
+    enable_fused_attend,
+    install_fused_attend_patch,
 )

--- a/layers/polar_kv_cache.py
+++ b/layers/polar_kv_cache.py
@@ -117,6 +117,9 @@ class TurboQuantKVCache:
         self._v_bits = int(v_bits)
         self._group_size = int(group_size)
         self._seed = int(seed)
+        # Opt-in fused decode+attend Metal kernel (reads packed KV directly,
+        # skips the fp16 dequantize). Set via enable_fused_attend().
+        self._use_fused_attend = False
 
         # Precompute K codebook
         self._k_codebook_f32, self._k_boundaries_f32 = get_codebook(
@@ -225,6 +228,59 @@ class TurboQuantKVCache:
             v_deq.astype(mx.float32), signs.astype(mx.float32), block_size
         )
         return v_deq.astype(mx.float16)
+
+    def _fused_applicable(self, B, num_steps):
+        """True when the fused decode+attend kernel can serve this step.
+
+        Requires: opt-in flag; a single new token (decode); batch 1; single tier
+        (no fp16 attention-sink window); equal K/V head dims that are a multiple
+        of 32; and bit-packed (2^bits) codebooks — never trit for KV.
+        """
+        return (
+            self._use_fused_attend
+            and num_steps == 1
+            and B == 1
+            and self._min_tokens_before_quant == 0
+            and self._k_head_dim is not None
+            and self._k_head_dim == self._v_head_dim
+            and self._k_head_dim % 32 == 0
+        )
+
+    def fused_attend(self, queries, scale):
+        """Fused decode attention straight from packed storage.
+
+        ``queries``: (1, n_q_heads, 1, D). Returns (1, n_q_heads, 1, D) fp16.
+        Rotation stays outside the kernel via the orthonormal identity; the
+        model's ``scale`` is folded into the pre-rotated query so the kernel's
+        baked 1/sqrt(D) reproduces it.
+        """
+        from turboquant_mlx.kernels.kv_decode_attend import kv_decode_attend
+
+        B, n_q, S_q, D = queries.shape
+        b_total = self.offset  # threshold == 0 -> all tokens are in Tier B
+
+        q_rot = self._rotate(
+            queries.astype(mx.float32), self._k_signs.astype(mx.float32),
+            self._k_block_size,
+        ).astype(mx.float16).reshape(n_q, D)
+        # fold the model scale into q so the kernel's baked 1/sqrt(D) == scale
+        q_rot = q_rot * mx.array(scale * math.sqrt(D), dtype=mx.float16)
+
+        out = kv_decode_attend(
+            q_rot,
+            mx.contiguous(self._tq_keys[0][0, :, :b_total, :]),
+            mx.contiguous(self._tq_keys[1][0, :, :b_total, :]),
+            self._k_codebook_f16,
+            mx.contiguous(self._tq_values[0][0, :, :b_total, :]),
+            mx.contiguous(self._tq_values[1][0, :, :b_total, :]),
+            self._v_codebook_f16,
+            self._k_bits, self._v_bits, self._k_gs, self._v_gs,
+        ).reshape(1, n_q, 1, D)
+        out = self._unrotate(
+            out.astype(mx.float32), self._v_signs.astype(mx.float32),
+            self._v_block_size,
+        )
+        return out.astype(mx.float16)
 
     def update_and_fetch(self, keys, values):
         """Store new KV across two tiers, return float16 for SDPA.
@@ -341,6 +397,11 @@ class TurboQuantKVCache:
             self._tq_values[1][..., b_prev:b_new, :] = v_scales
 
         self.offset = new_offset
+
+        # Fused decode path: the token is stored; skip the fp16 dequantize and
+        # signal the patched SDPA seam (keys is None) to run the fused kernel.
+        if self._fused_applicable(B, num_steps):
+            return None, None
 
         # Fetch: concat Tier A (fp16) + Tier B (dequantized)
         b_total = max(0, new_offset - threshold)
@@ -556,6 +617,62 @@ class TurboQuantKVCache:
 
         return create_attention_mask(N, self.offset, return_array=return_array,
                                      window_size=window_size)
+
+
+_FUSED_PATCH_INSTALLED = False
+
+
+def install_fused_attend_patch():
+    """Route the model's SDPA seam to the fused kernel on fused decode steps.
+
+    mlx-lm models call ``scaled_dot_product_attention(q, k, v, cache=..., ...)``
+    (imported into each model module). When a fused-enabled TurboQuantKVCache
+    served a decode step it returned ``(None, None)`` from ``update_and_fetch``;
+    here ``keys is None`` is the signal to run ``cache.fused_attend``. All other
+    calls fall through to the original. Idempotent; call after model load.
+    """
+    global _FUSED_PATCH_INSTALLED
+    if _FUSED_PATCH_INSTALLED:
+        return
+    import sys
+    import mlx_lm.models.base as base
+
+    orig = base.scaled_dot_product_attention
+
+    def patched(queries, keys, values, cache=None, scale=1.0, mask=None,
+                sinks=None):
+        if keys is None and isinstance(cache, TurboQuantKVCache):
+            # update_and_fetch skipped the fp16 dequant before this call
+            # revealed mask/sinks. The fused kernel does plain causal decode
+            # (a single query attends to all stored tokens), so it cannot honor
+            # attention sinks or a sliding-window array mask. Fail loud rather
+            # than return silently wrong output — the user opted in explicitly.
+            if sinks is not None or (mask is not None and not isinstance(mask, str)):
+                raise RuntimeError(
+                    "fused KV decode+attend is incompatible with attention "
+                    "sinks or a non-causal/sliding-window mask; do not call "
+                    "enable_fused_attend() for this model."
+                )
+            return cache.fused_attend(queries, scale)
+        return orig(queries, keys, values, cache=cache, scale=scale, mask=mask,
+                    sinks=sinks)
+
+    base.scaled_dot_product_attention = patched
+    for name, mod in list(sys.modules.items()):
+        if (name.startswith("mlx_lm.models.")
+                and getattr(mod, "scaled_dot_product_attention", None) is orig):
+            mod.scaled_dot_product_attention = patched
+    _FUSED_PATCH_INSTALLED = True
+
+
+def enable_fused_attend(caches):
+    """Turn on the fused decode+attend path for every TurboQuantKVCache in the
+    list (and install the SDPA patch). Other cache types are ignored."""
+    install_fused_attend_patch()
+    for c in caches:
+        if isinstance(c, TurboQuantKVCache):
+            c._use_fused_attend = True
+    return caches
 
 
 def make_turboquant_cache(

--- a/layers/polar_kv_cache.py
+++ b/layers/polar_kv_cache.py
@@ -619,9 +619,6 @@ class TurboQuantKVCache:
                                      window_size=window_size)
 
 
-_FUSED_PATCH_INSTALLED = False
-
-
 def install_fused_attend_patch():
     """Route the model's SDPA seam to the fused kernel on fused decode steps.
 
@@ -629,15 +626,15 @@ def install_fused_attend_patch():
     (imported into each model module). When a fused-enabled TurboQuantKVCache
     served a decode step it returned ``(None, None)`` from ``update_and_fetch``;
     here ``keys is None`` is the signal to run ``cache.fused_attend``. All other
-    calls fall through to the original. Idempotent; call after model load.
+    calls fall through to the original. Idempotent (the installed wrapper is
+    tagged and re-detected, so it survives module reloads); call after load.
     """
-    global _FUSED_PATCH_INSTALLED
-    if _FUSED_PATCH_INSTALLED:
-        return
     import sys
     import mlx_lm.models.base as base
 
     orig = base.scaled_dot_product_attention
+    if getattr(orig, "_turboquant_fused", False):
+        return  # already installed
 
     def patched(queries, keys, values, cache=None, scale=1.0, mask=None,
                 sinks=None):
@@ -657,12 +654,12 @@ def install_fused_attend_patch():
         return orig(queries, keys, values, cache=cache, scale=scale, mask=mask,
                     sinks=sinks)
 
+    patched._turboquant_fused = True
     base.scaled_dot_product_attention = patched
     for name, mod in list(sys.modules.items()):
         if (name.startswith("mlx_lm.models.")
                 and getattr(mod, "scaled_dot_product_attention", None) is orig):
             mod.scaled_dot_product_attention = patched
-    _FUSED_PATCH_INSTALLED = True
 
 
 def enable_fused_attend(caches):

--- a/tests/test_fused_kv_attend.py
+++ b/tests/test_fused_kv_attend.py
@@ -107,6 +107,25 @@ def test_applicability_guards():
     assert not c2._fused_applicable(B=1, num_steps=1)
 
 
+def test_enable_fused_attend_flips_flag_and_is_idempotent():
+    caches = [
+        TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
+                          min_tokens_before_quant=0),
+        "not-a-cache",  # non-cache entries (e.g. RotatingKVCache) are ignored
+        TurboQuantKVCache(k_bits=4, v_bits=3, group_size=64,
+                          min_tokens_before_quant=0),
+    ]
+    out = enable_fused_attend(caches)
+    assert out is caches
+    assert caches[0]._use_fused_attend and caches[2]._use_fused_attend
+    # installs the SDPA-seam patch exactly once (idempotent)
+    import mlx_lm.models.base as base
+    assert getattr(base.scaled_dot_product_attention, "_turboquant_fused", False)
+    first = base.scaled_dot_product_attention
+    enable_fused_attend(caches)  # second call must not re-wrap
+    assert base.scaled_dot_product_attention is first
+
+
 def test_update_and_fetch_skips_dequant_when_fused():
     cache = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
                               min_tokens_before_quant=0)

--- a/tests/test_fused_kv_attend.py
+++ b/tests/test_fused_kv_attend.py
@@ -1,0 +1,139 @@
+"""Fused KV decode+attend kernel: parity with the shipped dequant+SDPA path.
+
+The fused path (``TurboQuantKVCache.fused_attend`` + the SDPA-seam patch) must
+be numerically equivalent to ``dequantize -> scaled_dot_product_attention`` on
+the same stored (quantized) KV — it reads the identical packed bytes, only the
+arithmetic order differs. We assert high cosine similarity + small max-abs (fp16
+rounding), across bit widths, head dims, and GQA ratios, plus the applicability
+guards and the fail-loud sink/mask behavior.
+"""
+import math
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.layers.polar_kv_cache import (
+    TurboQuantKVCache,
+    enable_fused_attend,
+    install_fused_attend_patch,
+)
+
+
+def _reference(cache, b_total, q, scale):
+    """Shipped path: dequantize (with unrotate) then standard SDPA."""
+    k_hat = cache._tq_dequantize(
+        cache._tq_keys[0][..., :b_total, :], cache._tq_keys[1][..., :b_total, :],
+        cache._k_signs, cache._k_block_size, cache._k_gs, cache._k_head_dim,
+        cache._k_bits, cache._k_codebook_f16)
+    v_hat = cache._tq_dequantize(
+        cache._tq_values[0][..., :b_total, :], cache._tq_values[1][..., :b_total, :],
+        cache._v_signs, cache._v_block_size, cache._v_gs, cache._v_head_dim,
+        cache._v_bits, cache._v_codebook_f16)
+    return mx.fast.scaled_dot_product_attention(q, k_hat, v_hat, scale=scale)
+
+
+def _cos(a, b):
+    a = a.astype(mx.float32).reshape(-1)
+    b = b.astype(mx.float32).reshape(-1)
+    return float((a * b).sum()
+                 / (mx.sqrt((a * a).sum()) * mx.sqrt((b * b).sum())))
+
+
+@pytest.mark.parametrize("k_bits,v_bits", [(8, 3), (8, 4), (4, 3), (3, 3)])
+@pytest.mark.parametrize("n_q,n_kv,D", [(8, 8, 128), (32, 8, 128), (16, 2, 256)])
+def test_fused_matches_dequant_sdpa(k_bits, v_bits, n_q, n_kv, D):
+    S = 2048
+    mx.random.seed(0)
+    keys = mx.random.normal((1, n_kv, S, D)).astype(mx.float16)
+    values = mx.random.normal((1, n_kv, S, D)).astype(mx.float16)
+    q = mx.random.normal((1, n_q, 1, D)).astype(mx.float16)
+    scale = 1.0 / math.sqrt(D)
+
+    cache = TurboQuantKVCache(k_bits=k_bits, v_bits=v_bits,
+                              group_size=min(64, D), min_tokens_before_quant=0)
+    cache.update_and_fetch(keys, values)
+    mx.eval(cache._tq_keys, cache._tq_values)
+
+    ref = _reference(cache, cache.offset, q, scale)
+    fused = cache.fused_attend(q, scale)
+    mx.eval(ref, fused)
+
+    assert _cos(ref, fused) > 0.9999
+    max_abs = float(mx.max(mx.abs(ref.astype(mx.float32) - fused.astype(mx.float32))))
+    rms = float(mx.sqrt(mx.mean(ref.astype(mx.float32) ** 2)))
+    assert max_abs < 5e-3 * rms + 1e-3
+
+
+def test_fused_respects_model_scale():
+    """A non-default softmax scale must be honored (folded into q)."""
+    S, D = 1024, 128
+    mx.random.seed(1)
+    keys = mx.random.normal((1, 4, S, D)).astype(mx.float16)
+    values = mx.random.normal((1, 4, S, D)).astype(mx.float16)
+    q = mx.random.normal((1, 4, 1, D)).astype(mx.float16)
+    scale = 0.137  # deliberately not 1/sqrt(D)
+
+    cache = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
+                              min_tokens_before_quant=0)
+    cache.update_and_fetch(keys, values)
+    mx.eval(cache._tq_keys, cache._tq_values)
+    ref = _reference(cache, cache.offset, q, scale)
+    fused = cache.fused_attend(q, scale)
+    mx.eval(ref, fused)
+    assert _cos(ref, fused) > 0.9999
+
+
+def test_applicability_guards():
+    cache = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
+                              min_tokens_before_quant=0)
+    cache.update_and_fetch(
+        mx.random.normal((1, 4, 16, 128)).astype(mx.float16),
+        mx.random.normal((1, 4, 16, 128)).astype(mx.float16))
+    cache._use_fused_attend = True
+    # decode step, B=1 -> applicable
+    assert cache._fused_applicable(B=1, num_steps=1)
+    # prefill (num_steps>1) -> not applicable
+    assert not cache._fused_applicable(B=1, num_steps=8)
+    # batch > 1 -> not applicable
+    assert not cache._fused_applicable(B=2, num_steps=1)
+    # flag off -> not applicable
+    cache._use_fused_attend = False
+    assert not cache._fused_applicable(B=1, num_steps=1)
+    # fp16 attention-sink window (min_tokens>0) -> not applicable
+    c2 = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
+                           min_tokens_before_quant=64)
+    c2._use_fused_attend = True
+    c2._k_head_dim = c2._v_head_dim = 128
+    assert not c2._fused_applicable(B=1, num_steps=1)
+
+
+def test_update_and_fetch_skips_dequant_when_fused():
+    cache = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
+                              min_tokens_before_quant=0)
+    cache._use_fused_attend = True
+    # prefill returns real K/V (fused not applicable for num_steps>1)
+    k = mx.random.normal((1, 4, 16, 128)).astype(mx.float16)
+    v = mx.random.normal((1, 4, 16, 128)).astype(mx.float16)
+    ok_k, ok_v = cache.update_and_fetch(k, v)
+    assert ok_k is not None and ok_v is not None
+    # a decode step returns (None, None) — token stored, dequant skipped
+    k1 = mx.random.normal((1, 4, 1, 128)).astype(mx.float16)
+    v1 = mx.random.normal((1, 4, 1, 128)).astype(mx.float16)
+    r_k, r_v = cache.update_and_fetch(k1, v1)
+    assert r_k is None and r_v is None
+    assert cache.offset == 17  # token was still stored
+
+
+def test_patch_fails_loud_on_sinks():
+    install_fused_attend_patch()
+    import mlx_lm.models.base as base
+    cache = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
+                             min_tokens_before_quant=0)
+    cache.update_and_fetch(
+        mx.random.normal((1, 4, 8, 128)).astype(mx.float16),
+        mx.random.normal((1, 4, 8, 128)).astype(mx.float16))
+    q = mx.random.normal((1, 4, 1, 128)).astype(mx.float16)
+    sinks = mx.zeros((4,), dtype=mx.float16)
+    with pytest.raises(RuntimeError, match="attention sinks"):
+        base.scaled_dot_product_attention(q, None, None, cache=cache,
+                                          scale=1.0, mask=None, sinks=sinks)


### PR DESCRIPTION
## What

A hand-written Metal kernel that serves **decode-step attention straight from the packed TurboQuant KV cache** — decoding K/V on the fly in a FlashAttention-style online-softmax pass, never materializing the fp16 tensors that today's `dequantize → scaled_dot_product_attention` path builds. Opt-in via `layers.enable_fused_attend(cache)`.

## Why

The "speed flip" penalty documented in the README (TQ-KV is *slower* than fp16 on small-KV models, and the gap widens with context) is almost entirely the **dequantize** step. Removing it recovers most of that penalty.

## How

- The inverse-Hadamard rotation is kept **outside** the kernel via an orthonormal identity: `q·k_hat = H(q⊙signs_k)·k_ds` and `out = signs_v⊙H(Σ p_s·v_ds)`. So the per-key WHT collapses to one rotation on the query and one on the output, and the kernel is a pure per-dim decode + online softmax.
- **Split-K / flash-decoding** layout (grid = n_q_heads × n_chunks simdgroups + a Metal combine kernel) keeps the GPU saturated at long context — a naïve one-simdgroup-per-head version was 1.4–2.7× *slower*.
- Integration: `update_and_fetch` returns `(None, None)` on applicable decode steps (stores the token, skips dequant); a patch on the model SDPA seam routes `keys is None` to `fused_attend`.

## Results

Numerically equivalent to the dequant path (cosine **1.0**, same fp16 rounding). Decode speedup **over the standard TQ-KV path**, byte-identical greedy output:

| Model | Context | TQ-KV shipped | TQ-KV fused | Speedup |
|-------|---------|--------------:|------------:|--------:|
| Llama-3.2-1B (D=64, full-attn) | 4.2K | 70.5 t/s | 105.2 t/s | **1.49×** |
| Qwen3.6-35B-A3B (hybrid, 10/40 full-attn) | 2.1K | 40.2 t/s | 43.9 t/s | 1.09× |

Isolated attention-layer speedup reaches ≈**10×** at 32K in a per-layer microbenchmark; the end-to-end gain scales with (full-attention-layer fraction × context).

## Scope / safety

- Decode only (`S_q=1`), batch 1, single-tier (`min_tokens_before_quant=0`), bit-packed K/V, equal K/V head dims that are a multiple of 32. Prefill and every non-applicable step **fall back to the standard path**.
- Plain causal attention only. Enabling it on an attention-sink / sliding-window model **raises** rather than returning wrong output. (Those layers use `RotatingKVCache` and never convert anyway; the guard covers GPT-OSS full-attention-with-sinks.)
- Not yet wired into `turboquant-serve` (follow-up).
- Flag defaults **off** → zero behavior change when unused.

## Tests

`tests/test_fused_kv_attend.py`: parity vs dequant+SDPA across bit widths × head dims × GQA ratios, model-scale handling, applicability guards, skip-dequant behavior, and the fail-loud sink guard. Full suite **333 pass**.