### PR TITLE
feat: Poolside Laguna support (0.17.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-07-24
+
+### Added
+
+- **Poolside Laguna support** (`model_type: "laguna"`) — MLX port in
+  `models/laguna.py` (per-layer query-head counts, 3:1 full/sliding attention,
+  partial+YaRN RoPE on global layers, per-head softplus attention gate, QK-norm,
+  sigmoid router with selection-only correction bias, dense layer 0). Registered
+  through `compat.py` so `convert`/`generate`/`serve` resolve it. Logit parity
+  vs transformers CPU/fp32 is 2e-7. `Model.sanitize` handles both the on-disk
+  per-expert layout (`experts.{i}.gate_proj.weight`, singular `shared_expert`)
+  and the transformers in-memory packed layout.
+- **`turboquant-generate --stop`** — register an extra terminator for one run,
+  as a token string (`--stop '</assistant>'`) or id (`--stop 24`). Repeatable.
+
+### Fixed
+
+- **EOS ids declared in `generation_config.json` are now honored.** A tokenizer
+  exposes only its single `eos_token_id`, so models declaring several turn
+  terminators (Laguna ends a turn with `</assistant>` = 24, not `〈|EOS|〉` = 2)
+  lost all but the first: generation ran past the end of the turn and the model
+  answered the same question two or three more times, up to `--max-tokens`.
+  `load_turboquant` now unions the model's declared ids into the tokenizer, so
+  `generate`, `serve` (resident and streaming) and `evaluate` all stop correctly.
+- **GLM-style tool-call function names are stripped.** mlx-lm's `glm47` tool
+  parser (auto-selected for Laguna and GLM-4.7) captured the function name with
+  a trailing newline (`"list_dir\n"`), so agent harnesses failed to match the
+  tool and string arguments were wrongly deserialized. `compat.py` patches the
+  parser to strip the name (self-disables once upstream fixes it).
+
 ## [0.16.0] - 2026-07-22
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1176,6 +1176,48 @@ prompts, so this hybrid handles long-context retrieval (e.g. password-
 recall over 4000+ tokens of context) without the kernel argument-validation
 crash that affected earlier builds.
 
+### Poolside Laguna (33B MoE for agentic coding)
+
+[Laguna-XS.2](https://huggingface.co/poolside/Laguna-XS.2) is Poolside's 33B
+Mixture-of-Experts (256 experts, top-8, 3B active) built for **agentic coding
+and long-horizon work on a local machine**. It is a custom architecture —
+mixed sliding-window / global attention in a 3:1 ratio, per-head attention
+gating, QK-norm, partial+YaRN RoPE on the global layers, and a sigmoid router
+with a selection-only correction bias. `mlx-lm` has **no native `laguna`
+model**; the MLX port and loader ship here (registered via `compat.py`), with
+logit-parity of 2e-7 against the transformers reference.
+
+```bash
+# Convert bf16 -> TurboQuant 3-bit. bf16 (~67 GB) exceeds 64 GB RAM, so use --streaming.
+python -m turboquant_mlx.convert \
+    --hf-path poolside/Laguna-XS.2 \
+    --mlx-path ./laguna-xs2-tq3-g64 \
+    --bits 3 --group-size 64 --streaming
+
+# Generate. Laguna's generation_config ships top_p 1.0; ALWAYS pass --top-p 0.9
+# or the untruncated 100k-vocab tail injects rare junk tokens.
+python -m turboquant_mlx.generate \
+    --model ./laguna-xs2-tq3-g64 \
+    --prompt "Write a mergesort in Python." --temp 0.7 --top-p 0.9
+
+# Serve (agentic use). Do NOT pass --kv-bits: 30/40 layers are sliding-window(512)
+# so KV is already tiny (peak 16.8 GB @2K -> 19.4 GB @31K); KV-quant saves nothing
+# here and can cost up to ~4x decode.
+turboquant-serve --model ./laguna-xs2-tq3-g64 --port 8080 \
+    --temp 0.7 --top-p 0.9 --prompt-concurrency 1 \
+    --chat-template-args '{"enable_thinking": false}'
+```
+
+- **Runs on a 32 GB Mac** at 13.8 GB on disk / ~16 GB peak; MMLU-Redux 76.9 %,
+  GSM8K 79.0 % (3-bit, no-think), and passes the Opencode observe→read→edit→verify
+  loop.
+- **Tool calls are GLM-XML**, not Hermes-JSON; `mlx-lm`'s `glm47` parser is
+  auto-selected and patched here for a trailing-newline function-name bug.
+- **3-bit vs 4-bit**: this data-free codebook 3-bit build is 4 GB smaller than
+  MLX-native affine 4-bit but ~2× slower per token (codebook decode + online
+  Hadamard rotation, not bandwidth). Prefer it when memory-bound; prefer affine
+  4-bit for the fastest interactive loop.
+
 ---
 
 ## How It Works
@@ -1218,6 +1260,7 @@ Options:
 | Qwen3.5-MoE / Qwen3.6-35B-A3B | `qwen3_5_moe` | Yes (256 experts) | Tested (122B, 35B-A3B); 35B streams on a 16 GB Mac mini |
 | Qwen3-MoE | `qwen3_moe` | Yes (128 experts, top-8) | Tested — Qwen3-235B-A22B converted to a hybrid **tq3a-tq2e** build (70.5 GB) on a 16 GB Mac mini via `--streaming`; streams and passes 5/6 quality probes on a 64 GB Mac |
 | Nemotron-H (Mamba/attention hybrid) | `nemotron_h` | Yes (512 experts w/ latent MoE on Super-120B) | Tested (Nano-4B, Super-120B) — requires mlx-lm ≥ 0.31.3 |
+| Poolside Laguna (SWA + global attn, per-head gating) | `laguna` | Yes (256 experts, top-8) | Tested (XS.2 33B: convert + generate + Opencode agentic pass at 3-bit). Custom arch — MLX port + loader shipped here (mlx-lm has no native `laguna`); logit-parity 2e-7 vs transformers |
 | DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
 | DiffusionGemma (block-diffusion MoE, via **mlx-vlm**) | `diffusion_gemma` | Yes (128 experts, top-8) | Tested (26B-A4B: convert + block-diffusion sampler, coherent at 3-bit — [HF](https://huggingface.co/manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32)). **Experimental**: decode is much slower than native 4-bit until a batched codebook gather-GEMM kernel lands |
 

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.16.0"
+__version__ = "0.17.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/compat.py
+++ b/compat.py
@@ -83,4 +83,76 @@ def _patch_nemotron_h_pattern():
                 break
 
 
+def _register_laguna_model():
+    """Register the MLX Laguna model so mlx-lm's ``_get_classes`` can find it.
+
+    mlx-lm dispatches a checkpoint's ``model_type`` via
+    ``importlib.import_module(f"mlx_lm.models.{model_type}")``. Poolside's Laguna
+    architecture has no upstream mlx-lm module yet, so we alias our
+    implementation into ``sys.modules`` under that name — ``importlib`` consults
+    ``sys.modules`` first, so this makes ``load_turboquant`` (and plain mlx-lm)
+    resolve ``laguna`` to our ``Model`` / ``ModelArgs``. Idempotent, and
+    self-disables the moment mlx-lm ships native Laguna support.
+    """
+    import sys
+
+    if "mlx_lm.models.laguna" in sys.modules:
+        return
+    try:
+        import mlx_lm.models.laguna  # noqa: F401 — native support exists; defer
+        return
+    except ImportError:
+        pass
+
+    from turboquant_mlx.models import laguna as _laguna
+
+    sys.modules["mlx_lm.models.laguna"] = _laguna
+
+
+def _patch_glm47_tool_name_strip():
+    """Strip whitespace off GLM-style parsed tool-call function names.
+
+    mlx-lm's glm47 parser (also selected for Laguna, whose template is
+    ``laguna_glm_thinking_v5``) pulls the name with
+    ``re.compile(r"^(.*?)<arg_key>", re.DOTALL)`` and does not strip it. The
+    wire format puts the name on its own line::
+
+        <tool_call>list_dir
+        <arg_key>path</arg_key><arg_value>/tmp</arg_value>
+        </tool_call>
+
+    so the name comes back as ``"list_dir\\n"``. Two things break: agent
+    harnesses fail to match the tool by name, and the untrimmed name misses in
+    ``_get_string_arg_names``, so string arguments get run through
+    ``_deserialize`` and a value like ``"2024"`` silently becomes an int.
+
+    Self-disables once upstream strips the name itself.
+    """
+    try:
+        from mlx_lm.tool_parsers import glm47
+    except ImportError:
+        return
+
+    if getattr(glm47, "_tq_name_strip_patched", False):
+        return
+
+    orig = glm47.parse_tool_call
+
+    def parse_tool_call(text, tools=None):
+        result = orig(text, tools)
+        name = result.get("name")
+        if isinstance(name, str) and name != name.strip():
+            stripped = name.strip()
+            # re-resolve arguments with the correct name so string args that
+            # were wrongly deserialized come back as strings
+            result = orig(text.replace(name, stripped, 1), tools)
+            result["name"] = stripped
+        return result
+
+    glm47.parse_tool_call = parse_tool_call
+    glm47._tq_name_strip_patched = True
+
+
 _patch_nemotron_h_pattern()
+_register_laguna_model()
+_patch_glm47_tool_name_strip()

--- a/generate.py
+++ b/generate.py
@@ -199,6 +199,19 @@ def load_turboquant(model_path, lazy=False, fast=False):
     # Load tokenizer
     tokenizer = load_tokenizer(model_path)
 
+    # A tokenizer exposes only its single eos_token_id, but a model may declare
+    # several turn terminators in generation_config.json (Laguna ends a turn
+    # with </assistant>, not 〈|EOS|〉). Without this the model runs past the end
+    # of its turn and answers again.
+    from .sampling import apply_generation_config_eos
+
+    added = apply_generation_config_eos(tokenizer, model_path)
+    if added:
+        names = ", ".join(
+            f"{tid} ({tokenizer.decode([tid])!r})" for tid in sorted(added)
+        )
+        print(f"[INFO] Added EOS from generation_config.json: {names}")
+
     return model, tokenizer
 
 
@@ -256,6 +269,13 @@ def main():
              "prevents low-bit thinking models from re-emitting their answer.",
     )
     parser.add_argument(
+        "--stop", action="append", metavar="TOKEN", default=None,
+        help="Extra stop token to terminate generation on, as a token string "
+             "('</assistant>') or a token id ('24'). Repeatable. The model's "
+             "generation_config.json terminators are applied automatically; "
+             "use this only for one-off overrides. Must be a single token.",
+    )
+    parser.add_argument(
         "--rep-ctx", type=int, default=256,
         help="Repetition penalty context window in tokens (default: 256). "
              "Only used when --rep-penalty is set.",
@@ -306,6 +326,17 @@ def main():
     mode = "fast (QJL disabled)" if args.fast else "accurate (QJL enabled)"
     print(f"[INFO] Loading TurboQuant model from {args.model} [{mode}]")
     model, tokenizer = load_turboquant(args.model, fast=args.fast)
+
+    if args.stop:
+        from .sampling import resolve_stop_token
+
+        for tok in args.stop:
+            try:
+                tid = resolve_stop_token(tokenizer, tok)
+            except ValueError as e:
+                parser.error(f"--stop {e}")
+            tokenizer.add_eos_token(str(tid))
+            print(f"[INFO] Stop token: {tid} ({tokenizer.decode([tid])!r})")
 
     # Apply chat template if available
     prompt = args.prompt

--- a/models/__init__.py
+++ b/models/__init__.py
@@ -1,0 +1,2 @@
+# Copyright 2026 Manjunath Janardhan
+"""MLX model definitions for architectures not yet in mlx-lm (e.g. Laguna)."""

--- a/models/laguna.py
+++ b/models/laguna.py
@@ -27,18 +27,14 @@ also handles the transformers in-memory packed ``experts.gate_up_proj`` layout t
 logit-parity harness feeds it).
 """
 
-import math
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List
 
 import mlx.core as mx
 import mlx.nn as nn
 
-from mlx_lm.models.base import (
-    BaseModelArgs,
-    create_attention_mask,
-    scaled_dot_product_attention,
-)
+import mlx_lm.models.base as base
+from mlx_lm.models.base import BaseModelArgs, create_attention_mask
 from mlx_lm.models.cache import KVCache, RotatingKVCache
 from mlx_lm.models.rope_utils import YarnRoPE
 from mlx_lm.models.switch_layers import SwitchGLU
@@ -149,7 +145,7 @@ class Attention(nn.Module):
         if cache is not None:
             k, v = cache.update_and_fetch(k, v)
 
-        out = scaled_dot_product_attention(
+        out = base.scaled_dot_product_attention(
             q, k, v, cache=cache, scale=self.scale, mask=mask
         )
         out = out.transpose(0, 2, 1, 3)  # (B, L, H, D)

--- a/models/laguna.py
+++ b/models/laguna.py
@@ -1,0 +1,389 @@
+# Copyright 2026 Manjunath Janardhan
+"""MLX implementation of Poolside's Laguna architecture (``model_type: "laguna"``).
+
+Ported from the ``transformers`` ``LagunaForCausalLM`` reference. The architecture
+spans several non-standard pieces that this module reproduces faithfully so the
+weights load bit-for-bit and the forward pass matches HF logits:
+
+* **Hybrid attention** — a 3:1 schedule of sliding-window (512) and full-attention
+  layers (``layer_types``), with a **per-layer query-head count**
+  (``num_attention_heads_per_layer``: 48 on global, 64 on sliding) over a fixed
+  GQA KV-head count.
+* **Partial + YaRN RoPE** — global layers rotate the first ``head_dim * 0.5`` dims
+  with YaRN scaling (``factor`` 64, ``attention_factor`` folded into ``mscale``);
+  sliding layers rotate the full head with plain ``theta`` 10000.
+* **QK-norm** — per-head RMSNorm on queries and keys before RoPE.
+* **Per-head softplus attention gate** — ``g_proj: hidden -> num_heads`` produces a
+  scalar gate per head, ``softplus``-activated, multiplied into the attention output.
+* **Sigmoid-router MoE with a shared expert** — a leading dense MLP layer
+  (``mlp_layer_types[0] == "dense"``) then MoE blocks: sigmoid routing scores,
+  ``e_score_correction_bias`` added for selection only, top-k weights renormalized
+  to sum 1, scaled by ``moe_routed_scaling_factor`` (2.5), plus an always-on shared
+  expert.
+
+The real checkpoint stores experts *per expert* (``experts.7.gate_proj.weight``);
+:meth:`Model.sanitize` stacks them into ``SwitchGLU``'s ``(E, out, in)`` form (and
+also handles the transformers in-memory packed ``experts.gate_up_proj`` layout the
+logit-parity harness feeds it).
+"""
+
+import math
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import KVCache, RotatingKVCache
+from mlx_lm.models.rope_utils import YarnRoPE
+from mlx_lm.models.switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    num_experts: int
+    num_experts_per_tok: int
+    moe_intermediate_size: int
+    shared_expert_intermediate_size: int
+    moe_routed_scaling_factor: float
+    layer_types: List[str]
+    mlp_layer_types: List[str]
+    num_attention_heads_per_layer: List[int]
+    rope_parameters: Dict[str, Any]
+    sliding_window: int
+    max_position_embeddings: int = 262144
+    moe_router_logit_softcapping: float = 0.0
+    tie_word_embeddings: bool = False
+    attention_bias: bool = False
+
+
+def _make_rope(head_dim: int, layer_type: str, rope_parameters: Dict[str, Any],
+               max_pos: int):
+    """Build the RoPE module for a layer type from Laguna's nested rope config."""
+    params = rope_parameters[layer_type]
+    partial = params.get("partial_rotary_factor", 1.0)
+    dims = int(head_dim * partial)
+    base = params.get("rope_theta", 10000.0)
+    rope_type = params.get("rope_type", "default")
+
+    if rope_type == "yarn":
+        # mlx-lm's YarnRoPE reproduces HF YaRN exactly: its period-space freq blend
+        # is algebraically identical to HF's inv_freq blend, and its
+        # mscale = 0.1*ln(factor)+1 equals Laguna's attention_factor (RoPE is linear,
+        # so scaling x vs. cos/sin is equivalent).
+        return YarnRoPE(
+            dims=dims,
+            traditional=False,
+            max_position_embeddings=max_pos,
+            base=base,
+            scaling_factor=params["factor"],
+            original_max_position_embeddings=params.get(
+                "original_max_position_embeddings", 4096
+            ),
+            beta_fast=params.get("beta_fast", 32),
+            beta_slow=params.get("beta_slow", 1),
+        )
+    # plain RoPE (non-interleaved), full or partial dims
+    return nn.RoPE(dims, traditional=False, base=base)
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs, num_heads: int, layer_type: str):
+        super().__init__()
+        self.num_heads = num_heads
+        self.num_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        self.is_sliding = layer_type == "sliding_attention"
+
+        bias = args.attention_bias
+        self.q_proj = nn.Linear(args.hidden_size, num_heads * self.head_dim, bias=bias)
+        self.k_proj = nn.Linear(
+            args.hidden_size, self.num_kv_heads * self.head_dim, bias=bias
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size, self.num_kv_heads * self.head_dim, bias=bias
+        )
+        self.o_proj = nn.Linear(num_heads * self.head_dim, args.hidden_size, bias=bias)
+
+        self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        # per-head scalar attention gate
+        self.g_proj = nn.Linear(args.hidden_size, num_heads, bias=False)
+
+        self.rope = _make_rope(
+            self.head_dim, layer_type, args.rope_parameters,
+            args.max_position_embeddings,
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        B, L, _ = x.shape
+
+        q = self.q_proj(x).reshape(B, L, self.num_heads, self.head_dim)
+        k = self.k_proj(x).reshape(B, L, self.num_kv_heads, self.head_dim)
+        v = self.v_proj(x).reshape(B, L, self.num_kv_heads, self.head_dim)
+
+        # QK-norm over head_dim, then to (B, H, L, D)
+        q = self.q_norm(q).transpose(0, 2, 1, 3)
+        k = self.k_norm(k).transpose(0, 2, 1, 3)
+        v = v.transpose(0, 2, 1, 3)
+
+        offset = cache.offset if cache is not None else 0
+        q = self.rope(q, offset=offset)
+        k = self.rope(k, offset=offset)
+
+        if cache is not None:
+            k, v = cache.update_and_fetch(k, v)
+
+        out = scaled_dot_product_attention(
+            q, k, v, cache=cache, scale=self.scale, mask=mask
+        )
+        out = out.transpose(0, 2, 1, 3)  # (B, L, H, D)
+
+        # per-head softplus gate (computed in fp32 like HF)
+        g = self.g_proj(x).astype(mx.float32)  # (B, L, H)
+        gate = mx.logaddexp(mx.array(0.0, dtype=mx.float32), g).astype(out.dtype)
+        out = out * gate[..., None]
+
+        out = out.reshape(B, L, -1)
+        return self.o_proj(out)
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class LagunaRouter(nn.Module):
+    """MoE router. Named to match the HF ``mlp.gate`` weight + correction bias."""
+
+    def __init__(self, hidden_size: int, num_experts: int):
+        super().__init__()
+        self.weight = mx.zeros((num_experts, hidden_size))
+        self.e_score_correction_bias = mx.zeros((num_experts,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight.T
+
+
+class LagunaMoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.route_scale = args.moe_routed_scaling_factor
+        self.softcap = args.moe_router_logit_softcapping
+
+        self.gate = LagunaRouter(args.hidden_size, args.num_experts)
+        self.experts = SwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.num_experts
+        )
+        self.shared_experts = MLP(
+            args.hidden_size, args.shared_expert_intermediate_size
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        logits = self.gate(x).astype(mx.float32)
+        if self.softcap > 0.0:
+            logits = mx.tanh(logits / self.softcap) * self.softcap
+        scores = mx.sigmoid(logits)
+
+        # correction bias affects selection only, not the combine weights
+        selection = scores + self.gate.e_score_correction_bias.astype(mx.float32)
+        k = self.top_k
+        inds = mx.argpartition(-selection, kth=k - 1, axis=-1)[..., :k]
+
+        weights = mx.take_along_axis(scores, inds, axis=-1)
+        weights = weights / weights.sum(axis=-1, keepdims=True)
+        weights = (weights * self.route_scale).astype(x.dtype)
+
+        y = self.experts(x, inds)
+        y = (y * weights[..., None]).sum(axis=-2).astype(x.dtype)
+        return y + self.shared_experts(x)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        num_heads = args.num_attention_heads_per_layer[layer_idx]
+        layer_type = args.layer_types[layer_idx]
+        self.is_sliding = layer_type == "sliding_attention"
+
+        self.self_attn = Attention(args, num_heads, layer_type)
+        if args.mlp_layer_types[layer_idx] == "sparse":
+            self.mlp = LagunaMoE(args)
+        else:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class LagunaModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.layer_types = args.layer_types
+        self.sliding_window = args.sliding_window
+
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            DecoderLayer(args, i) for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+        # representative layer index per attention type, for mask construction
+        self._full_idx = self.layer_types.index("full_attention")
+        self._swa_idx = next(
+            (i for i, t in enumerate(self.layer_types) if t == "sliding_attention"),
+            None,
+        )
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        full_mask = create_attention_mask(h, cache[self._full_idx])
+        swa_mask = full_mask
+        if self._swa_idx is not None:
+            swa_mask = create_attention_mask(
+                h, cache[self._swa_idx], window_size=self.sliding_window
+            )
+
+        for layer, c in zip(self.layers, cache):
+            mask = swa_mask if layer.is_sliding else full_mask
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = LagunaModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(
+                args.hidden_size, args.vocab_size, bias=False
+            )
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        out = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Map on-disk / HF weight names onto this module's parameter names.
+
+        Two expert layouts are normalized to ``SwitchGLU``'s stacked
+        ``experts.{gate,up,down}_proj.weight`` (E, out, in):
+
+        * **On-disk (real checkpoint):** experts are stored *per expert*, e.g.
+          ``mlp.experts.7.gate_proj.weight`` (2D). These are stacked in expert
+          order along a new leading axis.
+        * **transformers in-memory:** experts come packed as
+          ``mlp.experts.gate_up_proj`` (E, 2*inter, hidden) + ``experts.down_proj``
+          (E, hidden, inter); split/relabel these. (Kept so the logit-parity
+          harness, which copies the HF ``state_dict``, still loads.)
+
+        Also relocates the router correction bias (on disk it sits under
+        ``mlp.experts``; our router owns it at ``mlp.gate``) and the singular
+        ``mlp.shared_expert`` -> our ``mlp.shared_experts``.
+        """
+        import re
+
+        inter = self.args.moe_intermediate_size
+        # collect per-expert tensors: prefix "...mlp.experts" -> proj -> {idx: w}
+        per_expert: Dict[str, Dict[str, Dict[int, mx.array]]] = {}
+        expert_re = re.compile(r"^(.*\.mlp\.experts)\.(\d+)\.(gate|up|down)_proj\.weight$")
+
+        new: Dict[str, mx.array] = {}
+        for k, v in weights.items():
+            if "rotary_emb.inv_freq" in k:
+                continue
+
+            m = expert_re.match(k)
+            if m is not None:
+                prefix, idx, proj = m.group(1), int(m.group(2)), m.group(3)
+                per_expert.setdefault(prefix, {}).setdefault(proj, {})[idx] = v
+                continue
+
+            if ".mlp.experts.e_score_correction_bias" in k:
+                # router owns the correction bias in our module (mlp.gate)
+                new[k.replace(".mlp.experts.e_score_correction_bias",
+                              ".mlp.gate.e_score_correction_bias")] = v
+                continue
+
+            if ".mlp.shared_expert." in k:
+                new[k.replace(".mlp.shared_expert.", ".mlp.shared_experts.")] = v
+                continue
+
+            if k.endswith("mlp.experts.gate_up_proj"):
+                # transformers in-memory: (E, 2*inter, hidden) -> split
+                base = k[: -len("gate_up_proj")]
+                new[base + "gate_proj.weight"] = v[:, :inter, :]
+                new[base + "up_proj.weight"] = v[:, inter:, :]
+            elif k.endswith("mlp.experts.down_proj"):
+                # transformers in-memory: (E, hidden, inter) already (out, in)
+                new[k + ".weight"] = v
+            else:
+                new[k] = v
+
+        # stack per-expert 2D weights -> (E, out, in) for SwitchGLU
+        for prefix, projs in per_expert.items():
+            for proj, by_idx in projs.items():
+                stacked = mx.stack([by_idx[i] for i in range(len(by_idx))], axis=0)
+                new[f"{prefix}.{proj}_proj.weight"] = stacked
+
+        if self.args.tie_word_embeddings:
+            new.pop("lm_head.weight", None)
+        return new
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    def make_cache(self):
+        return [
+            RotatingKVCache(max_size=self.args.sliding_window)
+            if layer.is_sliding
+            else KVCache()
+            for layer in self.model.layers
+        ]
+
+    @property
+    def cast_predicate(self):
+        # keep the router correction bias out of low-precision casts
+        def predicate(k):
+            return "e_score_correction_bias" not in k
+
+        return predicate

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.16.0"
+version = "0.17.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/sampling.py
+++ b/sampling.py
@@ -1,5 +1,6 @@
 """Sampling helpers for TurboQuant-MLX."""
 
+from pathlib import Path
 from typing import Callable, Iterable, Optional
 
 import mlx.core as mx
@@ -104,3 +105,61 @@ def eos_token_ids(tokenizer) -> set:
         return set(ids)
     primary = getattr(tokenizer, "eos_token_id", None)
     return {primary} if primary is not None else set()
+
+
+def resolve_stop_token(tokenizer, token: str) -> int:
+    """Resolve a user-supplied stop token to a single token id.
+
+    Accepts an id (``"24"``) or a token string (``"</assistant>"``). Raises
+    ValueError for anything that is not exactly one token.
+
+    ``TokenizerWrapper.add_eos_token`` cannot be trusted to validate this: it
+    falls back to ``convert_tokens_to_ids``, which returns the **UNK id** for
+    unknown text rather than None, so a typo would silently make UNK terminal
+    and truncate generation at the first unknown token.
+    """
+    if token.lstrip("-").isdigit():
+        return int(token)
+
+    ids = tokenizer.encode(token, add_special_tokens=False)
+    if len(ids) != 1:
+        raise ValueError(
+            f"{token!r} is {len(ids)} tokens for this tokenizer; only "
+            "single-token stops are supported"
+        )
+    unk = getattr(tokenizer, "unk_token_id", None)
+    if unk is not None and ids[0] == unk and token != getattr(tokenizer, "unk_token", None):
+        raise ValueError(f"{token!r} is not a token for this tokenizer")
+    return ids[0]
+
+
+def apply_generation_config_eos(tokenizer, model_path) -> set:
+    """Union the model's ``generation_config.json`` EOS ids into ``tokenizer``.
+
+    A tokenizer only ever exposes its *single* ``eos_token_id``, but a model may
+    declare several terminators in ``generation_config.json`` — e.g. Laguna ends
+    an assistant turn with ``</assistant>`` (24) and only uses ``〈|EOS|〉`` (2)
+    at document level. Without this, generation runs straight past the end of
+    the turn and the model answers again.
+
+    Returns the ids that were added (empty when there was nothing new).
+    """
+    import json
+
+    cfg_file = Path(model_path) / "generation_config.json"
+    if not cfg_file.exists():
+        return set()
+    try:
+        raw = json.loads(cfg_file.read_text()).get("eos_token_id")
+    except (json.JSONDecodeError, OSError):
+        return set()
+    if raw is None:
+        return set()
+
+    wanted = {raw} if isinstance(raw, int) else set(raw)
+    added = wanted - eos_token_ids(tokenizer)
+    for tid in added:
+        # add_eos_token accepts an id as a string; it is the only public hook
+        # TokenizerWrapper gives us for extending the terminator set.
+        tokenizer.add_eos_token(str(tid))
+    return added

--- a/tests/test_generation_config_eos.py
+++ b/tests/test_generation_config_eos.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Manjunath Janardhan
+"""Regression tests for generation_config.json EOS resolution.
+
+A tokenizer only ever exposes a single ``eos_token_id``, so models that declare
+several turn terminators in ``generation_config.json`` used to lose all but the
+first. Laguna is the motivating case: it ends an assistant turn with
+``</assistant>`` (24) and reserves ``〈|EOS|〉`` (2) for document level, so
+generation ran past the end of the turn and answered again.
+"""
+import json
+
+import pytest
+
+from turboquant_mlx.sampling import (
+    apply_generation_config_eos,
+    eos_token_ids,
+    resolve_stop_token,
+)
+
+
+class StubTokenizer:
+    """Minimal stand-in for mlx-lm's TokenizerWrapper eos surface."""
+
+    def __init__(self, ids):
+        self.eos_token_ids = set(ids)
+
+    def add_eos_token(self, token: str):
+        # mirrors TokenizerWrapper: an id may be passed as a string
+        self.eos_token_ids.add(int(token))
+
+
+def _write(tmp_path, payload):
+    (tmp_path / "generation_config.json").write_text(json.dumps(payload))
+    return tmp_path
+
+
+def test_adds_missing_terminator(tmp_path):
+    tok = StubTokenizer({2})
+    added = apply_generation_config_eos(tok, _write(tmp_path, {"eos_token_id": [2, 24]}))
+    assert added == {24}
+    assert eos_token_ids(tok) == {2, 24}
+
+
+def test_scalar_eos_token_id(tmp_path):
+    tok = StubTokenizer({2})
+    added = apply_generation_config_eos(tok, _write(tmp_path, {"eos_token_id": 7}))
+    assert added == {7}
+    assert eos_token_ids(tok) == {2, 7}
+
+
+def test_noop_when_already_present(tmp_path):
+    tok = StubTokenizer({2, 24})
+    assert apply_generation_config_eos(tok, _write(tmp_path, {"eos_token_id": [2, 24]})) == set()
+    assert eos_token_ids(tok) == {2, 24}
+
+
+@pytest.mark.parametrize("payload", [{}, {"eos_token_id": None}])
+def test_no_eos_declared(tmp_path, payload):
+    tok = StubTokenizer({2})
+    assert apply_generation_config_eos(tok, _write(tmp_path, payload)) == set()
+    assert eos_token_ids(tok) == {2}
+
+
+def test_missing_file_is_not_an_error(tmp_path):
+    tok = StubTokenizer({2})
+    assert apply_generation_config_eos(tok, tmp_path) == set()
+    assert eos_token_ids(tok) == {2}
+
+
+def test_malformed_json_is_not_an_error(tmp_path):
+    (tmp_path / "generation_config.json").write_text("{not json")
+    tok = StubTokenizer({2})
+    assert apply_generation_config_eos(tok, tmp_path) == set()
+    assert eos_token_ids(tok) == {2}
+
+
+class StubVocab:
+    """Tokenizer whose encode() maps unknown text to the UNK id, like HF."""
+
+    unk_token_id = 0
+    unk_token = "<unk>"
+    _vocab = {"</assistant>": 24, "</think>": 19, "<unk>": 0}
+
+    def encode(self, text, add_special_tokens=False):
+        if text in self._vocab:
+            return [self._vocab[text]]
+        # unknown text splits into one UNK per word, as a real BPE would not,
+        # but single unknown words must still resolve to UNK
+        return [self.unk_token_id] * max(1, len(text.split()))
+
+
+def test_resolve_stop_token_by_id():
+    assert resolve_stop_token(StubVocab(), "24") == 24
+
+
+def test_resolve_stop_token_by_string():
+    assert resolve_stop_token(StubVocab(), "</assistant>") == 24
+
+
+def test_resolve_stop_token_rejects_multi_token():
+    with pytest.raises(ValueError, match="tokens for this tokenizer"):
+        resolve_stop_token(StubVocab(), "not a real token at all")
+
+
+def test_resolve_stop_token_rejects_unk():
+    """A typo must not silently make UNK terminal (add_eos_token would)."""
+    with pytest.raises(ValueError, match="not a token"):
+        resolve_stop_token(StubVocab(), "</assistan>")
+
+
+def test_resolve_stop_token_allows_explicit_unk():
+    assert resolve_stop_token(StubVocab(), "<unk>") == 0

--- a/tests/test_laguna.py
+++ b/tests/test_laguna.py
@@ -9,9 +9,7 @@ builds and runs on the real XS.2 layer schedule (mixed dense/MoE, mixed
 full/sliding attention, per-layer head counts).
 """
 import mlx.core as mx
-import pytest
 
-import turboquant_mlx.compat  # noqa: F401 — registers the laguna dispatch on import
 from turboquant_mlx.models.laguna import Model, ModelArgs
 
 
@@ -59,6 +57,7 @@ def _tiny_config():
 
 def test_get_classes_resolves_laguna():
     """Importing compat aliases our module so mlx-lm dispatch finds it."""
+    import turboquant_mlx.compat  # noqa: F401 — registers the laguna dispatch
     from mlx_lm.utils import _get_classes
 
     model_cls, args_cls = _get_classes({"model_type": "laguna"})

--- a/tests/test_laguna.py
+++ b/tests/test_laguna.py
@@ -1,0 +1,112 @@
+# Copyright 2026 Manjunath Janardhan
+"""Laguna MLX model: loader-dispatch registration + a forward smoke test.
+
+The numerical logit-parity check against the transformers HF reference lives in
+``scripts/laguna_parity.py`` (it needs torch); these tests are torch-free so they
+run in CI. They cover the two things the port must guarantee to be loadable:
+``_get_classes`` resolves ``model_type: "laguna"`` to our module, and the model
+builds and runs on the real XS.2 layer schedule (mixed dense/MoE, mixed
+full/sliding attention, per-layer head counts).
+"""
+import mlx.core as mx
+import pytest
+
+import turboquant_mlx.compat  # noqa: F401 — registers the laguna dispatch on import
+from turboquant_mlx.models.laguna import Model, ModelArgs
+
+
+def _tiny_config():
+    """Small config that still spans both attention + both MLP layer types."""
+    return dict(
+        model_type="laguna",
+        vocab_size=128,
+        hidden_size=64,
+        intermediate_size=48,
+        num_hidden_layers=4,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=16,
+        rms_norm_eps=1e-6,
+        num_experts=8,
+        num_experts_per_tok=2,
+        moe_intermediate_size=32,
+        shared_expert_intermediate_size=32,
+        moe_routed_scaling_factor=2.5,
+        moe_router_logit_softcapping=0.0,
+        sliding_window=4,
+        max_position_embeddings=262144,
+        tie_word_embeddings=False,
+        attention_bias=False,
+        layer_types=[
+            "full_attention", "sliding_attention",
+            "sliding_attention", "full_attention",
+        ],
+        mlp_layer_types=["dense", "sparse", "sparse", "sparse"],
+        num_attention_heads_per_layer=[4, 6, 6, 4],
+        rope_parameters={
+            "full_attention": {
+                "rope_type": "yarn", "rope_theta": 500000.0, "factor": 64.0,
+                "original_max_position_embeddings": 4096,
+                "beta_fast": 64.0, "beta_slow": 1.0, "partial_rotary_factor": 0.5,
+            },
+            "sliding_attention": {
+                "rope_type": "default", "rope_theta": 10000.0,
+                "partial_rotary_factor": 1.0,
+            },
+        },
+    )
+
+
+def test_get_classes_resolves_laguna():
+    """Importing compat aliases our module so mlx-lm dispatch finds it."""
+    from mlx_lm.utils import _get_classes
+
+    model_cls, args_cls = _get_classes({"model_type": "laguna"})
+    assert model_cls is Model
+    assert args_cls is ModelArgs
+
+
+def test_forward_smoke():
+    args = ModelArgs.from_dict(_tiny_config())
+    model = Model(args)
+    mx.eval(model.parameters())
+
+    ids = mx.array([[7, 13, 42, 5, 88, 61]])  # L=6 > sliding_window=4
+    out = model(ids)
+    mx.eval(out)
+
+    assert out.shape == (1, 6, args.vocab_size)
+    assert bool(mx.all(mx.isfinite(out)))
+
+
+def test_make_cache_matches_layer_types():
+    from mlx_lm.models.cache import KVCache, RotatingKVCache
+
+    args = ModelArgs.from_dict(_tiny_config())
+    model = Model(args)
+    caches = model.make_cache()
+
+    assert len(caches) == args.num_hidden_layers
+    # full_attention -> KVCache, sliding_attention -> RotatingKVCache
+    kinds = [type(c) for c in caches]
+    assert kinds[0] is KVCache and kinds[3] is KVCache
+    assert kinds[1] is RotatingKVCache and kinds[2] is RotatingKVCache
+
+
+def test_decode_step_with_cache():
+    """A prefill + single decode step runs through the cache path."""
+    args = ModelArgs.from_dict(_tiny_config())
+    model = Model(args)
+    mx.eval(model.parameters())
+    cache = model.make_cache()
+
+    prompt = mx.array([[7, 13, 42, 5, 88]])
+    logits = model(prompt, cache=cache)
+    mx.eval(logits)
+    assert logits.shape == (1, 5, args.vocab_size)
+
+    nxt = mx.array([[61]])
+    step = model(nxt, cache=cache)
+    mx.eval(step)
+    assert step.shape == (1, 1, args.vocab_size)
+    assert bool(mx.all(mx.isfinite(step)))


### PR DESCRIPTION
## Summary

Adds MLX support for Poolside's **Laguna** MoE (`model_type: "laguna"`), a custom architecture with no native mlx-lm model. Validated on **Laguna-XS.2** (33B, 256 experts, top-8) at 3-bit.

- **`models/laguna.py`** — the MLX port: mixed sliding-window / global attention (3:1), per-head attention gating, QK-norm, partial+YaRN RoPE on global layers, sigmoid router with selection-only correction bias, dense layer 0. `sanitize` handles both the on-disk per-expert layout and the transformers in-memory packed layout.
- **`compat.py`** — registers `laguna` so `convert`/`generate`/`serve` resolve it (self-disables if mlx-lm ships native support).
- Logit-parity **2e-7** vs the transformers CPU/fp32 reference.

Also fixes two issues Laguna surfaced that affect **any** such model:

- **`generation_config.json` EOS ids are now honored.** A tokenizer exposes only its single `eos_token_id`, so a model declaring several terminators (Laguna ends a turn with `</assistant>`=24, not the document EOS=2) lost all but the first and ran past the end of the turn. `load_turboquant` now unions the declared ids into the tokenizer, covering `generate` / `serve` / `evaluate`. Adds `turboquant-generate --stop` for per-run terminators.
- **GLM-style tool-call function names are stripped.** mlx-lm's `glm47` parser (auto-selected for Laguna and GLM-4.7) captured the name with a trailing newline (`"list_dir\n"`), breaking harness tool matching and string-arg parsing. `compat.py` patches it (self-disables once upstream fixes it).

## Validation (Laguna-XS.2, 3-bit)

- Convert (`--streaming`) + generate + Opencode agentic pass (run tests → fix bug → re-run).
- **MMLU-Redux 76.9%**, **GSM8K 79.0%** (no-think).
- 6/6 internal stress battery (essay / math / code / needle / format / repetition).

## Test plan

- `pytest -q` → **353 passed**.
- New tests are torch-free (no weights needed): `tests/test_laguna.py` (dispatch, forward smoke, cache, decode) and `tests/test_generation_config_eos.py` (eos union + `--stop` validation).

## Release

Bumps version to **0.17.0** (`pyproject.toml`, `__init__.py`, CHANGELOG). After merge, push `v0.17.0` to publish to PyPI.