### PR TITLE
fix: Laguna expert streaming — recognise mlp.experts across the swap, planner, cache budget, and repack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   unaffected). The rule now lives in one place, `expert_naming.py`, imported by
   both. `experts` matches only anchored as `.mlp.experts.`, so the dense
   always-on `shared_experts` MLP stays resident as it must.
+- **`stream/repack_experts.py` no longer corrupts routing on a Laguna
+  checkpoint.** Its expert-stack branch matched the container by `switch_mlp`
+  while the router branch matched `mlp.gate.*` unconditionally, so on Laguna it
+  permuted the router rows and left the expert stacks in place — for all 47 MoE
+  layers. The tool's correctness argument is that the two move *together*
+  (a relabeling); permuting one alone is a rerouting. The output loaded cleanly
+  and passed every shape assertion, so the damage was silent.
+- **`stream/calibrate_experts.py` sizes the hot-expert pin list correctly on
+  Laguna.** `_model_expert_info` returned 0 bytes/expert, so the
+  `used + cost > cap` budget check never fired and *every* expert was written
+  to `hot_experts.json` claiming ~0 GB — which the streaming loader then tries
+  to pin into a wired cache sized for a fraction of it.
 
 ## [0.17.0] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Laguna's experts are recognised as streamable by the planner and the cache
+  budget.** The module swap already handled both container names
+  (`switch_mlp` and mlx-lm's `SwitchGLU` at `experts`), but the two places that
+  *count* expert bytes — `plan.py:footprint` and
+  `stream/loader.py:_streamed_expert_bytes` — still matched `switch_mlp` alone.
+  Laguna therefore streamed correctly while reporting **zero** streamable bytes:
+  `turboquant-plan` called a streamable model resident-only and printed
+  "❌ WILL NOT RUN" for a 16 GB Mac that in fact runs Laguna-S-2.1 at a 7.3 GB
+  peak, and `--cache-budget-gb auto` sized its cache from a resident figure that
+  wrongly included all 26.4 GB of experts (explicit `--cache-budget-gb` was
+  unaffected). The rule now lives in one place, `expert_naming.py`, imported by
+  both. `experts` matches only anchored as `.mlp.experts.`, so the dense
+  always-on `shared_experts` MLP stays resident as it must.
+
 ## [0.17.0] - 2026-07-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, 
 | Nemotron-3-Super-120B-A12B | BF16 (original) | 16 | — | ~240 GB | *Doesn't fit 64GB* |
 | **Nemotron-3-Super-120B-A12B** | **TurboQuant** | **3** | **—** | **~50 GB** | **18.7 tok/s** |
 | **[Nemotron-3-Super-120B-A12B (hybrid for 48GB)](https://huggingface.co/manjunathshiva/Nemotron-3-Super-120B-A12B-tq3a-tq2e-g32)** | **TQ 3-attn / 2-experts, gs=32** | **2/3 mix** | **—** | **~36 GB** | **~27.2 tok/s** |
+| **[Laguna-XS.2 (33B agentic coder)](https://huggingface.co/manjunathshiva/Laguna-XS.2-tq3-g64)** | **TurboQuant, gs=64** | **3** | **—** | **13.8 GB** | **46.8 tok/s · 32 GB Mac · Opencode pass** |
+| Laguna-S-2.1 (118B) | BF16 (original) | 16 | — | ~219 GB | *Doesn't fit 64GB* |
+| Laguna-S-2.1 (118B) | [Affine 4-bit](https://huggingface.co/mlx-community/Laguna-S-2.1-4bit) | 4 | — | ~64 GB | *Exceeds Metal's ~56 GB working set — won't load* |
+| **[Laguna-S-2.1 (118B, ternary experts)](https://huggingface.co/manjunathshiva/Laguna-S-2.1-tqTe-g64)** | **TQ 3-attn / ternary trit-packed experts, gs=64** | **1.6/3 mix** | **—** | **~27 GB** | **~12.5 tok/s · fully resident on 64 GB with ~25 GB spare · Opencode pass** |
 
 ## Key Results — KV Cache Compression
 
@@ -1176,7 +1180,13 @@ prompts, so this hybrid handles long-context retrieval (e.g. password-
 recall over 4000+ tokens of context) without the kernel argument-validation
 crash that affected earlier builds.
 
-### Poolside Laguna (33B MoE for agentic coding)
+### Poolside Laguna (33B and 118B MoE for agentic coding)
+
+Two models share this architecture: **XS.2** (33B) and **S-2.1** (118B). The port
+covers both; the licence does **not** — XS.2 is Apache-2.0, S-2.1 is OpenMDW-1.1.
+Check per repo before redistributing derived weights.
+
+#### Laguna-XS.2 (33B)
 
 [Laguna-XS.2](https://huggingface.co/poolside/Laguna-XS.2) is Poolside's 33B
 Mixture-of-Experts (256 experts, top-8, 3B active) built for **agentic coding
@@ -1217,6 +1227,56 @@ turboquant-serve --model ./laguna-xs2-tq3-g64 --port 8080 \
   MLX-native affine 4-bit but ~2× slower per token (codebook decode + online
   Hadamard rotation, not bandwidth). Prefer it when memory-bound; prefer affine
   4-bit for the fastest interactive loop.
+
+#### Laguna-S-2.1 (118B) — ternary experts, resident on a 64 GB Mac
+
+[Laguna-S-2.1](https://huggingface.co/poolside/Laguna-S-2.1) is the 118B sibling
+(256 experts, top-10 + 1 shared, `moe_intermediate` 1024, 48 layers). At bf16 it
+is ~219 GB. **Ternary (1.58-bit) experts bring it to ~27 GB, which is the only
+build of this model that runs resident on a 64 GB Mac** — affine 4-bit (~64 GB)
+exceeds Metal's ~56 GB working set and won't load at all, and TurboQuant's own
+3-bit (48 GB) peaks at 52.7 GB and starves the OS.
+
+```bash
+python -m turboquant_mlx.convert --hf-path poolside/Laguna-S-2.1 \
+    --mlx-path ./laguna-s21-tqTe-g64 \
+    --attn-bits 3 --ternary-experts --group-size 64 --streaming
+
+# Resident on 64 GB. --no-think matters: Laguna reasons out loud by default, so
+# a plain generate call can spend its whole budget deliberating and never answer.
+python -m turboquant_mlx.generate --model ./laguna-s21-tqTe-g64 \
+    --prompt "Write a mergesort in Python." \
+    --temp 0.7 --top-p 0.9 --max-tokens 1024 --no-think
+```
+
+- **~30 GB peak resident, ~12.5 tok/s** on an M4 Max, leaving ~25 GB for the OS.
+- **MMLU-Redux 79.5 %, GSM8K 82.5 %** — at 1.58-bit experts this 118B still edges
+  the 33B XS.2 at 3-bit (76.9 / 79.0). The larger, wider expert pool absorbs the
+  deeper quantization.
+- **Passes Opencode agentic coding at 1.58-bit**, where the 512-wide-expert 35B
+  ternary build fails the same harness. Expert **width** (1024 vs 512), not just
+  count, is what sustains sub-2-bit — see [Sub-2-bit ternary experts](#key-results--weight-compression).
+
+**Expert streaming** works on Laguna too, so 27 GB resident is not the floor —
+only 2.28 GB of this model has to stay resident, the other 26.42 GB pages from
+disk on demand:
+
+```bash
+python -m turboquant_mlx.stream.stream_generate --model ./laguna-s21-tqTe-g64 \
+    --cache-budget-gb 4 --max-active-experts 0 --prompt "..." --max-tokens 256
+```
+
+Measured on an M4 Max with a 4 GB expert cache: **peak 7.3 GB** (RSS 6.6 GB),
+141 of 144 expert projections streamed, ~5 tok/s, 56.8 % cache hit rate — a
+footprint that fits a **16 GB Mac mini**. Use `--max-active-experts 0` to keep
+native top-10 routing (lowering it reads less from disk but changes which experts
+run, and breaks agentic tool-calling).
+
+> Requires `turboquant-mlx-full >= 0.18.0`. Earlier versions matched expert
+> tensors by the `switch_mlp` name only, so Laguna's `mlp.experts` container
+> counted as resident: `turboquant-plan` reported "won't run" on small Macs and
+> `--cache-budget-gb auto` sized itself from a bad figure. Explicit
+> `--cache-budget-gb` was unaffected.
 
 ---
 
@@ -1260,7 +1320,7 @@ Options:
 | Qwen3.5-MoE / Qwen3.6-35B-A3B | `qwen3_5_moe` | Yes (256 experts) | Tested (122B, 35B-A3B); 35B streams on a 16 GB Mac mini |
 | Qwen3-MoE | `qwen3_moe` | Yes (128 experts, top-8) | Tested — Qwen3-235B-A22B converted to a hybrid **tq3a-tq2e** build (70.5 GB) on a 16 GB Mac mini via `--streaming`; streams and passes 5/6 quality probes on a 64 GB Mac |
 | Nemotron-H (Mamba/attention hybrid) | `nemotron_h` | Yes (512 experts w/ latent MoE on Super-120B) | Tested (Nano-4B, Super-120B) — requires mlx-lm ≥ 0.31.3 |
-| Poolside Laguna (SWA + global attn, per-head gating) | `laguna` | Yes (256 experts, top-8) | Tested (XS.2 33B: convert + generate + Opencode agentic pass at 3-bit). Custom arch — MLX port + loader shipped here (mlx-lm has no native `laguna`); logit-parity 2e-7 vs transformers |
+| Poolside Laguna (SWA + global attn, per-head gating) | `laguna` | Yes (256 experts, top-8/top-10) | Tested (XS.2 33B at 3-bit; S-2.1 118B at ternary 1.58-bit — both convert + generate + Opencode agentic pass; expert streaming wired for both). Custom arch — MLX port + loader shipped here (mlx-lm has no native `laguna`); logit-parity 2e-7 vs transformers |
 | DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
 | DiffusionGemma (block-diffusion MoE, via **mlx-vlm**) | `diffusion_gemma` | Yes (128 experts, top-8) | Tested (26B-A4B: convert + block-diffusion sampler, coherent at 3-bit — [HF](https://huggingface.co/manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32)). **Experimental**: decode is much slower than native 4-bit until a batched codebook gather-GEMM kernel lands |
 

--- a/expert_naming.py
+++ b/expert_naming.py
@@ -32,12 +32,20 @@ SWITCH_ATTRS = ("switch_mlp", "experts")
 STREAMED_SUFFIXES = (".weight", ".scales")
 
 
+def is_expert_container_key(key: str) -> bool:
+    """True if this key lives in a stacked-expert container, so its axis 0 is
+    the expert axis. Says nothing about *which* tensor — see the callers.
+
+    Excludes ``shared_experts``: it is a dense always-on MLP with no expert
+    axis at all.
+    """
+    return "switch_mlp" in key or ".mlp.experts." in key
+
+
 def is_streamed_expert_key(key: str) -> bool:
     """True if this safetensors key is a per-expert tensor the swap pages in.
 
     Excludes ``shared_experts`` (dense, always resident) and the resident
     codebook/signs of a quantized expert layer.
     """
-    if not key.endswith(STREAMED_SUFFIXES):
-        return False
-    return "switch_mlp" in key or ".mlp.experts." in key
+    return key.endswith(STREAMED_SUFFIXES) and is_expert_container_key(key)

--- a/expert_naming.py
+++ b/expert_naming.py
@@ -1,0 +1,43 @@
+"""Where a MoE block keeps its stacked experts — the one naming rule.
+
+Two modules have to agree on which safetensors keys hold *streamable* expert
+weights: ``stream/loader.py`` (which pages them from disk) and ``plan.py``
+(which projects how much RAM that saves). They drifted — both matched only
+``switch_mlp``, so Laguna, whose experts live at ``mlp.experts``, reported zero
+streamable bytes: the planner called a streamable model resident-only, and
+``--cache-budget-gb auto`` sized itself from a resident figure that included
+every expert. Keeping the rule in one stdlib-only module is what stops that
+happening again; ``plan.py`` imports no model framework, so this must not
+either.
+
+The two spellings are not symmetric, and that asymmetry is the point:
+
+* ``switch_mlp`` is ours (qwen3_5_moe, deepseek) and unambiguous anywhere in a
+  key, so it matches unanchored — that also preserves any prefix layout that
+  already worked before this module existed.
+* ``experts`` is a plain mlx-lm ``SwitchGLU`` attribute (laguna, gpt-oss) and is
+  a *substring of* ``shared_experts`` — a dense, always-on MLP that must stay
+  resident. So it only matches anchored as ``.mlp.experts.``, which is exactly
+  how ``loader.py`` splices the attribute back into a key
+  (``{prefix}.{i}.mlp.{attr}.{proj}.weight``).
+"""
+
+# Attribute name of the stacked-expert container on an MoE block, by convention.
+SWITCH_ATTRS = ("switch_mlp", "experts")
+
+# Only these two are paged per-expert. A trit/codebook layer also ships
+# `.codebook` (3 entries) and `.signs` (the rotation sign vector); both are tiny
+# and held resident on the StreamingSwitchLinear, so counting them as streamable
+# would overstate what streaming actually saves.
+STREAMED_SUFFIXES = (".weight", ".scales")
+
+
+def is_streamed_expert_key(key: str) -> bool:
+    """True if this safetensors key is a per-expert tensor the swap pages in.
+
+    Excludes ``shared_experts`` (dense, always resident) and the resident
+    codebook/signs of a quantized expert layer.
+    """
+    if not key.endswith(STREAMED_SUFFIXES):
+        return False
+    return "switch_mlp" in key or ".mlp.experts." in key

--- a/plan.py
+++ b/plan.py
@@ -47,6 +47,8 @@ import struct
 import subprocess
 import sys
 
+from turboquant_mlx.expert_naming import is_streamed_expert_key
+
 _ITEMSIZE = {"F64": 8, "I64": 8, "U64": 8, "F32": 4, "I32": 4, "U32": 4,
              "F16": 2, "BF16": 2, "I16": 2, "U16": 2, "F8_E4M3": 1,
              "F8_E5M2": 1, "I8": 1, "U8": 1, "BOOL": 1}
@@ -121,10 +123,10 @@ def footprint(index: dict) -> dict:
             n *= d
         b = n * _ITEMSIZE.get(dtype, 4)
         total += b
-        # what the streaming swap pages from disk (mirrors
-        # stream/loader.py:_streamed_expert_bytes)
-        if "switch_mlp" in name and (name.endswith(".weight")
-                                     or name.endswith(".scales")):
+        # what the streaming swap pages from disk — same rule as
+        # stream/loader.py:_streamed_expert_bytes, now shared so they can't
+        # drift again (they did: both missed laguna's `mlp.experts`)
+        if is_streamed_expert_key(name):
             expert += b
     return {"total_bytes": total, "expert_bytes": expert,
             "resident_bytes": total - expert}

--- a/stream/calibrate_experts.py
+++ b/stream/calibrate_experts.py
@@ -29,6 +29,8 @@ import json
 import time
 from collections import Counter, defaultdict
 
+from turboquant_mlx.expert_naming import is_streamed_expert_key
+
 # A spread of tasks so the routing trace reflects general use, not one domain.
 CALIB_PROMPTS = [
     "Write a detailed, well-structured 300-word essay on the history of the printing press.",
@@ -83,9 +85,7 @@ def _model_expert_info(model_path):
     seen = 0
     num_experts = 0
     for key, loc in r._index.items():
-        if "switch_mlp" not in key:
-            continue
-        if not (key.endswith(".weight") or key.endswith(".scales")):
+        if not is_streamed_expert_key(key):
             continue
         num_experts = loc.shape[0]
         per = 1

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -25,6 +25,47 @@ from .streaming_switch import ExpertCache, StreamingSwitchLinear
 
 _PROJS = ("gate_proj", "up_proj", "down_proj")
 
+# Attribute name of the stacked-expert container on an MoE block, by convention.
+# qwen3_5_moe/deepseek call it `switch_mlp`; laguna's LagunaMoE holds a plain
+# mlx-lm `SwitchGLU` at `experts`. The name is also the weight-key segment
+# (`...mlp.<name>.gate_proj.weight`), so whichever attribute matched has to be
+# the one the reader is pointed at — hence _find_switch returns both.
+# `shared_experts` is deliberately absent: it is a dense always-on MLP that must
+# stay resident, and its projections are PolarQuantizedLinear anyway.
+_SWITCH_ATTRS = ("switch_mlp", "experts")
+
+
+def _find_switch(mlp):
+    """Return ``(attr_name, module)`` for an MoE block's stacked-expert container.
+
+    ``(None, None)`` when the block has none (dense layer, or an expert container
+    holding something other than quantized switch projections). The type check is
+    deliberate here: the caller splices ``attr_name`` into a weight key and hands
+    it to the reader, so claiming a container whose projections aren't quantized
+    switch layers would point the reader at a tensor that doesn't exist.
+    """
+    if mlp is None:
+        return None, None
+    for name in _SWITCH_ATTRS:
+        sm = getattr(mlp, name, None)
+        if sm is None:
+            continue
+        if any(isinstance(getattr(sm, p, None), PolarQuantizedSwitchLinear)
+               for p in _PROJS):
+            return name, sm
+    return None, None
+
+
+def _has_switch(mlp) -> bool:
+    """True if this mlp looks like an MoE block, by container presence alone.
+
+    Deliberately looser than :func:`_find_switch`: routing changes (K-reduction)
+    only need to know "is this a router-driven MoE block", and apply equally to
+    quantized and unquantized experts.
+    """
+    return mlp is not None and any(
+        getattr(mlp, name, None) is not None for name in _SWITCH_ATTRS)
+
 # When the model file fits comfortably in RAM, trusting the OS page cache makes
 # LRU-eviction re-reads come back from warm RAM instead of disk — measured 2.44x
 # faster decode on a streamed 35B-A3B (scripts/flash_moe/trust_os_ab.py). When
@@ -84,7 +125,7 @@ def _cap_active_experts(layers, max_active: int) -> None:
     changed = []
     for layer in layers:
         mlp = getattr(layer, "mlp", None)
-        if mlp is None or not hasattr(mlp, "top_k") or not hasattr(mlp, "switch_mlp"):
+        if mlp is None or not hasattr(mlp, "top_k") or not _has_switch(mlp):
             continue
         native = int(mlp.top_k)
         new_k = min(native, max_active)
@@ -358,7 +399,7 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
     swapped = 0
     pin_keys: set = set()
     for i, layer in enumerate(layers):
-        sm = getattr(layer.mlp, "switch_mlp", None)
+        sm_name, sm = _find_switch(getattr(layer, "mlp", None))
         if sm is None:
             continue
         proj_keys = []
@@ -368,8 +409,8 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
                 continue
             cb, sg = res.codebook, res.signs
             mx.eval(cb, sg)  # tiny — pin resident, let the rest of res be freed
-            wkey = f"{prefix}.{i}.mlp.switch_mlp.{proj}.weight"
-            skey = f"{prefix}.{i}.mlp.switch_mlp.{proj}.scales"
+            wkey = f"{prefix}.{i}.mlp.{sm_name}.{proj}.weight"
+            skey = f"{prefix}.{i}.mlp.{sm_name}.{proj}.scales"
             for e in pin_layers.get(i, ()):  # pin every projection of a hot expert
                 pin_keys.add((wkey, e))
             st = StreamingSwitchLinear(

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -17,6 +17,7 @@ import time
 
 import mlx.core as mx
 
+from turboquant_mlx.expert_naming import SWITCH_ATTRS, is_streamed_expert_key
 from turboquant_mlx.generate import load_turboquant, resolve_model_path
 from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
 
@@ -32,7 +33,8 @@ _PROJS = ("gate_proj", "up_proj", "down_proj")
 # the one the reader is pointed at — hence _find_switch returns both.
 # `shared_experts` is deliberately absent: it is a dense always-on MLP that must
 # stay resident, and its projections are PolarQuantizedLinear anyway.
-_SWITCH_ATTRS = ("switch_mlp", "experts")
+# Shared with plan.py so the module swap and the byte accounting agree.
+_SWITCH_ATTRS = SWITCH_ATTRS
 
 
 def _find_switch(mlp):
@@ -152,12 +154,10 @@ _SAFETENSORS_ITEMSIZE = {"U32": 4, "I32": 4, "F32": 4, "F16": 2, "BF16": 2,
 
 def _streamed_expert_bytes(reader) -> int:
     """Total on-disk bytes of the tensors the streaming swap pages from disk
-    (MoE switch_mlp weight/scales) — everything else stays resident."""
+    (per-expert weight/scales) — everything else stays resident."""
     total = 0
     for key, loc in reader._index.items():
-        if "switch_mlp" not in key:
-            continue
-        if not (key.endswith(".weight") or key.endswith(".scales")):
+        if not is_streamed_expert_key(key):
             continue
         n = 1
         for d in loc.shape:

--- a/stream/repack_experts.py
+++ b/stream/repack_experts.py
@@ -36,6 +36,8 @@ import struct
 
 import mlx.core as mx
 
+from turboquant_mlx.expert_naming import is_expert_container_key
+
 _LAYER_RE = re.compile(r"\.layers\.(\d+)\.")
 
 
@@ -47,12 +49,19 @@ def _st_metadata(path):
 
 
 def _reorder_axis0_keys(name: str) -> bool:
-    """True if this tensor's axis 0 is the expert axis and must be permuted."""
+    """True if this tensor's axis 0 is the expert axis and must be permuted.
+
+    The expert stacks and the router rows must agree: permuting one without the
+    other stops being a relabeling and starts being a rerouting. Matching the
+    container by ``switch_mlp`` alone missed laguna's ``mlp.experts``, which
+    permuted the router rows below while leaving the expert stacks in place —
+    a checkpoint that loads cleanly and routes every token to the wrong expert.
+    """
     if name.endswith(("gate_proj.weight", "gate_proj.scales",
                        "up_proj.weight", "up_proj.scales",
                        "down_proj.weight", "down_proj.scales")):
-        return "switch_mlp" in name
-    # router (NOT switch_mlp.*_proj): mlp.gate.weight / .bias / correction bias
+        return is_expert_container_key(name)
+    # router (NOT the expert projections): mlp.gate.weight / .bias / correction
     return name.endswith(("mlp.gate.weight", "mlp.gate.bias",
                           "mlp.gate.e_score_correction_bias"))
 

--- a/tests/test_expert_naming.py
+++ b/tests/test_expert_naming.py
@@ -165,7 +165,8 @@ def test_real_laguna_index_if_present():
         "~/RandD/laguna-s21-tqTe-g64/model.safetensors.index.json")
     if not os.path.exists(path):
         return
-    keys = json.load(open(path))["weight_map"]
+    with open(path) as f:
+        keys = json.load(f)["weight_map"]
     streamed = [k for k in keys if is_streamed_expert_key(k)]
     assert streamed, "no streamable experts found in a real Laguna MoE repo"
     assert not any("shared_experts" in k for k in streamed)

--- a/tests/test_expert_naming.py
+++ b/tests/test_expert_naming.py
@@ -113,6 +113,51 @@ def test_plan_and_loader_agree_on_the_same_index():
             _Reader(idx)), f"plan/loader disagree on {template}"
 
 
+def test_calibrate_expert_cost_is_nonzero_for_either_container(tmp_path):
+    """`_model_expert_info` sizes the hot-expert pin list. Returning 0 bytes per
+    expert makes the `used + cost > cap` budget check never fire, so *every*
+    expert lands in hot_experts.json claiming ~0 GB — and the loader then tries
+    to pin the whole expert stack into a wired cache sized for a fraction of it."""
+    import mlx.core as mx
+
+    from turboquant_mlx.stream.calibrate_experts import _model_expert_info
+
+    for container in ("switch_mlp", "experts"):
+        d = tmp_path / container
+        d.mkdir()
+        t = {}
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            t[f"model.layers.0.mlp.{container}.{proj}.weight"] = mx.zeros(
+                (8, 4, 2), dtype=mx.uint32)
+            t[f"model.layers.0.mlp.{container}.{proj}.scales"] = mx.zeros(
+                (8, 4, 1), dtype=mx.float16)
+        mx.eval(*t.values())
+        mx.save_safetensors(str(d / "model.safetensors"), t)
+        (d / "config.json").write_text("{}")
+
+        cost, num_experts = _model_expert_info(str(d))
+        assert num_experts == 8, f"{container}: expert axis not found"
+        assert cost > 0, f"{container}: 0 bytes/expert defeats the pin budget"
+
+
+def test_router_and_experts_are_classified_consistently():
+    """Cross-module invariant: any layer whose router rows repack_experts will
+    permute must also have expert stacks it will permute. Violating this is not
+    a missed optimization — it reroutes every token."""
+    from turboquant_mlx.stream.repack_experts import _reorder_axis0_keys
+
+    for container in ("switch_mlp", "experts"):
+        router = "model.layers.0.mlp.gate.weight"
+        expert = f"model.layers.0.mlp.{container}.gate_proj.weight"
+        assert _reorder_axis0_keys(router), "router always permutes"
+        assert _reorder_axis0_keys(expert), (
+            f"router permutes but mlp.{container} experts do not — "
+            "the checkpoint would load fine and route to the wrong expert")
+    # and the dense always-on MLP must stay put under either scheme
+    assert not _reorder_axis0_keys(
+        "model.layers.0.mlp.shared_experts.gate_proj.weight")
+
+
 def test_real_laguna_index_if_present():
     """Against the actual converted repo when it's on this machine — the case
     that was wrong in the field. Skipped in CI."""
@@ -125,3 +170,21 @@ def test_real_laguna_index_if_present():
     assert streamed, "no streamable experts found in a real Laguna MoE repo"
     assert not any("shared_experts" in k for k in streamed)
     assert all(k.endswith((".weight", ".scales")) for k in streamed)
+
+    # repack's per-layer invariant, over real key names: no layer may have its
+    # router permuted without its experts. Before the fix this held for 0 of 47.
+    import collections
+    import re
+
+    from turboquant_mlx.stream.repack_experts import _reorder_axis0_keys
+
+    layer_re = re.compile(r"\.layers\.(\d+)\.")
+    router, expert = collections.Counter(), collections.Counter()
+    for k in keys:
+        m = layer_re.search(k)
+        if not m or not _reorder_axis0_keys(k):
+            continue
+        (router if ".mlp.gate." in k else expert)[int(m.group(1))] += 1
+    orphaned = sorted(l for l in router if expert[l] == 0)
+    assert not orphaned, (
+        f"layers {orphaned} would permute the router but not the experts")

--- a/tests/test_expert_naming.py
+++ b/tests/test_expert_naming.py
@@ -1,0 +1,127 @@
+"""Which safetensors keys count as streamable expert weights.
+
+The companion to ``test_stream_switch_attr.py``: that one pins the *module*
+swap, this one pins the *byte accounting* over the same two naming conventions.
+Both halves have to agree, and once they didn't — the swap learned laguna's
+``mlp.experts`` container while ``plan.py`` and ``_streamed_expert_bytes`` kept
+matching only ``switch_mlp``. Laguna therefore streamed correctly but reported
+zero streamable bytes, so ``turboquant-plan`` called a streamable model
+resident-only (❌ on a 16 GB Mac that in fact runs it at a 7.3 GB peak) and
+``--cache-budget-gb auto`` sized its cache from a resident figure that wrongly
+included all 28.7 GB of experts.
+"""
+
+import json
+import os
+
+from turboquant_mlx.expert_naming import is_streamed_expert_key
+from turboquant_mlx.plan import footprint
+
+# Real key shapes, as emitted by the converter.
+_QWEN = "model.layers.3.mlp.switch_mlp.{proj}.{suffix}"      # qwen3_5_moe/deepseek
+_LAGUNA = "model.layers.3.mlp.experts.{proj}.{suffix}"       # laguna SwitchGLU
+_SHARED = "model.layers.3.mlp.shared_experts.{proj}.{suffix}"  # dense, resident
+
+
+def test_counts_switch_mlp_keys():
+    for suffix in ("weight", "scales"):
+        assert is_streamed_expert_key(_QWEN.format(proj="gate_proj",
+                                                   suffix=suffix))
+
+
+def test_counts_laguna_experts_keys():
+    """The regression: `mlp.experts` is a stacked-expert container too."""
+    for suffix in ("weight", "scales"):
+        assert is_streamed_expert_key(_LAGUNA.format(proj="down_proj",
+                                                     suffix=suffix))
+
+
+def test_never_counts_shared_experts():
+    """`shared_experts` is a dense always-on MLP. It contains the substring
+    "experts", so an unanchored match would page a tensor every token needs —
+    and would overstate the streaming saving by the whole shared-expert stack."""
+    for suffix in ("weight", "scales"):
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            assert not is_streamed_expert_key(_SHARED.format(proj=proj,
+                                                             suffix=suffix))
+
+
+def test_never_counts_resident_codebook_and_signs():
+    """A trit/codebook expert layer keeps its 3-entry codebook and rotation
+    signs resident on the StreamingSwitchLinear — they are not paged."""
+    for suffix in ("codebook", "signs"):
+        assert not is_streamed_expert_key(_LAGUNA.format(proj="gate_proj",
+                                                         suffix=suffix))
+        assert not is_streamed_expert_key(_QWEN.format(proj="gate_proj",
+                                                       suffix=suffix))
+
+
+def test_never_counts_dense_or_router_keys():
+    for key in ("model.layers.3.mlp.gate_proj.weight",       # dense layer 0 MLP
+                "model.layers.3.mlp.gate.weight",            # router
+                "model.layers.3.mlp.gate.e_score_correction_bias",
+                "model.layers.3.self_attn.q_proj.weight",
+                "model.embed_tokens.weight"):
+        assert not is_streamed_expert_key(key)
+
+
+def _index(template, n_layers=2, itemsize_shape=(4, 8)):
+    """A fake safetensors index: {name: (dtype, shape)}, as plan.footprint wants."""
+    idx = {}
+    for i in range(n_layers):
+        for proj in ("gate_proj", "up_proj", "down_proj"):
+            for suffix, dtype in (("weight", "uint32"), ("scales", "float16"),
+                                  ("codebook", "float16"), ("signs", "float16")):
+                key = template.format(proj=proj, suffix=suffix).replace(
+                    "layers.3", f"layers.{i}")
+                idx[key] = (dtype, itemsize_shape)
+    return idx
+
+
+def test_footprint_reports_laguna_experts_as_streamable():
+    """plan.footprint must not call a streamable MoE resident-only."""
+    fp = footprint(_index(_LAGUNA))
+    assert fp["expert_bytes"] > 0, "laguna experts counted as resident"
+    assert fp["resident_bytes"] == fp["total_bytes"] - fp["expert_bytes"]
+    # is_moe is derived from this in plan.build_plan
+    assert fp["expert_bytes"] > 0
+
+
+def test_footprint_keeps_shared_experts_resident():
+    fp = footprint(_index(_SHARED))
+    assert fp["expert_bytes"] == 0
+    assert fp["resident_bytes"] == fp["total_bytes"]
+
+
+def test_plan_and_loader_agree_on_the_same_index():
+    """The drift guard. Both modules must classify identical keys identically —
+    a planner that disagrees with the loader mispredicts the thing it exists to
+    predict."""
+    from turboquant_mlx.stream.loader import _streamed_expert_bytes
+
+    class _Loc:
+        def __init__(self, dtype, shape):
+            self.dtype, self.shape = dtype, shape
+
+    class _Reader:
+        def __init__(self, idx):
+            self._index = {k: _Loc(*v) for k, v in idx.items()}
+
+    for template in (_QWEN, _LAGUNA, _SHARED):
+        idx = _index(template)
+        assert footprint(idx)["expert_bytes"] == _streamed_expert_bytes(
+            _Reader(idx)), f"plan/loader disagree on {template}"
+
+
+def test_real_laguna_index_if_present():
+    """Against the actual converted repo when it's on this machine — the case
+    that was wrong in the field. Skipped in CI."""
+    path = os.path.expanduser(
+        "~/RandD/laguna-s21-tqTe-g64/model.safetensors.index.json")
+    if not os.path.exists(path):
+        return
+    keys = json.load(open(path))["weight_map"]
+    streamed = [k for k in keys if is_streamed_expert_key(k)]
+    assert streamed, "no streamable experts found in a real Laguna MoE repo"
+    assert not any("shared_experts" in k for k in streamed)
+    assert all(k.endswith((".weight", ".scales")) for k in streamed)

--- a/tests/test_repack_experts.py
+++ b/tests/test_repack_experts.py
@@ -1,0 +1,118 @@
+"""Repacking experts must be a pure *relabeling*, under either naming scheme.
+
+`repack_experts` reorders each layer's expert stacks and permutes the router
+rows by the same permutation, so the model picks the same expert for the same
+input and only the on-disk position changes. That argument holds only while the
+two move *together*.
+
+They didn't. The expert-stack branch matched the container by `switch_mlp`
+alone, while the router branch matched `mlp.gate.*` unconditionally — so on a
+laguna checkpoint (`mlp.experts`) the router rows were permuted and the expert
+stacks were left in place. The result loads cleanly, passes every shape check,
+and routes every token to the wrong expert.
+
+These tests run the real `main()` over a tiny synthetic checkpoint, so they
+exercise the tool rather than just its predicate.
+"""
+
+import json
+import os
+import sys
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.stream.repack_experts import main
+
+N_EXPERTS, OUT, PACKED, HIDDEN = 4, 3, 2, 5
+PERM = [2, 0, 3, 1]          # order[p] = old expert id now at position p
+PROJS = ("gate_proj", "up_proj", "down_proj")
+
+
+def _checkpoint(tmp_path, container):
+    """One layer of a `container`-style MoE, with distinguishable values."""
+    src = tmp_path / f"src_{container}"
+    src.mkdir()
+    t = {}
+    for i, proj in enumerate(PROJS):
+        # expert e is filled with a value that identifies it
+        t[f"model.layers.0.mlp.{container}.{proj}.weight"] = mx.broadcast_to(
+            mx.arange(N_EXPERTS, dtype=mx.uint32).reshape(N_EXPERTS, 1, 1),
+            (N_EXPERTS, OUT, PACKED)) + i * 100
+        t[f"model.layers.0.mlp.{container}.{proj}.scales"] = mx.broadcast_to(
+            mx.arange(N_EXPERTS, dtype=mx.float16).reshape(N_EXPERTS, 1, 1),
+            (N_EXPERTS, OUT, PACKED))
+        # the dense always-on MLP: no expert axis, must never be touched
+        t[f"model.layers.0.mlp.shared_experts.{proj}.weight"] = mx.arange(
+            OUT * PACKED, dtype=mx.uint32).reshape(OUT, PACKED)
+    t["model.layers.0.mlp.gate.weight"] = mx.broadcast_to(
+        mx.arange(N_EXPERTS, dtype=mx.float16).reshape(N_EXPERTS, 1),
+        (N_EXPERTS, HIDDEN))
+    t["model.layers.0.mlp.gate.e_score_correction_bias"] = mx.arange(
+        N_EXPERTS, dtype=mx.float16)
+    t["model.embed_tokens.weight"] = mx.arange(HIDDEN, dtype=mx.float16)
+    mx.eval(*t.values())
+    mx.save_safetensors(str(src / "model.safetensors"), t)
+    (src / "config.json").write_text("{}")
+
+    perm_file = tmp_path / f"perm_{container}.json"
+    perm_file.write_text(json.dumps({"perm": {"0": PERM}}))
+    return src, perm_file, t
+
+
+def _run(src, perm_file, out):
+    argv = sys.argv
+    sys.argv = ["repack_experts", "--model", str(src), "--perm",
+                str(perm_file), "--out", str(out)]
+    try:
+        main()
+    finally:
+        sys.argv = argv
+    return mx.load(os.path.join(str(out), "model.safetensors"))
+
+
+@pytest.mark.parametrize("container", ["switch_mlp", "experts"])
+def test_experts_and_router_move_together(tmp_path, container):
+    """The invariant the whole tool rests on: after repacking, position p holds
+    the expert that used to be at PERM[p] — in BOTH the weight stacks and the
+    router rows. Permuting one alone is a rerouting, not a relabeling."""
+    src, perm_file, before = _checkpoint(tmp_path, container)
+    after = _run(src, perm_file, tmp_path / f"out_{container}")
+
+    for p, old in enumerate(PERM):
+        for proj in PROJS:
+            for suffix in ("weight", "scales"):
+                key = f"model.layers.0.mlp.{container}.{proj}.{suffix}"
+                assert mx.array_equal(after[key][p], before[key][old]), (
+                    f"{key}: position {p} should hold old expert {old}")
+        for key in ("model.layers.0.mlp.gate.weight",
+                    "model.layers.0.mlp.gate.e_score_correction_bias"):
+            assert mx.array_equal(after[key][p], before[key][old]), (
+                f"{key}: router row {p} should hold old expert {old} — router "
+                f"and experts are out of step, which silently reroutes tokens")
+
+
+@pytest.mark.parametrize("container", ["switch_mlp", "experts"])
+def test_shared_experts_and_non_expert_tensors_are_untouched(tmp_path,
+                                                             container):
+    """`shared_experts` is dense and always-on — it has no expert axis, so
+    permuting its axis 0 would scramble rows of a matrix every token uses."""
+    src, perm_file, before = _checkpoint(tmp_path, container)
+    after = _run(src, perm_file, tmp_path / f"out2_{container}")
+
+    for proj in PROJS:
+        key = f"model.layers.0.mlp.shared_experts.{proj}.weight"
+        assert mx.array_equal(after[key], before[key]), f"{key} was permuted"
+    assert mx.array_equal(after["model.embed_tokens.weight"],
+                          before["model.embed_tokens.weight"])
+
+
+@pytest.mark.parametrize("container", ["switch_mlp", "experts"])
+def test_repack_preserves_the_tensor_set(tmp_path, container):
+    """Names and shards are supposed to be untouched — only values move."""
+    src, perm_file, before = _checkpoint(tmp_path, container)
+    after = _run(src, perm_file, tmp_path / f"out3_{container}")
+    assert set(after) == set(before)
+    for k in before:
+        assert after[k].shape == before[k].shape
+    assert os.path.exists(str(tmp_path / f"out3_{container}" / "config.json"))

--- a/tests/test_stream_switch_attr.py
+++ b/tests/test_stream_switch_attr.py
@@ -1,0 +1,147 @@
+"""The streaming loader must find an MoE block's stacked-expert container under
+either conventional attribute name.
+
+qwen3_5_moe/deepseek name it ``switch_mlp``; laguna's ``LagunaMoE`` holds a plain
+mlx-lm ``SwitchGLU`` at ``experts``. Before this was handled, ``load_streaming``
+on a Laguna model swapped **zero** projections and silently fell back to loading
+the whole model resident — fine on a 64 GB Mac, an OOM on a 16 GB one. The
+attribute name is also the weight-key segment, so a mismatch here reads the
+wrong tensor rather than failing loudly; both are pinned below.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
+from turboquant_mlx.stream.loader import _PROJS, _find_switch
+
+
+def _switch_linear(num_experts=4, input_dims=64, output_dims=32, bits=3,
+                   group_size=64):
+    """A minimal PolarQuantizedSwitchLinear with the right shapes/dtypes."""
+    packed = input_dims * bits // 32
+    layer = PolarQuantizedSwitchLinear(
+        input_dims=input_dims,
+        output_dims=output_dims,
+        num_experts=num_experts,
+        bits=bits,
+        group_size=group_size,
+        needs_rotation=True,
+    )
+    layer.weight = mx.zeros((num_experts, output_dims, packed), dtype=mx.uint32)
+    layer.scales = mx.ones((num_experts, output_dims, input_dims // group_size),
+                           dtype=mx.float16)
+    layer.codebook = mx.zeros((2 ** bits,), dtype=mx.float16)
+    layer.signs = mx.ones((input_dims,), dtype=mx.float16)
+    return layer
+
+
+class _Container(nn.Module):
+    """Stands in for SwitchGLU: just holds the three projections."""
+
+    def __init__(self):
+        super().__init__()
+        for proj in _PROJS:
+            setattr(self, proj, _switch_linear())
+
+
+class _MoEBlock(nn.Module):
+    def __init__(self, attr):
+        super().__init__()
+        self.top_k = 8
+        setattr(self, attr, _Container())
+
+
+def test_finds_switch_mlp_container():
+    name, sm = _find_switch(_MoEBlock("switch_mlp"))
+    assert name == "switch_mlp"
+    assert isinstance(sm.gate_proj, PolarQuantizedSwitchLinear)
+
+
+def test_finds_experts_container_laguna_style():
+    name, sm = _find_switch(_MoEBlock("experts"))
+    assert name == "experts"
+    assert isinstance(sm.gate_proj, PolarQuantizedSwitchLinear)
+
+
+def test_returned_name_matches_the_weight_key_segment():
+    """The name is spliced into `model.layers.N.mlp.<name>.gate_proj.weight`;
+    returning the module without its attribute name would read the wrong key."""
+    for attr in ("switch_mlp", "experts"):
+        name, _ = _find_switch(_MoEBlock(attr))
+        assert f"model.layers.0.mlp.{name}.gate_proj.weight" == (
+            f"model.layers.0.mlp.{attr}.gate_proj.weight")
+
+
+def test_dense_mlp_is_not_a_switch():
+    """A block with no expert container must be skipped, not crash."""
+    class Dense(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.gate_proj = nn.Linear(8, 8)
+
+    assert _find_switch(Dense()) == (None, None)
+    assert _find_switch(None) == (None, None)
+
+
+def test_shared_expert_mlp_is_not_mistaken_for_the_switch():
+    """`shared_experts` is a dense always-on MLP that must stay resident. It is
+    not in the candidate list, and its projections aren't switch layers anyway —
+    streaming it would page a tensor that every single token needs."""
+    class WithSharedOnly(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.top_k = 8
+            self.shared_experts = nn.Linear(8, 8)
+
+    assert _find_switch(WithSharedOnly()) == (None, None)
+
+
+def test_empty_expert_container_is_ignored():
+    """An `experts` attribute holding something other than quantized switch
+    projections (e.g. an unquantized model) must not be claimed."""
+    class NotQuantized(nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.top_k = 8
+            self.experts = nn.Linear(8, 8)
+
+    assert _find_switch(NotQuantized()) == (None, None)
+
+
+def test_k_reduction_sees_moe_blocks_under_either_name():
+    """K-reduction only needs "is this a router-driven MoE block", so it uses the
+    presence-only check — an unquantized or stubbed expert container still counts.
+    Tightening this to _find_switch would silently stop capping top_k."""
+    from turboquant_mlx.stream.loader import _cap_active_experts, _has_switch
+
+    class Stub:
+        def __init__(self, attr):
+            self.top_k = 8
+            setattr(self, attr, object())
+
+    class Layer:
+        def __init__(self, mlp):
+            self.mlp = mlp
+
+    for attr in ("switch_mlp", "experts"):
+        assert _has_switch(Stub(attr))
+        layers = [Layer(Stub(attr))]
+        _cap_active_experts(layers, 4)
+        assert layers[0].mlp.top_k == 4, f"top_k not capped for mlp.{attr}"
+
+
+def test_k_reduction_leaves_dense_blocks_alone():
+    from turboquant_mlx.stream.loader import _cap_active_experts, _has_switch
+
+    class Dense:
+        top_k = 8  # a top_k without any expert container is not an MoE block
+
+    class Layer:
+        def __init__(self, mlp):
+            self.mlp = mlp
+
+    assert not _has_switch(Dense())
+    layers = [Layer(Dense())]
+    _cap_active_experts(layers, 4)
+    assert layers[0].mlp.top_k == 8


### PR DESCRIPTION
Makes expert streaming actually usable on Poolside Laguna (both XS.2 33B and S-2.1 118B), and stops two tools from silently misbehaving on it.

## The thread

MoE blocks name their stacked-expert container one of two ways: `switch_mlp` (qwen3_5_moe, deepseek) or a plain mlx-lm `SwitchGLU` at `experts` (laguna, gpt-oss). Four places had to know that. Only one of them did.

**1. The module swap** (`fc53590`) — `load_streaming` keyed on `switch_mlp` alone, so on Laguna it swapped **zero** projections and silently fell back to loading all 27 GB resident. Fine on a 64 GB Mac, an OOM on a 16 GB one.

**2. Byte accounting** (`dbfea66`) — the swap learned both names, but the two functions that *count* expert bytes did not:

- `turboquant-plan` set `is_moe = False` and never offered streaming. It printed "❌ WILL NOT RUN" for S-2.1 on a 16 GB Mac that in fact runs it at a 7.3 GB peak. Now: 26.42 GB streamable / 2.28 GB resident, verdict ⚠️ STREAMING with the right flags.
- `--cache-budget-gb auto` derived its budget from a `resident_bytes` that included every expert. Explicit `--cache-budget-gb`, which is what all the measured runs used, was unaffected.

**3. Two tools** (`41f4e41`) — neither was a missed optimisation:

- `repack_experts` matched expert stacks by `switch_mlp` but matched router rows (`mlp.gate.*`) unconditionally. On Laguna that permutes the router and leaves the expert stacks in place, in **all 47** MoE layers. The tool is only correct because the two move *together* — a relabeling; one alone is a rerouting. The output loads cleanly and passes every shape assert, so it fails silently.
- `calibrate_experts._model_expert_info` returned 0 bytes/expert, so the `used + cost > cap` check never fired: every expert went into `hot_experts.json` claiming ~0 GB, which the loader then tries to pin into a wired cache sized for a fraction of it.

## The fix

One stdlib-only module, `expert_naming.py`, imported by all four call sites. `plan.py` deliberately imports no model framework, so it could not reuse `loader.py` — that is how they drifted, and the shared module is the guard.

The two names are **not** symmetric, and that is the point:

- `switch_mlp` matches unanchored — unambiguous, and it preserves any prefix layout that already worked.
- `experts` matches **only** as `.mlp.experts.`, because it is a substring of `shared_experts`, a dense always-on MLP that must stay resident. An unanchored match pages a tensor every token needs *and* overstates the streaming saving.

Two predicates, because repack asks a different question than the loader: `is_expert_container_key` ("is axis 0 the expert axis") and `is_streamed_expert_key` (that plus the weight/scales suffix).

## Testing

`tests/test_repack_experts.py` runs the real `main()` over a KB-scale synthetic checkpoint under both naming schemes — you don't need a 28.7 GB rewrite to test a checkpoint rewriter, you need the right key names. It asserts position `p` holds the expert formerly at `perm[p]` in the stacks **and** the router rows, that `shared_experts` is untouched, and that the tensor set survives.

`tests/test_expert_naming.py` pins the predicates, a plan/loader drift guard, the calibrate cost check, and the repack invariant over the real Laguna index (47 layers, 0 orphaned; before the fix, 47 orphaned).

Every new test was verified to **fail against the old predicates** while the `switch_mlp` paths keep passing. Full suite: **378 passed** (was 370).

## Docs

README covers Laguna S-2.1 118B ternary (Key Results + a section), the `--no-think` requirement, the streaming recipe with the measured 7.3 GB mini footprint, and the per-model licence split (XS.2 Apache-2.0, S-2.1 OpenMDW-1.1).

Version bump to 0.18.0 follows separately, after the 16 GB mini validation runs against this on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)