### PR TITLE
fix: one auto cache budget, sized from measurement

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,36 @@ jobs:
       - name: Check distribution metadata
         run: twine check dist/*
 
+      # The same guard ci.yml runs, repeated here on the tarball that actually
+      # gets published. `twine check` validates metadata, not contents: 0.17.0
+      # and 0.18.0 both passed it while shipping without the `models/`
+      # subpackage, which broke every console script on install. CI gates main
+      # and tags come from main, so this is belt-and-braces — but this is the
+      # job whose output reaches users, so this is where it must not be skipped.
+      - name: Verify sdist carries every declared package
+        run: |
+          python - <<'PY'
+          import glob, sys, tarfile, tomllib
+
+          with open("pyproject.toml", "rb") as f:
+              packages = tomllib.load(f)["tool"]["setuptools"]["packages"]
+          tar = glob.glob("dist/*.tar.gz")[0]
+          with tarfile.open(tar) as t:
+              names = set(t.getnames())
+          root = min(names, key=len).split("/")[0]
+
+          missing = []
+          for p in packages:
+              sub = "" if p == "turboquant_mlx" else p.split(".", 1)[1]
+              sub = sub.replace(".", "/")
+              path = f"{root}/{sub}/__init__.py" if sub else f"{root}/__init__.py"
+              if path not in names:
+                  missing.append(f"{p} ({path})")
+          if missing:
+              sys.exit(f"sdist {tar} is missing declared package(s): {missing}")
+          print(f"sdist carries all {len(packages)} declared packages")
+          PY
+
       - name: Verify tag matches package version
         run: |
           TAG="${GITHUB_REF#refs/tags/v}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Changed
+
+- **`--cache-budget-gb auto` is no longer double-conservative, and `plan` now
+  predicts what the loader actually does.** The two computed the budget
+  differently: `plan.py` sized from the cap a `sysctl` bump *could* reach and
+  subtracted a 1 GB reserve, while `stream/loader.py` sized from the cap the
+  machine has and subtracted 2 GB. On a 16 GB M4 mini planning Laguna-S-2.1,
+  `turboquant-plan` advertised "~9.1 GB here" where the loader chose 5.89 GB —
+  and 9.1 GB would have peaked near 12.4 GB against that machine's 12.71 GB
+  cap. The arithmetic now lives in one module, `cache_budget.py`, imported by
+  both, and sizes from the *current* working set: a default must not assume a
+  sysctl the user was never told to run.
+
+  The formula also stopped taking 80% of the working set *and* subtracting a
+  2 GB reserve, which double-counted safety. A `--cache-budget-gb` sweep on
+  that mini (2/4/5.89/6/8 GB) put mlx's peak at **cache budget + 3.33 GB**
+  every time, within 40 MB, so the budget is now derived from that measured
+  relation rather than a blanket fraction. `auto` picks **7.4 GB** where it
+  used to pick 5.89 on the same machine; measured throughput across that range
+  was 1.36 → 1.58 tok/s. `turboquant-plan` prints the projected peak alongside
+  the budget so the number can be checked against a real run.
+
+### Fixed
+
+- **`turboquant-plan --model ~/typo` says the directory is missing.** Anything
+  that was not a directory was handed to the Hub, so a mistyped path came back
+  as "Repo id must be in the form 'repo_name' or 'namespace/repo_name'" — which
+  sends you looking for a naming rule when a directory is simply not there.
+- **`release.yml` verifies sdist contents too.** The guard added in 0.18.1 ran
+  only in `ci.yml`; the job whose output actually reaches PyPI now runs it as
+  well.
+
 ## [0.18.1] - 2026-07-26
 
 Hotfix. **0.17.0 and 0.18.0 installed from PyPI cannot run any command** — the

--- a/cache_budget.py
+++ b/cache_budget.py
@@ -1,0 +1,78 @@
+"""How big the streaming expert cache should be — in one place.
+
+``--cache-budget-gb auto`` is answered twice: once by ``stream/loader.py``,
+which actually sizes the cache, and once by ``plan.py``, which tells you what
+the loader is going to pick before you download 28 GB to find out. They
+disagreed. On a 16 GB M4 mini planning Laguna-S-2.1, ``turboquant-plan``
+advertised "~9.1 GB here" while the loader chose 5.89 GB — because plan sized
+from the cap you *could* raise the wired limit to and subtracted a 1 GB
+reserve, and the loader sized from the cap you actually have and subtracted 2.
+A planner that contradicts the thing it predicts is worse than no planner, so
+the arithmetic now lives here and both import it.
+
+The constants are measured, not guessed. Sweeping ``--cache-budget-gb`` over
+2 / 4 / 5.89 / 6 / 8 GB on a 16 GB M4 mini (Metal working set 12.71 GB,
+Laguna-S-2.1 ternary, 2.28 GB resident) put mlx's peak at **budget + 3.33 GB**
+every single time, within 40 MB:
+
+    budget  2.00  4.00  5.89  6.00  8.00
+    peak    5.31  7.32  9.23  9.34 11.35
+
+2.28 GB of that constant is the resident weights, which the caller already
+knows, leaving ~1.05 GB of runtime overhead that tracks neither the cache nor
+the model. That is what ``RUNTIME_OVERHEAD_BYTES`` is, and it is why a budget
+can be derived rather than guessed at with a blanket fraction.
+
+The old formula took 80% of the working set *and then* subtracted a 2 GB
+reserve, which double-counts safety: on that mini it reserved 4.5 GB against a
+measured need of ~1.05 GB plus KV, and cost ~15% of achievable throughput
+(5.89 GB → 1.36 tok/s where 8 GB → 1.58 tok/s). The reserve here is explicit
+about what each gigabyte is for.
+"""
+
+# Runtime cost that scales with neither the cache nor the resident weights:
+# activations, buffer-cache slack, fragmentation. Measured at ~1.05 GB; carried
+# at 1.1 to avoid pricing the floor exactly at the observation.
+RUNTIME_OVERHEAD_BYTES = int(1.1e9)
+
+# KV cache plus margin. KV grows with context and the loader does not know the
+# context in advance, so this is deliberately generous: at 16K tokens Laguna's
+# hybrid attention wants 0.88 GB, and a model with less sliding-window
+# attention wants more. Callers that *do* know their KV size should pass it as
+# `kv_bytes` and this shrinks to pure margin.
+KV_RESERVE_BYTES = int(1.9e9)
+
+# Below this a cache is not worth having: every token would miss.
+MIN_BUDGET_BYTES = int(0.5e9)
+
+
+def auto_cache_budget(wss_bytes: int, resident_bytes: int, expert_bytes: int,
+                      kv_bytes: int = 0) -> int:
+    """Bytes of expert cache to use when the user says ``auto``.
+
+    ``wss_bytes`` is Metal's max recommended working set — the *current* one,
+    not what a ``sysctl iogpu.wired_limit_mb`` bump could make it. Sizing a
+    default against a limit the user has not raised is how plan.py came to
+    recommend a budget that would have peaked at 12.4 GB against a 12.71 GB
+    cap.
+
+    Clamped to ``[MIN_BUDGET_BYTES, expert_bytes]``. The upper clamp must win:
+    when the experts are smaller than the floor, a budget bigger than every
+    expert that exists is just wasted reservation.
+    """
+    reserve = RUNTIME_OVERHEAD_BYTES + (kv_bytes or KV_RESERVE_BYTES)
+    budget = int(wss_bytes) - int(resident_bytes) - reserve
+    return min(int(expert_bytes), max(MIN_BUDGET_BYTES, budget))
+
+
+def projected_peak_bytes(budget_bytes: int, resident_bytes: int,
+                         kv_bytes: int = 0) -> int:
+    """What a streaming run will actually peak at — the inverse of the above.
+
+    Exposed because it is the number a user can check against their own
+    machine: measured peak was within 40 MB of this across a 4x range of
+    budgets. `turboquant-plan` prints it; the streaming loader could assert on
+    it.
+    """
+    return int(budget_bytes) + int(resident_bytes) + RUNTIME_OVERHEAD_BYTES \
+        + int(kv_bytes)

--- a/plan.py
+++ b/plan.py
@@ -47,6 +47,7 @@ import struct
 import subprocess
 import sys
 
+from turboquant_mlx.cache_budget import auto_cache_budget, projected_peak_bytes
 from turboquant_mlx.expert_naming import is_streamed_expert_key
 
 _ITEMSIZE = {"F64": 8, "I64": 8, "U64": 8, "F32": 4, "I32": 4, "U32": 4,
@@ -394,9 +395,16 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
     if mode == "streaming":
         flags.append("--streaming   (weights exceed even the raised cap; "
                      "experts page from disk)")
-        budget = max(0.5, ((ceiling or 0) * 0.8 - fp["resident_bytes"]
-                           - _RESERVE_BYTES) / _GB)
-        flags.append(f"--cache-budget-gb auto   (~{budget:.1f} GB here)")
+        # Predict what the loader will choose, by calling the same function it
+        # calls. Note `wss`, not `ceiling`: the loader sizes against the cap
+        # this machine has right now, and a default must not assume the user
+        # ran a sysctl they were never told to run. Getting that wrong is how
+        # this line came to advertise 9.1 GB where the loader picked 5.89.
+        budget_bytes = auto_cache_budget(wss or 0, fp["resident_bytes"],
+                                         fp["expert_bytes"])
+        peak_bytes = projected_peak_bytes(budget_bytes, fp["resident_bytes"])
+        flags.append(f"--cache-budget-gb auto   (~{budget_bytes / _GB:.1f} GB "
+                     f"here, peaking near {peak_bytes / _GB:.1f} GB)")
     if chosen != 2048:
         flags.append(f"--prefill-step-size {chosen}   (the default 2048 needs "
                      f"{_gb(prefill_workspace_bytes(cfg, context, 2048))} of "
@@ -644,6 +652,15 @@ def _resolve(path: str) -> tuple:
     p = os.path.expanduser(path)
     if os.path.isdir(p):
         return p, False                     # an explicit local path is the user's word
+    # Something that is clearly meant as a path, and isn't one, is a typo — not
+    # a repo id. Handing it to the hub gets you "Repo id must be in the form
+    # 'repo_name' or 'namespace/repo_name'", which sends you looking for a
+    # naming rule when the real problem is a directory that isn't there.
+    if os.path.isabs(p) or path.startswith((".", "~")) or path.count("/") > 1:
+        raise FileNotFoundError(
+            f"no such directory: {p}\n"
+            "(looks like a local path; an HF repo id would be "
+            "'namespace/repo_name' with no leading '/', '.' or '~')")
     try:                                    # already downloaded? use the cache
         from huggingface_hub import snapshot_download
         local = snapshot_download(path, local_files_only=True)

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -17,6 +17,12 @@ import time
 
 import mlx.core as mx
 
+from turboquant_mlx.cache_budget import (
+    KV_RESERVE_BYTES,
+    RUNTIME_OVERHEAD_BYTES,
+    auto_cache_budget,
+    projected_peak_bytes,
+)
 from turboquant_mlx.expert_naming import SWITCH_ATTRS, is_streamed_expert_key
 from turboquant_mlx.generate import load_turboquant, resolve_model_path
 from turboquant_mlx.layers.polar_switch_linear import PolarQuantizedSwitchLinear
@@ -141,12 +147,9 @@ def _cap_active_experts(layers, max_active: int) -> None:
 
 
 # Auto cache budget (ds4-style): size the expert cache from what the GPU can
-# actually keep resident — a fraction of Metal's max recommended working set,
-# minus the resident (non-expert) weights, minus a reserve for the KV cache
-# and the transient prefill workspace — instead of a fixed guess.
-_AUTO_WSS_FRACTION = 0.8
-_AUTO_RESERVE_BYTES = int(2.0e9)
-_AUTO_MIN_BUDGET_BYTES = int(0.5e9)
+# actually keep resident, rather than a fixed guess. The arithmetic and the
+# measured constants behind it are in cache_budget.py, shared with plan.py.
+_AUTO_RESERVE_BYTES = RUNTIME_OVERHEAD_BYTES + KV_RESERVE_BYTES
 
 _SAFETENSORS_ITEMSIZE = {"U32": 4, "I32": 4, "F32": 4, "F16": 2, "BF16": 2,
                          "U8": 1}
@@ -168,15 +171,13 @@ def _streamed_expert_bytes(reader) -> int:
 
 def _auto_cache_budget(model_bytes: int, expert_bytes: int,
                        wss_bytes: int) -> int:
-    """Pure budget math (unit-testable without a model): what's left of the
-    working-set fraction after the resident weights and the reserve, clamped
-    to [floor, all experts] — a budget past every expert buys nothing."""
+    """Pure budget math (unit-testable without a model).
+
+    The arithmetic lives in cache_budget.py so that plan.py predicts exactly
+    what happens here — those two drifted apart once already.
+    """
     resident = max(0, model_bytes - expert_bytes)
-    budget = int(_AUTO_WSS_FRACTION * wss_bytes) - resident - _AUTO_RESERVE_BYTES
-    # expert_bytes is the hard ceiling and must win over the floor: when the
-    # experts themselves are smaller than the minimum budget, the floor would
-    # otherwise hand back a budget larger than everything it could ever hold.
-    return min(expert_bytes, max(_AUTO_MIN_BUDGET_BYTES, budget))
+    return auto_cache_budget(wss_bytes, resident, expert_bytes)
 
 
 # A model repo may ship its own routing profile alongside the weights (the
@@ -312,11 +313,12 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
         budget_bytes = _auto_cache_budget(resident_bytes + expert_bytes,
                                           expert_bytes, wss)
         cache_budget_gb = budget_bytes / 1e9
-        print(f"[stream] auto budget: {_AUTO_WSS_FRACTION:.0%} × working set "
-              f"{wss / 1e9:.1f} GB − resident {resident_bytes / 1e9:.1f} GB − "
-              f"reserve {_AUTO_RESERVE_BYTES / 1e9:.1f} GB -> cache "
+        print(f"[stream] auto budget: working set {wss / 1e9:.1f} GB − "
+              f"resident {resident_bytes / 1e9:.1f} GB − reserve "
+              f"{_AUTO_RESERVE_BYTES / 1e9:.1f} GB -> cache "
               f"{cache_budget_gb:.1f} GB (experts on disk: "
-              f"{expert_bytes / 1e9:.1f} GB)")
+              f"{expert_bytes / 1e9:.1f} GB, projected peak "
+              f"{projected_peak_bytes(budget_bytes, resident_bytes) / 1e9:.1f} GB)")
     if wire_memory:
         wss = mx.device_info()["max_recommended_working_set_size"]
         want = int(min(wss, resident_bytes + cache_budget_gb * 1e9

--- a/tests/test_cache_budget.py
+++ b/tests/test_cache_budget.py
@@ -1,0 +1,175 @@
+"""`--cache-budget-gb auto` means one number, not two.
+
+`turboquant-plan` exists to tell you what the streaming loader will do before
+you download the model. It was telling you something else: on a 16 GB M4 mini
+planning Laguna-S-2.1 it advertised "~9.1 GB here" while the loader chose
+5.89 GB, because the two computed the budget from different ceilings with
+different reserves. The measured peak at 9.1 GB would have been ~12.4 GB
+against that machine's 12.71 GB cap.
+
+The sweep the constants come from (16 GB M4 mini, Metal working set 12.71 GB,
+Laguna-S-2.1 ternary, 2.28 GB resident, 26.42 GB of experts):
+
+    budget  2.00  4.00  5.89  6.00  8.00   GB
+    peak    5.31  7.32  9.23  9.34 11.35   GB
+    tok/s   1.15  1.26  1.36  1.35  1.58
+"""
+
+import os
+
+from turboquant_mlx.cache_budget import (
+    MIN_BUDGET_BYTES,
+    auto_cache_budget,
+    projected_peak_bytes,
+)
+
+_GB = 1e9
+
+# The machine the constants were measured on.
+_MINI_WSS = 12.71 * _GB
+_MINI_RESIDENT = 2.28 * _GB
+_MINI_EXPERTS = 26.42 * _GB
+
+# (budget GB, measured mlx peak GB) — every point of the real sweep.
+_SWEEP = [(2.00, 5.31), (4.00, 7.32), (5.89, 9.23), (6.00, 9.34), (8.00, 11.35)]
+
+
+def test_projected_peak_matches_every_measured_point():
+    """The peak model is the whole basis for deriving a budget. If it drifts
+    from what the hardware does, the budget silently stops being safe."""
+    for budget_gb, measured_gb in _SWEEP:
+        predicted = projected_peak_bytes(budget_gb * _GB, _MINI_RESIDENT) / _GB
+        assert abs(predicted - measured_gb) < 0.2, (
+            f"budget {budget_gb} GB: predicted peak {predicted:.2f} GB vs "
+            f"measured {measured_gb:.2f} GB")
+
+
+def test_auto_budget_fits_under_the_cap():
+    """The point of the reserve: whatever auto picks must leave room."""
+    budget = auto_cache_budget(_MINI_WSS, _MINI_RESIDENT, _MINI_EXPERTS)
+    peak = projected_peak_bytes(budget, _MINI_RESIDENT)
+    assert peak < _MINI_WSS, "auto budget projects a peak over the Metal cap"
+    assert _MINI_WSS - peak > 1.0 * _GB, "less than 1 GB of headroom is not a reserve"
+
+
+def test_auto_budget_is_not_wastefully_small():
+    """The regression this replaced. The old formula took 80% of the working
+    set *and* subtracted a 2 GB reserve — double-counted safety that cost ~15%
+    of throughput on the mini (5.89 GB -> 1.36 tok/s where 8 GB -> 1.58)."""
+    budget = auto_cache_budget(_MINI_WSS, _MINI_RESIDENT, _MINI_EXPERTS)
+    old = int(0.8 * _MINI_WSS) - _MINI_RESIDENT - 2.0 * _GB   # 5.89 GB
+    assert budget > old, "auto is no better than the formula it replaced"
+    assert budget / _GB > 7.0, f"auto picked {budget / _GB:.2f} GB, still timid"
+
+
+def test_never_exceeds_the_experts_that_exist():
+    """Upper clamp must beat the floor: caching more than every expert is
+    reserved memory that can never be used."""
+    tiny = 0.2 * _GB
+    assert auto_cache_budget(_MINI_WSS, _MINI_RESIDENT, tiny) == int(tiny)
+
+
+def test_floor_applies_on_a_machine_with_no_room():
+    """A cramped machine still gets a usable (if bad) budget rather than a
+    negative one."""
+    budget = auto_cache_budget(4 * _GB, 3.5 * _GB, _MINI_EXPERTS)
+    assert budget == MIN_BUDGET_BYTES
+
+
+def test_monotonic_in_working_set():
+    """More GPU, more cache — never the reverse."""
+    budgets = [auto_cache_budget(w * _GB, _MINI_RESIDENT, _MINI_EXPERTS)
+               for w in (12.71, 16, 24, 32)]
+    assert budgets == sorted(budgets)
+
+
+def test_known_kv_size_shrinks_the_reserve():
+    """A caller that knows its KV cache shouldn't pay the blanket estimate."""
+    blind = auto_cache_budget(_MINI_WSS, _MINI_RESIDENT, _MINI_EXPERTS)
+    known = auto_cache_budget(_MINI_WSS, _MINI_RESIDENT, _MINI_EXPERTS,
+                              kv_bytes=int(0.88 * _GB))  # laguna @16K
+    assert known > blind
+
+
+def test_plan_and_loader_pick_the_same_budget():
+    """The drift guard. `plan.py` promises what `stream/loader.py` does; the
+    two must be the same arithmetic, not two copies of it."""
+    from turboquant_mlx.stream.loader import _auto_cache_budget
+
+    model_bytes = _MINI_RESIDENT + _MINI_EXPERTS
+    loader = _auto_cache_budget(model_bytes, _MINI_EXPERTS, _MINI_WSS)
+    plan = auto_cache_budget(_MINI_WSS, _MINI_RESIDENT, _MINI_EXPERTS)
+    assert loader == plan, (
+        f"loader would use {loader / _GB:.2f} GB but plan advertises "
+        f"{plan / _GB:.2f} GB")
+
+
+def test_plan_advertises_it_in_the_flag_a_user_reads(tmp_path):
+    """End-to-end over the rendered flag string. The drift guard above proves
+    the two functions agree; this proves plan actually *prints* that result
+    rather than a stale expression alongside it — which is exactly the shape
+    the original bug had."""
+    import json
+    import struct
+
+    from turboquant_mlx.plan import build_plan
+
+    # A 30 GB MoE in 300 bytes. `turboquant-plan` reads only the safetensors
+    # *header* — that is its whole reason to exist — so a hand-written header
+    # declaring large shapes with no tensor data behind it exercises the real
+    # code path. Reaching the streaming branch needs a model genuinely bigger
+    # than the machine, which is not something you can allocate in a test.
+    hdr, off = {}, 0
+    for name, shape in (
+            ("model.layers.0.mlp.switch_mlp.gate_proj.weight",
+             (256, 4096, 7168)),                       # ~30 GB of experts
+            ("model.layers.0.self_attn.q_proj.weight", (4096, 4096))):
+        n = 1
+        for s in shape:
+            n *= s
+        hdr[name] = {"dtype": "U32", "shape": list(shape),
+                     "data_offsets": [off, off + n * 4]}
+        off += n * 4
+    blob = json.dumps(hdr).encode()
+    d = tmp_path / "moe"
+    d.mkdir()
+    with open(d / "model.safetensors", "wb") as f:
+        f.write(struct.pack("<Q", len(blob)))
+        f.write(blob)
+    (d / "config.json").write_text(
+        '{"model_type": "qwen3_next", "num_hidden_layers": 4, '
+        '"hidden_size": 4096, "num_attention_heads": 32, '
+        '"num_key_value_heads": 4}')
+
+    # the machine the constants were measured on
+    plan = build_plan(str(d), wired_gb=_MINI_WSS / _GB, ram_gb=17.18)
+    assert plan["verdict"]["mode"] == "streaming", (
+        "a 30 GB model on a 12.71 GB machine must plan as streaming; this test "
+        "checks nothing otherwise")
+
+    flag = next(f for f in plan["flags"] if "--cache-budget-gb" in f)
+    expected = auto_cache_budget(plan["machine"]["wss_bytes"],
+                                 plan["model"]["resident_bytes"],
+                                 plan["model"]["expert_bytes"])
+    assert f"{expected / _GB:.1f} GB" in flag, (
+        f"plan prints {flag!r}, loader would use {expected / _GB:.2f} GB")
+
+
+def test_local_path_typo_says_so(tmp_path):
+    """A path that isn't there is a typo, not a repo id.
+
+    `_resolve` used to hand anything non-directory to the hub, so
+    `turboquant-plan --model ~/typo` reported "Repo id must be in the form
+    'repo_name' or 'namespace/repo_name'" — which sends you hunting for a
+    naming rule when a directory is simply missing.
+    """
+    import pytest
+
+    from turboquant_mlx.plan import _resolve
+
+    with pytest.raises(FileNotFoundError, match="no such directory"):
+        _resolve(str(tmp_path / "not-there"))
+
+    # a real repo id must still be treated as remote, not as a broken path
+    target, remote = _resolve("manjunathshiva/Laguna-S-2.1-tqTe-g64")
+    assert remote or os.path.isdir(target)

--- a/tests/test_expert_naming.py
+++ b/tests/test_expert_naming.py
@@ -2,13 +2,17 @@
 
 The companion to ``test_stream_switch_attr.py``: that one pins the *module*
 swap, this one pins the *byte accounting* over the same two naming conventions.
-Both halves have to agree, and once they didn't — the swap learned laguna's
-``mlp.experts`` container while ``plan.py`` and ``_streamed_expert_bytes`` kept
-matching only ``switch_mlp``. Laguna therefore streamed correctly but reported
-zero streamable bytes, so ``turboquant-plan`` called a streamable model
-resident-only (❌ on a 16 GB Mac that in fact runs it at a 7.3 GB peak) and
-``--cache-budget-gb auto`` sized its cache from a resident figure that wrongly
-included all 28.7 GB of experts.
+Both halves have to agree, and in every release up to and including 0.18.0
+neither did — all four call sites matched ``switch_mlp`` alone, so on laguna's
+``mlp.experts`` container the swap replaced nothing and the accounting counted
+nothing.
+
+Fixing the swap first (mid-branch) left the accounting still wrong for a while,
+and it is worth knowing what that half alone costs: laguna streams correctly
+but reports zero streamable bytes, so ``turboquant-plan`` calls a streamable
+model resident-only (❌ on a 16 GB Mac that in fact runs it at a 7.3 GB peak)
+and ``--cache-budget-gb auto`` sizes its cache from a resident figure that
+wrongly includes all 28.7 GB of experts. Both halves ship fixed in 0.18.0.
 """
 
 import json

--- a/tests/test_stream_autobudget.py
+++ b/tests/test_stream_autobudget.py
@@ -9,10 +9,10 @@ import argparse
 
 import pytest
 
+from turboquant_mlx.cache_budget import MIN_BUDGET_BYTES as _AUTO_MIN_BUDGET_BYTES
+from turboquant_mlx.cache_budget import projected_peak_bytes
 from turboquant_mlx.stream.loader import (
-    _AUTO_MIN_BUDGET_BYTES,
     _AUTO_RESERVE_BYTES,
-    _AUTO_WSS_FRACTION,
     _auto_cache_budget,
     _streamed_expert_bytes,
 )
@@ -20,13 +20,21 @@ from turboquant_mlx.stream.loader import (
 
 def test_auto_budget_mini_case():
     # 16 GB mini serving the 122B ternary: model ~31 GB of which ~28 GB is
-    # experts, working set ~11.5 GB. Expected: 0.8*11.5 - 3 - 2 = ~4.2 GB —
-    # matching the hand-tuned known-good --cache-budget-gb 4.
+    # experts, working set ~11.5 GB.
+    #
+    # This used to assert 0.8*wss - resident - 2 GB = ~4.2 GB, chosen to match
+    # a hand-tuned --cache-budget-gb 4. A later sweep on the same class of
+    # machine showed that reserve was double-counted (a 20% haircut *and* a
+    # 2 GB subtraction) and cost real throughput, so the budget is now derived
+    # from the measured peak model instead: everything the working set has,
+    # minus the resident weights, minus what a run actually needs on top.
     b = _auto_cache_budget(model_bytes=31_000_000_000,
                            expert_bytes=28_000_000_000,
                            wss_bytes=11_500_000_000)
-    assert b == int(0.8 * 11_500_000_000) - 3_000_000_000 - _AUTO_RESERVE_BYTES
-    assert 3.5e9 < b < 5e9
+    assert b == 11_500_000_000 - 3_000_000_000 - _AUTO_RESERVE_BYTES
+    assert 5e9 < b < 6e9
+    # and the thing that actually matters: it still fits
+    assert projected_peak_bytes(b, 3_000_000_000) < 11_500_000_000
 
 
 def test_auto_budget_clamps_to_all_experts_on_roomy_machine():
@@ -91,8 +99,11 @@ def test_stream_generate_budget_arg_type():
         _budget_arg("lots")
 
 
-def test_wss_fraction_sane():
-    assert 0.5 <= _AUTO_WSS_FRACTION <= 0.9
+def test_reserve_sane():
+    """The reserve replaced the working-set fraction. Too small and a streaming
+    run peaks over the Metal cap; too large and it repeats the mistake it was
+    written to fix."""
+    assert 2.0e9 <= _AUTO_RESERVE_BYTES <= 4.0e9
 
 
 def test_auto_budget_experts_smaller_than_floor_cap_at_experts():


### PR DESCRIPTION
Follow-up to #66/#68, from measurements taken on the 16 GB M4 mini while validating Laguna streaming.

## `auto` meant two different numbers

`turboquant-plan` exists to tell you what the streaming loader will do before you download the model. It was telling you something else:

| | ceiling used | reserve | result on the mini |
|---|---|---|---|
| `plan.py` | `max(wss, raisable)` = 15.46 GB | 1 GB | **9.1 GB** |
| `stream/loader.py` | `wss` = 12.71 GB | 2 GB | **5.89 GB** |

9.1 GB projects a peak near **12.4 GB against that machine's 12.71 GB cap**. plan sized against a limit only reachable via `sudo sysctl -w iogpu.wired_limit_mb`, which it never recommends in the streaming branch — so it was advertising a budget premised on a step the user was never told to take.

The arithmetic now lives in `cache_budget.py` and both import it, the same shape as `expert_naming.py` in #66.

## It was also double-conservative

The old formula took 80% of the working set **and** subtracted a 2 GB reserve. On the mini that reserved 4.5 GB against a measured need of ~1.05 GB plus KV.

A `--cache-budget-gb` sweep (2 / 4 / 5.89 / 6 / 8 GB, same prompt, greedy, expert-learning and hot-lists off) put mlx's peak at **budget + 3.33 GB** every time, within 40 MB:

| budget | peak | tok/s | hit rate | GB read |
|---|---|---|---|---|
| 2.00 | 5.31 | 1.152 | 39.8% | 168.2 |
| 4.00 | 7.32 | 1.257 | 56.2% | 122.4 |
| 5.89 (`auto`, old) | 9.23 | 1.364 | 66.1% | 94.6 |
| 6.00 | 9.34 | 1.354 | 66.5% | 93.4 |
| 8.00 | 11.35 | 1.578 | 75.6% | 68.0 |

2.28 GB of that constant is the resident weights, which the caller already knows, leaving ~1.05 GB of runtime overhead that tracks neither the cache nor the model. The budget is derived from that relation now, so `auto` picks **7.4 GB** where it picked 5.89 — worth ~15% throughput on this machine — and still projects a peak of 10.8 GB with 1.9 GB of headroom.

`turboquant-plan` prints the projected peak next to the budget, so the claim is checkable:

```
--cache-budget-gb auto   (~7.4 GB here, peaking near 10.8 GB)
```

Verified against hardware: the model predicts 11.38 GB at an 8 GB budget; the mini measured 11.35.

## Also in here

- **`turboquant-plan --model ~/typo`** reported `Repo id must be in the form 'repo_name' or 'namespace/repo_name'`, because anything that was not a directory got handed to the Hub. It now says the directory is missing. (Hit this for real: `export MODEL=~/laguna-...` before the model was at that path.)
- **`release.yml` runs the sdist-contents guard** that 0.18.1 added to `ci.yml` only. CI gates `main` and tags come from `main`, so this is belt-and-braces — but it is the job whose output reaches PyPI.
- **`test_expert_naming.py`'s docstring** claimed Laguna streamed correctly before 0.18.0 while only the byte accounting was wrong. It didn't: that was true of a mid-branch state, and every released version swapped zero projections. Corrected, since it is the note someone will hit when they wonder whether streaming ever worked.

## Tests

**391 passed** (381 + 10). New `tests/test_cache_budget.py` covers:

- the peak model against **all five** measured sweep points (±0.2 GB)
- `auto` fits under the cap with >1 GB headroom, and is no longer smaller than the formula it replaced
- clamps (experts-smaller-than-floor, squeezed machine), monotonicity in working set, known-KV shrinking the reserve
- **a drift guard**: `plan.py` and `stream/loader.py` must return the identical budget for identical inputs
- **end-to-end through the rendered flag string**, because a correct number computed and then printed from a stale expression is still a lie. Reaching the streaming branch needs a model bigger than the machine, so the fixture is a hand-written safetensors *header* declaring 30 GB with no tensor data behind it — which is exactly how `plan` reads a repo anyway.

`tests/test_stream_autobudget.py::test_auto_budget_mini_case` asserted the old formula exactly and has been updated rather than deleted, with the reasoning for the change recorded in place.