### PR TITLE
feat(serve): --kv-fused flag for the fused KV decode+attend kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`turboquant-serve --kv-fused`** — enable the fused KV decode+attend kernel on
+  the server. Requires KV quantization and `--kv-min-tokens 0` (single-tier); a
+  non-zero sink window keeps decode on the standard path and the flag warns. On
+  attention-sink / sliding-window layers the fused path **gracefully falls back**
+  to dequantize+SDPA for that step (the earlier fail-loud guard became a
+  fallback via `TurboQuantKVCache.fused_fallback_fetch`), so it is safe to enable
+  on any model including GPT-OSS. The startup banner reports fused on/inactive.
+
 - **Fused KV decode+attend Metal kernel** (`turboquant_mlx.kernels.kv_decode_attend`,
   opt-in via `layers.enable_fused_attend`). At each decode token it reads the
   **packed** TurboQuant KV cache directly and runs a FlashAttention-style
@@ -24,9 +32,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   32K. Scope: decode-only (`S_q=1`), batch 1, single-tier
   (`min_tokens_before_quant=0`), bit-packed K/V, equal K/V head dims that are a
   multiple of 32; prefill and non-applicable steps fall back to the standard
-  path. Plain causal attention only — enabling it on an attention-sink /
-  sliding-window model raises rather than returning wrong output. Not yet wired
-  into `turboquant-serve`. Parity + guard tests in `tests/test_fused_kv_attend.py`.
+  path. Plain causal attention only — on attention-sink / sliding-window layers
+  it gracefully falls back to dequantize+SDPA (see `--kv-fused` below). Parity +
+  guard tests in `tests/test_fused_kv_attend.py`.
 
 ### Documentation
 

--- a/README.md
+++ b/README.md
@@ -511,6 +511,7 @@ turboquant-serve \
 | `--kv-bits N` | Symmetric K=V=N (legacy; not recommended below 3) |
 | `--kv-min-tokens N` | Keep first N cached tokens in fp16 (sink protection) |
 | `--kv-group-size G` | Hadamard rotation group size (default 64) |
+| `--kv-fused` | Use the fused decode+attend Metal kernel (experimental; needs `--kv-min-tokens 0`; see [Fused decode+attend](#fused-decodeattend-kernel-experimental)) |
 
 These are processed by `turboquant-serve` and stripped before the remaining
 flags forward to `mlx_lm.server`. See [KV Cache Compression](#kv-cache-compression)
@@ -719,15 +720,24 @@ dequant path at 32K in a per-layer microbenchmark); the end-to-end gain scales
 with the full-attention-layer fraction × context length, so hybrid MoEs
 (Qwen3.5's GatedDeltaNet layers are untouched) see less than dense models.
 
+Or enable it while serving with `--kv-fused` (see the
+[serve KV flags](#compress-the-kv-cache-while-serving)):
+
+```bash
+turboquant-serve --model ./model-tq3 --kv-k-bits 8 --kv-v-bits 3 \
+    --kv-min-tokens 0 --kv-fused
+```
+
 **Scope / limits.** Decode only (`S_q=1`), batch 1, single-tier
 (`min_tokens_before_quant=0`, no fp16 sink window), bit-packed K/V, and equal
 K/V head dims that are a multiple of 32. Prefill and any non-applicable step
 transparently fall back to the standard path. The kernel performs plain causal
-attention, so it is **not** compatible with attention sinks or a sliding-window
-mask — enabling it on such a model raises a clear error rather than returning
-wrong output. (Sink/sliding layers use `RotatingKVCache` and never convert to
-`TurboQuantKVCache` anyway; the guard covers the GPT-OSS full-attention-with-sinks
-case.) Not yet wired into `turboquant-serve`.
+attention, so on a layer that needs attention sinks or a sliding-window mask it
+**gracefully falls back** to the standard dequantize+SDPA path for that step
+(correct output, just without the fused speedup) — so it is safe to enable on
+any model, including GPT-OSS. (Sink/sliding layers mostly use `RotatingKVCache`
+and never convert to `TurboQuantKVCache`; the fallback covers the GPT-OSS
+full-attention-with-sinks case.)
 
 ### Compatibility
 
@@ -738,7 +748,7 @@ case.) Not yet wired into `turboquant-serve`.
 | Linear attention | Yes | `ArraysCache` (Qwen3.5 GatedDeltaNet) is left untouched |
 | Hybrid architectures | Yes | Per-layer cache type is preserved |
 | Prompt-first conversion | Yes | Process prompt with FP16, convert before generation |
-| Fused decode+attend | Experimental | Opt-in `enable_fused_attend`; standard causal decode only (see above) |
+| Fused decode+attend | Experimental | Opt-in (`enable_fused_attend` / serve `--kv-fused`); standard causal decode, graceful dequant fallback on sink/sliding layers (see above) |
 
 ---
 

--- a/layers/polar_kv_cache.py
+++ b/layers/polar_kv_cache.py
@@ -282,6 +282,27 @@ class TurboQuantKVCache:
         )
         return out.astype(mx.float16)
 
+    def fused_fallback_fetch(self):
+        """Full fp16 (keys, values) for a fused-cache decode step that turned
+        out to need sink / mask semantics the kernel can't honor.
+
+        ``update_and_fetch`` already stored the token and returned
+        ``(None, None)`` to skip the dequantize; the SDPA seam calls this to
+        reconstruct the dequantized cache and fall back to standard attention.
+        Only the compressed tier exists here (fused requires
+        ``min_tokens_before_quant == 0``).
+        """
+        b_total = self.offset
+        k = self._tq_dequantize(
+            self._tq_keys[0][..., :b_total, :], self._tq_keys[1][..., :b_total, :],
+            self._k_signs, self._k_block_size, self._k_gs, self._k_head_dim,
+            self._k_bits, self._k_codebook_f16)
+        v = self._tq_dequantize(
+            self._tq_values[0][..., :b_total, :], self._tq_values[1][..., :b_total, :],
+            self._v_signs, self._v_block_size, self._v_gs, self._v_head_dim,
+            self._v_bits, self._v_codebook_f16)
+        return k, v
+
     def update_and_fetch(self, keys, values):
         """Store new KV across two tiers, return float16 for SDPA.
 
@@ -640,16 +661,15 @@ def install_fused_attend_patch():
                 sinks=None):
         if keys is None and isinstance(cache, TurboQuantKVCache):
             # update_and_fetch skipped the fp16 dequant before this call
-            # revealed mask/sinks. The fused kernel does plain causal decode
-            # (a single query attends to all stored tokens), so it cannot honor
-            # attention sinks or a sliding-window array mask. Fail loud rather
-            # than return silently wrong output — the user opted in explicitly.
+            # revealed mask/sinks. The fused kernel does plain causal decode (a
+            # single query attends to all stored tokens), so it cannot honor
+            # attention sinks or a sliding-window array mask. Fall back to the
+            # standard dequantize+SDPA path for those steps (correct, just
+            # without the fused speedup) so --kv-fused is safe on any model.
             if sinks is not None or (mask is not None and not isinstance(mask, str)):
-                raise RuntimeError(
-                    "fused KV decode+attend is incompatible with attention "
-                    "sinks or a non-causal/sliding-window mask; do not call "
-                    "enable_fused_attend() for this model."
-                )
+                k, v = cache.fused_fallback_fetch()
+                return orig(queries, k, v, cache=cache, scale=scale, mask=mask,
+                            sinks=sinks)
             return cache.fused_attend(queries, scale)
         return orig(queries, keys, values, cache=cache, scale=scale, mask=mask,
                     sinks=sinks)

--- a/serve.py
+++ b/serve.py
@@ -471,6 +471,7 @@ def _extract_kv_args(argv):
     parser.add_argument("--kv-v-bits", type=int, default=None)
     parser.add_argument("--kv-min-tokens", type=int, default=0)
     parser.add_argument("--kv-group-size", type=int, default=64)
+    parser.add_argument("--kv-fused", action="store_true")
     ns, remaining = parser.parse_known_args(argv)
 
     if ns.kv_bits is not None and (
@@ -488,7 +489,23 @@ def _extract_kv_args(argv):
         sys.exit(2)
 
     if ns.kv_bits is None and ns.kv_k_bits is None:
+        if ns.kv_fused:
+            sys.stderr.write(
+                "ERROR: --kv-fused requires KV quantization "
+                "(--kv-bits or --kv-k-bits/--kv-v-bits)\n"
+            )
+            sys.exit(2)
         return None, remaining
+
+    # The fused decode+attend kernel only engages on single-tier caches; a
+    # non-zero sink window keeps decode on the standard dequant path, so warn
+    # rather than silently do nothing.
+    if ns.kv_fused and ns.kv_min_tokens > 0:
+        sys.stderr.write(
+            "WARNING: --kv-fused has no effect with --kv-min-tokens > 0 "
+            "(the fp16 sink window forces the standard dequant path); "
+            "use --kv-min-tokens 0 to engage the fused kernel\n"
+        )
 
     kv_config = dict(
         tq_bits=ns.kv_bits,
@@ -496,6 +513,7 @@ def _extract_kv_args(argv):
         v_bits=ns.kv_v_bits,
         group_size=ns.kv_group_size,
         min_tokens_before_quant=ns.kv_min_tokens,
+        fused=ns.kv_fused,
     )
     return kv_config, remaining
 
@@ -669,13 +687,21 @@ def _patch_kv_cache(kv_config) -> None:
     import mlx_lm.server as _server_mod
     from turboquant_mlx.layers.polar_kv_cache import (
         convert_cache_to_turboquant,
+        enable_fused_attend,
     )
+
+    # `fused` is a serve-level toggle, not a convert_cache_to_turboquant kwarg.
+    kv_config = dict(kv_config)
+    fused = kv_config.pop("fused", False)
 
     _orig_make = _server_mod.make_prompt_cache
 
     def _tq_make_prompt_cache(model, *args, **kwargs):
         cache = _orig_make(model, *args, **kwargs)
-        return convert_cache_to_turboquant(cache, **kv_config)
+        cache = convert_cache_to_turboquant(cache, **kv_config)
+        if fused:
+            enable_fused_attend(cache)
+        return cache
 
     _server_mod.make_prompt_cache = _tq_make_prompt_cache
 
@@ -934,10 +960,18 @@ def main() -> None:
             desc = f"K=V={kv_config['tq_bits']}-bit"
         else:
             desc = f"K={kv_config['k_bits']}-bit, V={kv_config['v_bits']}-bit"
+        fused_note = ""
+        if kv_config.get("fused"):
+            fused_note = (
+                ", fused=on (decode+attend Metal kernel; falls back to dequant "
+                "on attention-sink/sliding-window layers)"
+                if kv_config["min_tokens_before_quant"] == 0
+                else ", fused=requested but INACTIVE (needs --kv-min-tokens 0)"
+            )
         sys.stderr.write(
             f"[turboquant-serve] TurboQuant KV cache: {desc}, "
             f"group={kv_config['group_size']}, "
-            f"sink={kv_config['min_tokens_before_quant']} "
+            f"sink={kv_config['min_tokens_before_quant']}{fused_note} "
             "(forces single-stream serving)\n"
         )
     if disk_cache_config is not None:

--- a/tests/test_fused_kv_attend.py
+++ b/tests/test_fused_kv_attend.py
@@ -143,16 +143,28 @@ def test_update_and_fetch_skips_dequant_when_fused():
     assert cache.offset == 17  # token was still stored
 
 
-def test_patch_fails_loud_on_sinks():
+def test_patch_falls_back_to_dequant_on_sinks():
+    """With sinks present, the seam must dequantize + call standard SDPA (the
+    kernel can't honor sinks) — correct output, not a crash."""
     install_fused_attend_patch()
     import mlx_lm.models.base as base
+    S, D = 64, 128
+    mx.random.seed(4)
     cache = TurboQuantKVCache(k_bits=8, v_bits=3, group_size=64,
-                             min_tokens_before_quant=0)
+                              min_tokens_before_quant=0)
     cache.update_and_fetch(
-        mx.random.normal((1, 4, 8, 128)).astype(mx.float16),
-        mx.random.normal((1, 4, 8, 128)).astype(mx.float16))
-    q = mx.random.normal((1, 4, 1, 128)).astype(mx.float16)
+        mx.random.normal((1, 4, S, D)).astype(mx.float16),
+        mx.random.normal((1, 4, S, D)).astype(mx.float16))
+    mx.eval(cache._tq_keys, cache._tq_values)
+    cache._use_fused_attend = True
+    q = mx.random.normal((1, 4, 1, D)).astype(mx.float16)
     sinks = mx.zeros((4,), dtype=mx.float16)
-    with pytest.raises(RuntimeError, match="attention sinks"):
-        base.scaled_dot_product_attention(q, None, None, cache=cache,
-                                          scale=1.0, mask=None, sinks=sinks)
+    scale = 1.0 / math.sqrt(D)
+
+    got = base.scaled_dot_product_attention(q, None, None, cache=cache,
+                                            scale=scale, mask=None, sinks=sinks)
+    # reference: same standard SDPA over the dequantized cache with sinks
+    k, v = cache.fused_fallback_fetch()
+    ref = mx.fast.scaled_dot_product_attention(q, k, v, scale=scale, sinks=sinks)
+    mx.eval(got, ref)
+    assert _cos(got, ref) > 0.99999

--- a/tests/test_serve_kv.py
+++ b/tests/test_serve_kv.py
@@ -91,6 +91,24 @@ def test_extract_rejects_bits_with_split():
         _extract_kv_args(["--kv-bits", "3", "--kv-k-bits", "8", "--kv-v-bits", "3"])
 
 
+def test_extract_kv_fused_flag():
+    kv, remaining = _extract_kv_args(
+        ["--model", "foo", "--kv-k-bits", "8", "--kv-v-bits", "3", "--kv-fused"]
+    )
+    assert kv["fused"] is True
+    assert remaining == ["--model", "foo"]  # flag peeled off
+
+
+def test_extract_kv_fused_defaults_off():
+    kv, _ = _extract_kv_args(["--kv-bits", "3"])
+    assert kv["fused"] is False
+
+
+def test_extract_kv_fused_without_quant_errors():
+    with pytest.raises(SystemExit):
+        _extract_kv_args(["--model", "foo", "--kv-fused"])
+
+
 def test_extract_rejects_unpaired_split():
     with pytest.raises(SystemExit):
         _extract_kv_args(["--kv-k-bits", "8"])


### PR DESCRIPTION
Follow-up to #61 — exposes the fused KV decode+attend kernel through `turboquant-serve`.

## What

```bash
turboquant-serve --model ./model-tq3 --kv-k-bits 8 --kv-v-bits 3 \
    --kv-min-tokens 0 --kv-fused
```

`--kv-fused` calls `enable_fused_attend` on each converted prompt-cache. It requires KV quantization and `--kv-min-tokens 0` (the fused kernel is single-tier — a non-zero sink window keeps decode on the standard dequant path, and the flag **warns** rather than silently doing nothing). The startup banner reports `fused=on` (or `INACTIVE` when a sink window is set).

## Safety change: fail-loud → graceful fallback

#61 shipped the kernel with a **fail-loud** guard on attention-sinks / sliding-window masks. A raised error mid-stream is bad UX for a server, so this PR upgrades it to a **graceful dequant fallback**: on a layer that needs sinks or a sliding-window mask, the SDPA seam reconstructs the dequantized cache (`TurboQuantKVCache.fused_fallback_fetch`) and calls standard SDPA for that step — correct output, just without the fused speedup. So `--kv-fused` is **safe to enable on any model**, including GPT-OSS (its full-attention-with-sinks layers transparently fall back; its sliding layers never convert). The guard was only in `[Unreleased]`, so no released behavior changes.

## Tests / verification

- `--kv-fused` arg parsing: on, default-off, and error when given without KV quant.
- Graceful-fallback parity: seam with `sinks` present matches `dequantize + SDPA(sinks=...)`.
- Full suite **337 pass**.
- End-to-end smoke: started the server with `--kv-fused`, confirmed the banner shows `fused=on` and a real `/v1/chat/completions` request returns a coherent completion through the fused path.

## Docs

README "Compress the KV cache while serving" flag table + the fused section (serve usage, graceful-fallback wording), CHANGELOG `[Unreleased]`.

Still deferred: `--kv-fused` is experimental and single-stream (inherits the existing KV-quant single-stream constraint).