### PR TITLE
fix: ship turboquant_mlx.models (0.17.0/0.18.0 unusable from PyPI), release 0.18.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,33 @@ jobs:
           python -m pip install --upgrade pip build twine
           python -m build --sdist
           python -m twine check dist/*.tar.gz
+      # The tests run from the source tree, so a subpackage missing from
+      # pyproject's `packages` list passes every test and still ships broken
+      # (0.17.0/0.18.0 shipped without `models/`, killing every console script
+      # on a fresh install). Assert the artifact itself carries each one.
+      - name: sdist contents
+        run: |
+          python - <<'PY'
+          import glob, sys, tarfile, tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              packages = tomllib.load(f)["tool"]["setuptools"]["packages"]
+          tar = glob.glob("dist/*.tar.gz")[0]
+          with tarfile.open(tar) as t:
+              names = set(t.getnames())
+          root = min(names, key=len).split("/")[0]
+
+          missing = []
+          for p in packages:
+              sub = "" if p == "turboquant_mlx" else p.split(".", 1)[1]
+              sub = sub.replace(".", "/")
+              path = f"{root}/{sub}/__init__.py" if sub else f"{root}/__init__.py"
+              if path not in names:
+                  missing.append(f"{p} ({path})")
+          if missing:
+              sys.exit(f"sdist {tar} is missing declared package(s): {missing}")
+          print(f"sdist carries all {len(packages)} declared packages")
+          PY
       - uses: actions/upload-artifact@v7
         with:
           name: sdist

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,36 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.18.1] - 2026-07-26
+
+Hotfix. **0.17.0 and 0.18.0 installed from PyPI cannot run any command** — the
+`models/` subpackage that 0.17.0 added for Poolside Laguna was never listed in
+`pyproject.toml`, so it was absent from the distribution. `compat.py` imports
+`turboquant_mlx.models.laguna` at module scope with no guard and eleven modules
+import `compat`, so `turboquant-generate`, `turboquant-convert`,
+`turboquant-serve` and `stream_generate` all raised
+`ModuleNotFoundError: No module named 'turboquant_mlx.models'` on first import.
+`turboquant-plan` and `turboquant-doctor` were unaffected — they are the only
+entry points that do not import `compat`. Upgrade from 0.17.0 or 0.18.0.
+
+### Fixed
+
+- **`turboquant_mlx.models` is included in the distribution.** The flat-package
+  layout (the repo root *is* the `turboquant_mlx` package) means subpackages
+  cannot be auto-discovered and must be enumerated in `[tool.setuptools]
+  packages`; `models/` was not. Nothing caught it because the test suite runs
+  from the source tree, where the directory is present regardless of what gets
+  packaged.
+
+### Added
+
+- **Two guards against a repeat.** `tests/test_packaging.py` cross-checks the
+  declared package list against the subpackages actually on disk (in both
+  directions), and CI's `build sdist` job now asserts the built tarball really
+  contains an `__init__.py` for every declared package. The second is the one
+  that tests the artifact rather than the source tree — verified against the
+  published 0.18.0 tarball, which it rejects.
+
 ## [0.18.0] - 2026-07-26
 
 Expert streaming on Poolside Laguna. A MoE block names its stacked-expert

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.18.0"
+__version__ = "0.18.1"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.18.0"
+version = "0.18.1"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"
@@ -74,6 +74,7 @@ packages = [
     "turboquant_mlx.layers",
     "turboquant_mlx.kernels",
     "turboquant_mlx.integration",
+    "turboquant_mlx.models",
     "turboquant_mlx.stream",
 ]
 include-package-data = true

--- a/tests/test_packaging.py
+++ b/tests/test_packaging.py
@@ -1,0 +1,74 @@
+"""Every runtime subpackage is declared in pyproject's `packages` list.
+
+The flat-package layout (the repo root *is* the importable `turboquant_mlx`
+package, via a package-dir trick) means subpackages must be enumerated by hand
+— setuptools cannot discover them. Adding a directory therefore silently does
+nothing to the distribution until someone remembers this list.
+
+That failed once, badly: 0.17.0 added `models/` for Poolside Laguna but not the
+list entry, so the sdist shipped without it. `compat.py` imports
+`turboquant_mlx.models.laguna` at import time with no guard, and eleven modules
+import `compat` — so every console script (`turboquant-generate`,
+`-convert`, `-serve`, `stream_generate`) raised ModuleNotFoundError on a fresh
+pip install of 0.17.0 and 0.18.0. The test suite passed throughout, because
+pytest runs from the source tree where `models/` is right there on disk.
+
+This test reads the same source tree, so it cannot prove the *tarball* is
+correct — CI's `sdist contents` step does that. It does catch the mistake at
+its origin: a new directory with no list entry.
+"""
+
+import os
+
+import pytest
+
+_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+# Not shipped, deliberately: pytest suite and dev benchmarks. Keep this list
+# tiny — anything else with an __init__.py is runtime code a user can import.
+_NOT_SHIPPED = {"tests", "benchmarks"}
+
+
+def _declared_packages() -> set:
+    try:
+        import tomllib
+    except ModuleNotFoundError:  # py3.10
+        tomllib = pytest.importorskip("tomli", reason="needs tomllib or tomli")
+    with open(os.path.join(_ROOT, "pyproject.toml"), "rb") as f:
+        return set(tomllib.load(f)["tool"]["setuptools"]["packages"])
+
+
+def _on_disk_subpackages() -> set:
+    """Directories that are importable subpackages (have an __init__.py)."""
+    return {
+        d for d in os.listdir(_ROOT)
+        if os.path.isfile(os.path.join(_ROOT, d, "__init__.py"))
+    }
+
+
+def test_every_subpackage_on_disk_is_declared():
+    declared = _declared_packages()
+    missing = sorted(
+        d for d in _on_disk_subpackages()
+        if d not in _NOT_SHIPPED and f"turboquant_mlx.{d}" not in declared
+    )
+    assert not missing, (
+        f"subpackage(s) {missing} exist on disk but are not in pyproject's "
+        "[tool.setuptools] packages — they will be missing from the sdist and "
+        "any import of them will fail on a pip install while passing here. "
+        f"Add 'turboquant_mlx.{missing[0]}' to that list, or to _NOT_SHIPPED "
+        "in this test if it is genuinely dev-only."
+    )
+
+
+def test_declared_packages_exist_on_disk():
+    """The other direction: a stale entry breaks the build outright."""
+    declared = _declared_packages() - {"turboquant_mlx"}
+    on_disk = _on_disk_subpackages()
+    stale = sorted(p for p in declared if p.split(".", 1)[1] not in on_disk)
+    assert not stale, f"declared but not on disk: {stale}"
+
+
+def test_models_is_packaged():
+    """The specific regression, named so a bisect points straight at it."""
+    assert "turboquant_mlx.models" in _declared_packages()


### PR DESCRIPTION
## The bug

`pip install turboquant-mlx-full==0.17.0` or `==0.18.0` produces an installation where **no command runs**:

```
ModuleNotFoundError: No module named 'turboquant_mlx.models'
```

0.17.0 added `models/` for Poolside Laguna support (#64) but never added it to `pyproject.toml`'s `[tool.setuptools] packages` list. The flat-package layout — the repo root *is* the importable `turboquant_mlx` package, via a `package-dir` trick — means subpackages cannot be auto-discovered and must be enumerated by hand.

`compat.py:157` calls `_register_laguna_model()` at module scope with no guard (unlike the two patch functions either side of it, which both self-disable on ImportError), and eleven modules import `compat`. So `turboquant-generate`, `turboquant-convert`, `turboquant-serve` and `stream_generate` all fail at import.

`turboquant-plan` and `turboquant-doctor` are unaffected — they are the only entry points that do not import `compat`, which is why the breakage went unnoticed.

Confirmed at the artifact level, not inferred: the sdist published to PyPI for 0.18.0 contains **zero** `models/` entries.

## Why the suite passed

pytest runs from the source tree, where `models/` is on disk regardless of what gets packaged. `tests/test_laguna.py` imports `compat` and passes. The `build sdist` CI job built the tarball but never inspected or installed it.

## The fix

One line in `pyproject.toml`. No `package-dir` entry is needed — `turboquant_mlx.stream` has none either and works, because the root `"turboquant_mlx" = "."` mapping lets setuptools derive subpackage paths.

## Two guards

The source tree and the artifact are different things, so there is a test for each:

- **`tests/test_packaging.py`** — cross-checks the declared package list against the subpackages actually on disk, in both directions (an undeclared directory ships broken; a stale entry breaks the build). Fails without the `pyproject.toml` line, passes with it.
- **CI `sdist contents`** — asserts the built tarball carries an `__init__.py` for every declared package. This one tests the artifact. Verified by running it against the tarball published for 0.18.0, which it correctly rejects:
  ```
  sdist pub.tar.gz is missing declared package(s): ['turboquant_mlx.models (turboquant_mlx_full-0.18.0/models/__init__.py)']
  ```

## Release

Bundled with the 0.18.1 bump rather than split into a follow-up `chore: release` PR — there is nothing to validate on `main` first, since the fix is a packaging change whose effect was already confirmed by hand on the affected machine.

0.17.0 and 0.18.0 will be yanked on PyPI.

## Verification

- Full suite: **381 passed** (378 + 3 new)
- Both new tests confirmed failing with the `pyproject.toml` change reverted
- Locally built sdist confirmed to contain `models/__init__.py` and `models/laguna.py`
- The affected machine (16 GB Mac mini, 0.18.0 from PyPI) recovered by dropping the two missing files into site-packages — same code, same path as this fix