### PR TITLE
chore: release 0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.16.0] - 2026-07-22
+
 ### Added
 
 - **`turboquant-serve --kv-fused`** — enable the fused KV decode+attend kernel on

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.15.1"
+__version__ = "0.16.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.15.1"
+version = "0.16.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Release **0.16.0** — the fused KV decode+attend kernel.

## Included since 0.15.1

- **Fused KV decode+attend Metal kernel** (#61) — reads the packed TurboQuant KV cache directly at decode and runs a FlashAttention-style online-softmax pass, skipping the fp16 dequantize. Numerically equivalent to the dequant path; 1.49× end-to-end decode on Llama-3.2-1B at 4.2K, byte-identical output. Opt-in via `layers.enable_fused_attend`.
- **`turboquant-serve --kv-fused`** (#62) — exposes the kernel on the server (needs KV-quant + `--kv-min-tokens 0`), with a graceful dequant fallback on attention-sink / sliding-window layers so it's safe on any model.

## Release mechanics

- Bump version 0.15.1 → 0.16.0 (`pyproject.toml`, `__init__.py`)
- Move CHANGELOG `[Unreleased]` → `[0.16.0]` (2026-07-22)

Full suite 337 pass. Merge, then push the `v0.16.0` tag to trigger `release.yml` (sdist build + PyPI publish via OIDC, gated on the manual `pypi` env approval).