### PR TITLE
feat: Kimi K3 (2.8T MoE) — model port, mxfp4 conversion, planner + expert streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, 
 | Laguna-S-2.1 (118B) | BF16 (original) | 16 | — | ~219 GB | *Doesn't fit 64GB* |
 | Laguna-S-2.1 (118B) | [Affine 4-bit](https://huggingface.co/mlx-community/Laguna-S-2.1-4bit) | 4 | — | ~64 GB | *Exceeds Metal's ~56 GB working set — won't load* |
 | **[Laguna-S-2.1 (118B, ternary experts)](https://huggingface.co/manjunathshiva/Laguna-S-2.1-tqTe-g64)** | **TQ 3-attn / ternary trit-packed experts, gs=64** | **1.6/3 mix** | **—** | **~27 GB** | **~12.5 tok/s · fully resident on 64 GB with ~25 GB spare · Opencode pass** |
+| **Kimi K3 (2.8T MoE)** | **TQ 3-attn / ternary experts / 4-bit expert-down, gs=64** | **1.6/3/4 mix** | **—** | **869 GB** | **2.3 tok/s (Mac Studio 512 GB, top-8) · 1.2 tok/s at native top-16 · streams experts from disk** |
 
 ## Key Results — KV Cache Compression
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, 
 | Laguna-S-2.1 (118B) | BF16 (original) | 16 | — | ~219 GB | *Doesn't fit 64GB* |
 | Laguna-S-2.1 (118B) | [Affine 4-bit](https://huggingface.co/mlx-community/Laguna-S-2.1-4bit) | 4 | — | ~64 GB | *Exceeds Metal's ~56 GB working set — won't load* |
 | **[Laguna-S-2.1 (118B, ternary experts)](https://huggingface.co/manjunathshiva/Laguna-S-2.1-tqTe-g64)** | **TQ 3-attn / ternary trit-packed experts, gs=64** | **1.6/3 mix** | **—** | **~27 GB** | **~12.5 tok/s · fully resident on 64 GB with ~25 GB spare · Opencode pass** |
-| **Kimi K3 (2.8T MoE)** | **TQ 3-attn / ternary experts / 4-bit expert-down, gs=64** | **1.6/3/4 mix** | **—** | **869 GB** | **2.3 tok/s (Mac Studio 512 GB, top-8) · 1.2 tok/s at native top-16 · streams experts from disk** |
+| **Kimi K3 (2.8T MoE)** | **TQ 3-attn / ternary experts / 4-bit expert-down, gs=64** | **1.6/3/4 mix** | **—** | **931 GB** | **2.3 tok/s (Mac Studio 512 GB, top-8) · 1.2 tok/s at native top-16 · streams experts from disk** |
 
 ## Key Results — KV Cache Compression
 

--- a/compat.py
+++ b/compat.py
@@ -109,6 +109,116 @@ def _register_laguna_model():
     sys.modules["mlx_lm.models.laguna"] = _laguna
 
 
+def _register_kimi_k3_model():
+    """Register the MLX Kimi K3 model so mlx-lm's ``_get_classes`` can find it.
+
+    Same mechanism as :func:`_register_laguna_model`: K3 checkpoints carry
+    ``model_type: "kimi_k3"`` at the top level (the text tower inside
+    ``text_config`` is ``kimi_linear``, which mlx-lm knows, but the wrapper is
+    what ``_get_classes`` dispatches on). Idempotent; self-disables the moment
+    mlx-lm ships native support.
+    """
+    import sys
+
+    if "mlx_lm.models.kimi_k3" in sys.modules:
+        return
+    try:
+        import mlx_lm.models.kimi_k3  # noqa: F401 — native support exists; defer
+        return
+    except ImportError:
+        pass
+
+    from turboquant_mlx.models import kimi_k3 as _kimi_k3
+
+    sys.modules["mlx_lm.models.kimi_k3"] = _kimi_k3
+
+
+def _patch_compressed_tensors_mxfp4():
+    """Fix mlx-lm's quantization mode for compressed-tensors mxfp4 checkpoints.
+
+    ``mlx_lm.utils.load_model`` maps ``quant_method == "compressed-tensors"`` to
+    ``{"group_size": 32, "bits": 4, "mode": "affine"}`` without consulting
+    ``quantization_config["format"]``. For ``mxfp4-pack-quantized`` checkpoints
+    (Kimi K3's routed experts) the packed nibbles are fp4-e2m1 codes with E8M0
+    uint8 scales — decoding them as affine int4 produces garbage. MLX decodes
+    them bit-exactly with ``mode="mxfp4"`` (verified against compressed-tensors
+    0.17.1), so rewrite the mode before the quantize wrapper runs.
+
+    Self-disables once upstream branches on the format itself.
+    """
+    import inspect
+
+    import mlx_lm.utils as _utils
+
+    if getattr(_utils, "_tq_mxfp4_patched", False):
+        return
+
+    orig = _utils.load_model
+    sig = inspect.signature(orig)
+
+    def load_model(*args, **kwargs):
+        bound = sig.bind(*args, **kwargs)
+        bound.apply_defaults()
+        try:
+            config = _utils.load_config(bound.arguments["model_path"])
+        except Exception:
+            config = {}
+        qc = config.get("quantization_config") or {}
+        if not qc:
+            qc = (config.get("text_config") or {}).get("quantization_config") or {}
+        if (
+            qc.get("quant_method") == "compressed-tensors"
+            and qc.get("format") == "mxfp4-pack-quantized"
+        ):
+            # A "quantization" key in the merged config takes priority over the
+            # legacy quantization_config branch, so injecting it via
+            # model_config routes the load through mode="mxfp4".
+            mc = dict(bound.arguments.get("model_config") or {})
+            mc["quantization"] = {"group_size": 32, "bits": 4, "mode": "mxfp4"}
+            bound.arguments["model_config"] = mc
+        return orig(*bound.args, **bound.kwargs)
+
+    load_model.__signature__ = sig
+    _utils.load_model = load_model
+    _utils._tq_mxfp4_patched = True
+
+
+def _patch_local_tokenizer_trust():
+    """Opt local-directory models into their own tokenizer code.
+
+    Kimi K3 (and other repos with a custom tokenizer class, e.g.
+    ``tokenization_kimi.py``) requires ``trust_remote_code=True`` to load —
+    without it transformers either raises or blocks on an interactive prompt,
+    which kills ``turboquant-generate``/``turboquant-serve`` on any converted
+    K3 model. For a *local directory* the "remote" code is already sitting on
+    the user's disk next to the weights they chose to run, so defaulting the
+    flag on is the same trust decision they already made. Hub repo ids are
+    left untouched.
+    """
+    from pathlib import Path
+
+    import mlx_lm.tokenizer_utils as _tok
+
+    if getattr(_tok, "_tq_local_trust_patched", False):
+        return
+
+    orig = _tok.load
+
+    def load(model_path, tokenizer_config_extra=None, eos_token_ids=None):
+        extra = dict(tokenizer_config_extra or {})
+        if "trust_remote_code" not in extra and Path(model_path).is_dir():
+            extra["trust_remote_code"] = True
+        return orig(model_path, extra, eos_token_ids=eos_token_ids)
+
+    _tok.load = load
+    _tok._tq_local_trust_patched = True
+    # mlx_lm.utils imports it by value as _load_tokenizer; re-point that too.
+    import mlx_lm.utils as _utils
+
+    if getattr(_utils, "_load_tokenizer", None) is orig:
+        _utils._load_tokenizer = load
+
+
 def _patch_glm47_tool_name_strip():
     """Strip whitespace off GLM-style parsed tool-call function names.
 
@@ -155,4 +265,7 @@ def _patch_glm47_tool_name_strip():
 
 _patch_nemotron_h_pattern()
 _register_laguna_model()
+_register_kimi_k3_model()
+_patch_compressed_tensors_mxfp4()
+_patch_local_tokenizer_trust()
 _patch_glm47_tool_name_strip()

--- a/compat.py
+++ b/compat.py
@@ -183,20 +183,40 @@ def _patch_compressed_tensors_mxfp4():
     _utils._tq_mxfp4_patched = True
 
 
-def _patch_local_tokenizer_trust():
-    """Opt local-directory models into their own tokenizer code.
-
-    Kimi K3 (and other repos with a custom tokenizer class, e.g.
-    ``tokenization_kimi.py``) requires ``trust_remote_code=True`` to load —
-    without it transformers either raises or blocks on an interactive prompt,
-    which kills ``turboquant-generate``/``turboquant-serve`` on any converted
-    K3 model. For a *local directory* the "remote" code is already sitting on
-    the user's disk next to the weights they chose to run, so defaulting the
-    flag on is the same trust decision they already made. Hub repo ids are
-    left untouched.
-    """
+def is_local_kimi_k3(model_path) -> bool:
+    """True iff ``model_path`` is a local directory whose ``config.json``
+    declares ``model_type: "kimi_k3"`` — the gate for auto-trusting the K3
+    tokenizer code that ships inside the checkpoint directory."""
+    import json
     from pathlib import Path
 
+    p = Path(model_path)
+    if not p.is_dir():
+        return False
+    try:
+        with open(p / "config.json") as f:
+            cfg = json.load(f)
+    except (OSError, ValueError):
+        return False
+    return cfg.get("model_type") == "kimi_k3"
+
+
+def _patch_kimi_k3_tokenizer_trust():
+    """Opt local Kimi K3 directories into their own tokenizer code.
+
+    K3 repos ship a custom tokenizer class (``tokenization_kimi.py``) that
+    requires ``trust_remote_code=True`` to load — without it transformers
+    either raises or blocks on an interactive prompt, which kills
+    ``turboquant-generate``/``turboquant-serve`` on any converted K3 model.
+
+    The flag is injected only when the model path is a *local directory*
+    whose ``config.json`` says ``model_type: "kimi_k3"`` — never as a
+    blanket local-directory default. Downloading tokenizer code and
+    executing it are separate trust decisions (``hf download`` writes
+    ``tokenization_*.py`` without running it), so every other model keeps
+    transformers' explicit opt-in behavior, and an explicit
+    ``trust_remote_code`` from the caller always wins.
+    """
     import mlx_lm.tokenizer_utils as _tok
 
     if getattr(_tok, "_tq_local_trust_patched", False):
@@ -206,7 +226,7 @@ def _patch_local_tokenizer_trust():
 
     def load(model_path, tokenizer_config_extra=None, eos_token_ids=None):
         extra = dict(tokenizer_config_extra or {})
-        if "trust_remote_code" not in extra and Path(model_path).is_dir():
+        if "trust_remote_code" not in extra and is_local_kimi_k3(model_path):
             extra["trust_remote_code"] = True
         return orig(model_path, extra, eos_token_ids=eos_token_ids)
 
@@ -267,5 +287,5 @@ _patch_nemotron_h_pattern()
 _register_laguna_model()
 _register_kimi_k3_model()
 _patch_compressed_tensors_mxfp4()
-_patch_local_tokenizer_trust()
+_patch_kimi_k3_tokenizer_trust()
 _patch_glm47_tool_name_strip()

--- a/config.py
+++ b/config.py
@@ -106,6 +106,16 @@ class TurboQuantConfig:
         MLP / MoE expert linears use ``mlp_group_size`` when set so a sub-2-bit
         expert tier can carry a finer block scale than the attention tier;
         everything else uses ``group_size``.
+
+        Deliberately, the ``shared_experts`` / ``routed_expert_*`` exemption in
+        :meth:`bits_for_path` is NOT mirrored here: that exemption protects
+        always-on projections from a quality-losing sub-2-bit tier, whereas a
+        finer ``mlp_group_size`` on those same projections only adds scale
+        resolution at negligible size cost. Exempting them would hand them the
+        coarser attention-tier group size — strictly worse. (Bit-width is
+        recovered from the on-disk codebook at load; group size is re-derived
+        through this same rule from the saved config, so convert and load
+        agree by construction and existing checkpoints are unaffected.)
         """
         if self.mlp_group_size is not None:
             for p in path.split("."):

--- a/config.py
+++ b/config.py
@@ -79,11 +79,24 @@ class TurboQuantConfig:
         Attention-block linears use ``attn_bits`` when set; MLP / MoE expert
         linears use ``mlp_bits`` when set; everything else (and either
         override left as None) falls back to ``bits``.
+
+        Always-on MoE plumbing that lives under the ``mlp`` block — shared
+        experts and latent-MoE projections (Kimi K3's
+        ``routed_expert_{down,up}_proj``) — is exempted from the ``mlp_bits``
+        tier: unlike a routed expert (1 of 896, top-16), these run on every
+        token, so dropping them to a sub-2-bit expert tier costs quality on
+        the whole stream for a rounding-error size saving.
         """
-        for p in path.split("."):
+        parts = path.split(".")
+        for p in parts:
             if p in ("self_attn", "attention", "linear_attn"):
                 return self.attn_bits if self.attn_bits is not None else self.bits
             if p in ("mlp", "feed_forward"):
+                if any(
+                    q == "shared_experts" or q.startswith("routed_expert_")
+                    for q in parts
+                ):
+                    return self.bits
                 return self.mlp_bits if self.mlp_bits is not None else self.bits
         return self.bits
 

--- a/convert.py
+++ b/convert.py
@@ -15,6 +15,7 @@ from pathlib import Path
 import mlx.core as mx
 
 import turboquant_mlx.compat  # noqa: F401 — registers upstream patches on import
+from turboquant_mlx.compat import is_local_kimi_k3
 from turboquant_mlx.config import TurboQuantConfig
 from turboquant_mlx.quantize_model import turboquant_quantize
 
@@ -78,9 +79,11 @@ def convert(
     print(f"[INFO] Loading model from {hf_path}")
     model, tokenizer, config = load(
         hf_path,
-        # Custom tokenizer classes (e.g. Kimi K3's tokenization_kimi.py) need
-        # the local code opt-in; local files were already inspected by the user.
-        tokenizer_config={"trust_remote_code": True},
+        # K3's custom tokenizer class (tokenization_kimi.py) needs the code
+        # opt-in; gated on a local kimi_k3 config so no other model gets it.
+        tokenizer_config=(
+            {"trust_remote_code": True} if is_local_kimi_k3(hf_path) else {}
+        ),
         return_config=True,
         lazy=True,
     )

--- a/convert.py
+++ b/convert.py
@@ -78,6 +78,9 @@ def convert(
     print(f"[INFO] Loading model from {hf_path}")
     model, tokenizer, config = load(
         hf_path,
+        # Custom tokenizer classes (e.g. Kimi K3's tokenization_kimi.py) need
+        # the local code opt-in; local files were already inspected by the user.
+        tokenizer_config={"trust_remote_code": True},
         return_config=True,
         lazy=True,
     )

--- a/convert_streaming.py
+++ b/convert_streaming.py
@@ -31,6 +31,7 @@ from mlx_lm.utils import (
 )
 
 import turboquant_mlx.compat  # noqa: F401 — registers upstream patches on import
+from turboquant_mlx.compat import is_local_kimi_k3
 from turboquant_mlx.config import TurboQuantConfig
 from turboquant_mlx.quantize_model import turboquant_quantize
 
@@ -144,9 +145,11 @@ def convert_streaming(
     print(f"[INFO] Loading model from {hf_path} (lazy)")
     model, tokenizer, config = load(
         hf_path,
-        # Custom tokenizer classes (e.g. Kimi K3's tokenization_kimi.py) need
-        # the local code opt-in; local files were already inspected by the user.
-        tokenizer_config={"trust_remote_code": True},
+        # K3's custom tokenizer class (tokenization_kimi.py) needs the code
+        # opt-in; gated on a local kimi_k3 config so no other model gets it.
+        tokenizer_config=(
+            {"trust_remote_code": True} if is_local_kimi_k3(hf_path) else {}
+        ),
         return_config=True,
         lazy=True,
     )

--- a/convert_streaming.py
+++ b/convert_streaming.py
@@ -142,7 +142,14 @@ def convert_streaming(
     )
 
     print(f"[INFO] Loading model from {hf_path} (lazy)")
-    model, tokenizer, config = load(hf_path, return_config=True, lazy=True)
+    model, tokenizer, config = load(
+        hf_path,
+        # Custom tokenizer classes (e.g. Kimi K3's tokenization_kimi.py) need
+        # the local code opt-in; local files were already inspected by the user.
+        tokenizer_config={"trust_remote_code": True},
+        return_config=True,
+        lazy=True,
+    )
     arch = config.get("model_type", "unknown")
     print(f"[INFO] Streaming TurboQuant convert: {bits}-bit, gs={group_size}, "
           f"arch={arch}, shard={max_file_size_gb} GB")

--- a/layers/polar_switch_linear.py
+++ b/layers/polar_switch_linear.py
@@ -284,6 +284,7 @@ class PolarQuantizedSwitchLinear(nn.Module):
         float_weight: mx.array = None,
         bias: mx.array = None,
         ternary: bool = False,
+        weight_shape: tuple = None,
     ) -> "PolarQuantizedSwitchLinear":
         """Create from an existing SwitchLinear with FP16/BF16 weights.
 
@@ -296,21 +297,36 @@ class PolarQuantizedSwitchLinear(nn.Module):
             group_size: Elements per quantization group.
             seed: Random seed for Hadamard rotation signs.
             needs_rotation: Whether this layer needs online input rotation.
-            float_weight: Optional pre-dequantized weight (N, out, in) float.
+            float_weight: Optional pre-dequantized weight (N, out, in) float,
+                or a callable ``f(e) -> (out, in) float`` for per-expert lazy
+                dequantization (pass ``weight_shape`` alongside).
             bias: Optional bias tensor (N, out) float.
+            weight_shape: (N, out, in), required when float_weight is callable.
 
         Returns:
             New PolarQuantizedSwitchLinear with quantized expert weights.
         """
-        if float_weight is not None:
+        if callable(float_weight):
+            # Per-expert dequant source: float_weight(e) -> (out, in) float.
+            # Keeps peak memory at one expert instead of the whole stacked
+            # tensor (~30 GB for an 896-expert layer, measured).
+            if weight_shape is None:
+                raise ValueError("weight_shape required with a callable float_weight")
+            get_expert = float_weight
+            num_experts, output_dims, input_dims = weight_shape
+            has_bias = bias is not None
+        elif float_weight is not None:
             weight_3d = float_weight
+            get_expert = lambda e: weight_3d[e]  # noqa: E731
+            num_experts, output_dims, input_dims = weight_3d.shape
             has_bias = bias is not None
         else:
             weight_3d = switch_linear.weight
+            get_expert = lambda e: weight_3d[e]  # noqa: E731
+            num_experts, output_dims, input_dims = weight_3d.shape
             has_bias = "bias" in switch_linear
             if has_bias:
                 bias = switch_linear.bias
-        num_experts, output_dims, input_dims = weight_3d.shape
 
         if input_dims % group_size != 0:
             raise ValueError(
@@ -340,7 +356,7 @@ class PolarQuantizedSwitchLinear(nn.Module):
 
         # Process experts one-by-one, eval each to flush graph immediately
         for e in range(num_experts):
-            expert_w = weight_3d[e]  # view into (output_dims, input_dims)
+            expert_w = get_expert(e)  # (output_dims, input_dims)
             result = polar_quantize_weight(
                 expert_w,
                 bits=bits,
@@ -358,7 +374,8 @@ class PolarQuantizedSwitchLinear(nn.Module):
             del result, expert_w
 
         # Free original weight reference
-        del weight_3d
+        del get_expert
+        weight_3d = None  # release stacked source if one was materialized
 
         # Create layer
         layer = cls(

--- a/model_card_kimi_k3.md
+++ b/model_card_kimi_k3.md
@@ -1,0 +1,76 @@
+---
+library_name: mlx
+license: other
+license_name: modified-mit
+pipeline_tag: text-generation
+base_model: moonshotai/Kimi-K3
+tags:
+- mlx
+- turboquant
+- moe
+- kimi
+---
+
+# Kimi-K3-tq3a-tqTe-down4-g64
+
+**Ternary-expert** TurboQuant quantization of Moonshot AI's **Kimi K3** — a **2.8-trillion-parameter** Mixture-of-Experts model — produced with [TurboQuant-MLX](https://github.com/manjunathshiva/turboquant-mlx).
+
+This is the largest model TurboQuant-MLX has run to date. The BF16 checkpoint is ~5.6 TB; this build lands at **869 GB on disk** and generates coherent, high-quality text on a **single 512 GB Apple Silicon Mac Studio** by streaming MoE experts from disk — no cluster, no GPUs.
+
+## Model Details
+
+- **Base model**: Moonshot AI Kimi K3 (`model_type: kimi_k3`) — text tower of the `KimiK3ForConditionalGeneration` multimodal reference, vision tower dropped
+- **Architecture**: 93 layers, hidden size 7168, **896 routed experts (native top-16) + 2 shared experts**, MoE intermediate 3072, routed-expert latent 3584, vocab 163,840 — ~2.8T total / ~30B active params
+  - **Hybrid attention** — 69 KDA (Kimi Delta Attention) linear-attention layers + 24 gated-NoPE MLA layers with q-LoRA, on a mostly-3:1 cadence
+  - **Stable LatentMoE** — routed experts operate in a 3584-dim latent space; the top-k weighted sum happens in latent space, then a shared RMSNorm, then the up-projection
+  - **`situ` activation**, **Attention Residuals (AttnRes)**, bounded KDA gate — all reproduced faithfully (fp32 parity vs the HF reference ≤ 2.7e-6)
+- **Quantization**: **TurboQuant** (Hadamard rotation, seed 42 + Lloyd-Max codebook), group size 64
+  - Attention (`q/k/v/o_proj`, q-LoRA, MLA latents) → **3-bit**
+  - Routed experts `gate/up_proj` → **ternary** (trit-packed, ~1.58-bit)
+  - Routed experts `down_proj` → **4-bit** (the recall-sensitive projection kept wider)
+  - Routers (`mlp.gate`) → full precision (auto-skipped — never quantized)
+- **Size**: **869 GB** across **186** shards (vs ~5.6 TB BF16). Experts alone are ~903 GB uncompressed-equivalent; the always-resident (non-expert) working set is ~30 GB.
+
+The recipe name decodes as **tq3a** (3-bit attention) / **tqTe** (ternary experts) / **down4** (4-bit expert down-projection) / **g64** (group size 64).
+
+> **Note:** this is an instruct/thinking model. Use the chat template (the streaming generator applies it by default). Thinking-mode output — a reasoning block before the answer — is normal.
+
+## Quality
+
+Even at ternary experts with a **2× K-cut** (top-16 → top-8 routing), real-use quality holds. Chat-template thinking-mode output on "Explain how Rayleigh scattering works, and why the sky is blue but sunsets are red" is accurate throughout — the λ⁻⁴ law, the (700/450)⁴ ≈ 5.9× blue/red scattering ratio, and the violet/ozone/eye-sensitivity nuance are all correct, with a clean reasoning structure.
+
+## Running it (expert streaming)
+
+At 869 GB this model does not fit resident on any single Mac. It runs by **streaming MoE experts from disk** — each token pages in only its router-selected experts (pinned hot-list + LRU cache), so the big expert tensors are never all in memory at once. Non-expert weights (attention, routers, shared experts, embeddings) stay resident.
+
+Measured on a **Mac Studio (M-series, 512 GB)** with `iogpu.wired_limit_mb=512000`, a 506 GB expert cache (`--cache-budget-gb auto`), the shipped hot-expert list, and `--no-chat-template` for controlled A/B (200-token generation):
+
+| Config | Decode speed | Expert hit-rate | Critical (blocking) disk reads | Peak memory |
+|---|---|---|---|---|
+| top-16, `--prefetch-workers 8` | 0.83 tok/s | 99.6% | 14.9 GB | 534 GB |
+| top-16, `--prefetch-workers 16` | **1.18 tok/s** | 99.6% | 13.4 GB | 530 GB |
+| top-16, `--prefetch-workers 32` | 1.14 tok/s | 99.6% | 11.7 GB | 533 GB |
+| **top-8 (2× K-cut), `--prefetch-workers 16`** | **2.30 tok/s** | **100%** | **0.0 GB** | 400 GB |
+
+The `--max-active-experts 8` lever (native top-16 → top-8) roughly halves per-token expert I/O for a ~2× decode speed-up at no observed quality cost. Prefetch parallelism matters: 16 workers is the knee — at 8 the reads serialize and lose ~30%, past 16 there's no further gain (decode is no longer disk-bandwidth-bound).
+
+### Recommended invocation
+
+```bash
+# Raise the Metal wired ceiling on a 512 GB box (resets on reboot)
+sudo sysctl iogpu.wired_limit_mb=512000
+
+python3 -m turboquant_mlx.stream.stream_generate \
+    --model ./Kimi-K3-tq3a-tqTe-down4-g64 \
+    --prompt "Explain how Rayleigh scattering works." \
+    --max-tokens 500 --cache-budget-gb auto \
+    --max-active-experts 8 --prefetch-workers 16
+```
+
+Kimi K3 uses a tiktoken-based tokenizer — install `tiktoken` and `blobfile` alongside TurboQuant-MLX.
+
+## Provenance & verification
+
+- fp32 forward parity vs the HF `transformers` reference: ≤ 2.7e-6 (harness in `scripts/k3/kimi_k3_parity.py`).
+- mxfp4 expert unpack is bit-exact with MLX `mode="mxfp4"` (`weight_packed.view(uint32)` + raw u8 scales).
+- Streaming output is functionally equivalent to the fully-materialized model; experts are paged, not approximated further.

--- a/model_card_kimi_k3.md
+++ b/model_card_kimi_k3.md
@@ -15,7 +15,7 @@ tags:
 
 **Ternary-expert** TurboQuant quantization of Moonshot AI's **Kimi K3** — a **2.8-trillion-parameter** Mixture-of-Experts model — produced with [TurboQuant-MLX](https://github.com/manjunathshiva/turboquant-mlx).
 
-This is the largest model TurboQuant-MLX has run to date. The BF16 checkpoint is ~5.6 TB; this build lands at **869 GB on disk** and generates coherent, high-quality text on a **single 512 GB Apple Silicon Mac Studio** by streaming MoE experts from disk — no cluster, no GPUs.
+This is the largest model TurboQuant-MLX has run to date. The BF16 checkpoint is ~5.6 TB; this build lands at **931 GB on disk** (867 GiB) and generates coherent, high-quality text on a **single 512 GB Apple Silicon Mac Studio** by streaming MoE experts from disk — no cluster, no GPUs.
 
 ## Model Details
 
@@ -29,7 +29,7 @@ This is the largest model TurboQuant-MLX has run to date. The BF16 checkpoint is
   - Routed experts `gate/up_proj` → **ternary** (trit-packed, ~1.58-bit)
   - Routed experts `down_proj` → **4-bit** (the recall-sensitive projection kept wider)
   - Routers (`mlp.gate`) → full precision (auto-skipped — never quantized)
-- **Size**: **869 GB** across **186** shards (vs ~5.6 TB BF16). Experts alone are ~903 GB uncompressed-equivalent; the always-resident (non-expert) working set is ~30 GB.
+- **Size**: **931 GB** (867 GiB) across **186** shards (vs ~5.6 TB BF16) — ~902 GB of quantized experts + ~30 GB always-resident (non-expert) working set.
 
 The recipe name decodes as **tq3a** (3-bit attention) / **tqTe** (ternary experts) / **down4** (4-bit expert down-projection) / **g64** (group size 64).
 
@@ -41,7 +41,7 @@ Even at ternary experts with a **2× K-cut** (top-16 → top-8 routing), real-us
 
 ## Running it (expert streaming)
 
-At 869 GB this model does not fit resident on any single Mac. It runs by **streaming MoE experts from disk** — each token pages in only its router-selected experts (pinned hot-list + LRU cache), so the big expert tensors are never all in memory at once. Non-expert weights (attention, routers, shared experts, embeddings) stay resident.
+At 931 GB this model does not fit resident on any single Mac. It runs by **streaming MoE experts from disk** — each token pages in only its router-selected experts (pinned hot-list + LRU cache), so the big expert tensors are never all in memory at once. Non-expert weights (attention, routers, shared experts, embeddings) stay resident.
 
 Measured on a **Mac Studio (M-series, 512 GB)** with `iogpu.wired_limit_mb=512000`, a 506 GB expert cache (`--cache-budget-gb auto`), the shipped hot-expert list, and `--no-chat-template` for controlled A/B (200-token generation):
 

--- a/model_card_kimi_k3.md
+++ b/model_card_kimi_k3.md
@@ -54,6 +54,8 @@ Measured on a **Mac Studio (M-series, 512 GB)** with `iogpu.wired_limit_mb=51200
 
 The `--max-active-experts 8` lever (native top-16 → top-8) roughly halves per-token expert I/O for a ~2× decode speed-up at no observed quality cost. Prefetch parallelism matters: 16 workers is the knee — at 8 the reads serialize and lose ~30%, past 16 there's no further gain (decode is no longer disk-bandwidth-bound).
 
+> **Stats-accounting note:** the hit-rate and critical-read columns above were measured when same-layer fan-out reads (pool reads for experts the router has already chosen this token) were counted as prefetch hits. Current builds count those reads as critical-path (`misses`/`bytes_read`, annotated by `fanout_hits` in `stats()`), the same meaning hit-rate has for every other streaming model in this repo — so the same runs now report a lower hit-rate and non-zero critical GB. The tok/s numbers are unaffected; only the accounting changed. Fan-out itself is on by default and can be disabled with `--no-fanout` (recommended on bandwidth-bound external storage, where the coalesced serial read path wins).
+
 ### Recommended invocation
 
 ```bash

--- a/models/kimi_k3.py
+++ b/models/kimi_k3.py
@@ -51,12 +51,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
+# Module-qualified access (not by-value imports): this repo patches mlx-lm
+# internals at runtime as its core mechanism, and a by-value import could
+# never observe such a patch.
 import mlx_lm.models.base as base
-from mlx_lm.models.base import (
-    BaseModelArgs,
-    create_attention_mask,
-    create_ssm_mask,
-)
+from mlx_lm.models.base import BaseModelArgs
 from mlx_lm.models.cache import ArraysCache, KVCache
 from mlx_lm.models.gated_delta import gated_delta_kernel, gated_delta_ops
 from mlx_lm.models.mla import MultiLinear
@@ -693,11 +692,12 @@ class KimiK3TextModel(nn.Module):
             cache = [None] * len(self.layers)
 
         ssm_mask = (
-            create_ssm_mask(h, cache[self.ssm_idx]) if self.ssm_idx is not None
+            base.create_ssm_mask(h, cache[self.ssm_idx])
+            if self.ssm_idx is not None
             else None
         )
         attn_mask = (
-            create_attention_mask(h, cache[self.attn_idx], return_array=True)
+            base.create_attention_mask(h, cache[self.attn_idx], return_array=True)
             if self.attn_idx is not None
             else None
         )

--- a/models/kimi_k3.py
+++ b/models/kimi_k3.py
@@ -51,11 +51,11 @@ from typing import Any, Dict, List, Optional, Tuple
 import mlx.core as mx
 import mlx.nn as nn
 
+import mlx_lm.models.base as base
 from mlx_lm.models.base import (
     BaseModelArgs,
     create_attention_mask,
     create_ssm_mask,
-    scaled_dot_product_attention,
 )
 from mlx_lm.models.cache import ArraysCache, KVCache
 from mlx_lm.models.gated_delta import gated_delta_kernel, gated_delta_ops
@@ -541,7 +541,7 @@ class KimiMLAAttention(nn.Module):
             k = self.embed_q(kv_latent, transpose=False)
             v = self.unembed_out(kv_latent)
 
-        output = scaled_dot_product_attention(
+        output = base.scaled_dot_product_attention(
             q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
         )
 

--- a/models/kimi_k3.py
+++ b/models/kimi_k3.py
@@ -1,0 +1,929 @@
+# Copyright 2026 Manjunath Janardhan
+"""MLX implementation of Moonshot AI's Kimi K3 (``model_type: "kimi_k3"``), text-only.
+
+Ported from the ``transformers`` ``KimiK3ForConditionalGeneration`` reference
+(``modeling_kimi_k3.py`` / ``modeling_kimi_linear.py``) and cross-checked against
+the Moonshot-contributed vLLM K3 implementation. K3 is a 2.8T-parameter MoE
+(93 layers, 896 experts, top-16) whose text tower extends the Kimi Linear
+architecture with several pieces this module reproduces faithfully:
+
+* **Hybrid attention** — 69 KDA (Kimi Delta Attention) linear-attention layers
+  and 24 MLA layers on a mostly-3:1 cadence (``linear_attn_config.kda_layers`` /
+  ``full_attn_layers``, both **1-indexed**; the cadence breaks at the tail —
+  layers 92 and 93 are consecutive MLA).
+* **Bounded KDA gate** — with ``gate_lower_bound`` set (K3: -5.0) the log-decay is
+  ``lower_bound * sigmoid(exp(A_log) * (a + dt_bias))`` — a *replacement* for the
+  standard ``-exp(A_log) * softplus(...)`` form, bounded to ``(lower_bound, 0)``.
+  The checkpoint stores ``A_log`` zero-padded to ``head_dim`` (128); only the
+  first ``num_heads`` (96) entries are real — :meth:`Model.sanitize` slices them.
+* **Full-rank KDA output gate** — ``g_proj: hidden -> heads*head_dim``
+  (``use_full_rank_gate``) instead of Kimi Linear 48B's low-rank pair.
+* **Gated NoPE MLA with q-LoRA** — ``q_a_proj -> q_a_layernorm -> q_b_proj``,
+  no positional encoding anywhere (position comes from the KDA layers), and a
+  sigmoid output gate ``g_proj`` applied between the head-merge and ``o_proj``.
+* **Stable LatentMoE** — routed experts live in a ``routed_expert_hidden_size``
+  (3584) latent space behind shared per-layer ``routed_expert_down_proj`` /
+  ``routed_expert_up_proj`` projections; the top-k weighted sum happens in latent
+  space, then a shared RMSNorm (``latent_moe_use_norm``), then the up-projection.
+  The router reads the full 7168-dim hidden state, NOT the latent.
+* **``situ`` activation** — ``[beta*tanh(g/beta)*sigmoid(g)] * [lb*tanh(u/lb)]``
+  computed in float32 (K3: beta=4.0, linear beta=25.0), used by the dense MLP,
+  the shared experts, and every routed expert.
+* **Attention Residuals (AttnRes)** — every sublayer input is a softmax-weighted
+  mix of the current residual stream and snapshots stashed at each
+  ``attn_res_block_size`` (12) boundary, where the stream also resets. The mixing
+  scores come from RMS-normalized candidates dotted with the fused product
+  ``norm.weight * proj.weight``, but the returned mixture is over the
+  *un-normalized* candidates. Recomputed per token — never cache state.
+
+The checkpoint stores routed experts *per expert* in compressed-tensors
+mxfp4 (``experts.E.w{1,3,2}.weight_packed``/``weight_scale``); ``sanitize``
+stacks them into ``SwitchGLU``'s ``(E, out, in)`` layout, views the packed
+uint8 as uint32 (bit-identical to MLX's ``mode="mxfp4"``; verified against
+compressed-tensors), renames ``block_sparse_moe`` -> ``mlp`` and
+``w1/w3/w2`` -> ``gate/up/down_proj``, and drops the vision tower.
+"""
+
+from dataclasses import dataclass, field
+from functools import partial
+from typing import Any, Dict, List, Optional, Tuple
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import (
+    BaseModelArgs,
+    create_attention_mask,
+    create_ssm_mask,
+    scaled_dot_product_attention,
+)
+from mlx_lm.models.cache import ArraysCache, KVCache
+from mlx_lm.models.gated_delta import gated_delta_kernel, gated_delta_ops
+from mlx_lm.models.mla import MultiLinear
+from mlx_lm.models.switch_layers import SwitchGLU
+
+
+@dataclass
+class TextArgs(BaseModelArgs):
+    model_type: str = "kimi_linear"
+    vocab_size: int = 163840
+    hidden_size: int = 7168
+    intermediate_size: int = 33792
+    num_hidden_layers: int = 93
+    num_attention_heads: int = 96
+    num_key_value_heads: int = 96
+    rms_norm_eps: float = 1e-5
+    hidden_act: str = "situ"
+    linear_attn_config: Dict[str, Any] = field(default_factory=dict)
+    tie_word_embeddings: bool = False
+    # MLA
+    q_lora_rank: Optional[int] = 1536
+    kv_lora_rank: int = 512
+    qk_nope_head_dim: int = 128
+    qk_rope_head_dim: int = 64
+    v_head_dim: int = 128
+    mla_use_nope: bool = True
+    mla_use_output_gate: bool = True
+    # MoE
+    num_experts: int = 896
+    num_experts_per_token: int = 16
+    num_shared_experts: int = 2
+    moe_intermediate_size: int = 3072
+    moe_router_activation_func: str = "sigmoid"
+    moe_renormalize: bool = True
+    routed_scaling_factor: float = 1.0
+    first_k_dense_replace: int = 1
+    moe_layer_freq: int = 1
+    num_expert_group: int = 1
+    topk_group: int = 1
+    routed_expert_hidden_size: Optional[int] = 3584
+    latent_moe_use_norm: bool = True
+    # K3 extras
+    attn_res_block_size: Optional[int] = 12
+    activation_situ_beta: Optional[float] = 4.0
+    activation_situ_linear_beta: Optional[float] = 25.0
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str = "kimi_k3"
+    text_config: Dict[str, Any] = field(default_factory=dict)
+    vision_config: Optional[Dict[str, Any]] = None
+
+
+def situ_mul(gate: mx.array, up: mx.array, beta: float,
+             linear_beta: Optional[float]) -> mx.array:
+    """K3's SwiGLU variant with tanh soft-clipping on both legs, in float32."""
+    g = gate.astype(mx.float32)
+    u = up.astype(mx.float32)
+    a = beta * mx.tanh(g / beta) * mx.sigmoid(g)
+    if linear_beta is not None:
+        u = linear_beta * mx.tanh(u / linear_beta)
+    return (a * u).astype(gate.dtype)
+
+
+class Situ(nn.Module):
+    """SwitchGLU-compatible activation module: called as ``activation(x_up, x_gate)``."""
+
+    def __init__(self, beta: float, linear_beta: Optional[float]):
+        super().__init__()
+        self._beta = beta
+        self._linear_beta = linear_beta
+
+    def __call__(self, x: mx.array, gate: mx.array) -> mx.array:
+        return situ_mul(gate, x, self._beta, self._linear_beta)
+
+
+@partial(mx.compile, shapeless=True)
+def _compute_g_softplus(A_log, a, dt_bias):
+    return mx.exp(-mx.exp(A_log.astype(mx.float32)) * nn.softplus(a + dt_bias))
+
+
+@partial(mx.compile, shapeless=True)
+def _compute_g_bounded(A_log, a, dt_bias, lower_bound):
+    # K3 safe gate: log-decay = lower_bound * sigmoid(exp(A_log) * (a + dt_bias)),
+    # bounded to (lower_bound, 0) — NOT a clamp of the softplus form.
+    return mx.exp(
+        lower_bound * mx.sigmoid(mx.exp(A_log.astype(mx.float32)) * (a + dt_bias))
+    )
+
+
+class KimiMLP(nn.Module):
+    def __init__(self, args: TextArgs, hidden_size: Optional[int] = None,
+                 intermediate_size: Optional[int] = None):
+        super().__init__()
+        dim = hidden_size or args.hidden_size
+        hidden = intermediate_size or args.intermediate_size
+        self.gate_proj = nn.Linear(dim, hidden, bias=False)
+        self.up_proj = nn.Linear(dim, hidden, bias=False)
+        self.down_proj = nn.Linear(hidden, dim, bias=False)
+        self._beta = args.activation_situ_beta or 1.0
+        self._linear_beta = args.activation_situ_linear_beta
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(
+            situ_mul(self.gate_proj(x), self.up_proj(x), self._beta, self._linear_beta)
+        )
+
+
+# Ported from mlx_lm.models.kimi_linear (MIT); selection on biased scores,
+# weights gathered from the raw sigmoid scores (the noaux_tc trick).
+@mx.compile
+def _group_expert_select(
+    gates: mx.array,
+    bias: Optional[mx.array],
+    top_k: int,
+    n_group: int,
+    topk_group: int,
+    routed_scaling_factor: float,
+    renormalize: bool,
+    score_function: str,
+) -> Tuple[mx.array, mx.array]:
+    if score_function == "sigmoid":
+        scores = mx.sigmoid(gates)
+    elif score_function == "softmax":
+        scores = mx.softmax(gates, axis=-1, precise=True)
+    else:
+        raise ValueError(f"Unsupported MoE router activation '{score_function}'")
+
+    orig_scores = scores
+    if bias is not None:
+        scores = scores + bias.astype(scores.dtype)
+
+    if n_group > 1:
+        scores = mx.unflatten(scores, axis=-1, shape=(n_group, -1))
+        group_scores = mx.topk(scores, 2, axis=-1).sum(axis=-1, keepdims=True)
+        k = n_group - topk_group
+        group_idx = mx.argpartition(group_scores, kth=k - 1, axis=-2)[..., :k, :]
+        scores = mx.put_along_axis(
+            scores,
+            mx.stop_gradient(group_idx),
+            mx.array(0.0, dtype=scores.dtype),
+            axis=-2,
+        )
+        scores = mx.flatten(scores, -2, -1)
+
+    inds = mx.argpartition(-scores, kth=top_k - 1, axis=-1)[..., :top_k]
+    scores = mx.take_along_axis(orig_scores, inds, axis=-1)
+
+    if top_k > 1 and renormalize:
+        denominator = scores.sum(axis=-1, keepdims=True) + 1e-20
+        scores = scores / denominator
+
+    return inds, scores * routed_scaling_factor
+
+
+class Router(nn.Module):
+    """MoE router. A plain module (not nn.Linear) so the quantizers skip it, with
+    the correction bias kept under ``mlp.gate.*`` where the streaming repack's
+    router whitelist expects it."""
+
+    def __init__(self, hidden_size: int, num_experts: int):
+        super().__init__()
+        self.weight = mx.zeros((num_experts, hidden_size))
+        self.e_score_correction_bias = mx.zeros((num_experts,), dtype=mx.float32)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # fp32 router matmul, as in the reference.
+        return mx.matmul(x.astype(mx.float32), self.weight.astype(mx.float32).T)
+
+
+class LatentMoE(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.args = args
+        hidden = args.hidden_size
+        latent = args.routed_expert_hidden_size or hidden
+
+        # Mutable so the streaming loader's K-reduction lever
+        # (_cap_active_experts) can lower it.
+        self.top_k = args.num_experts_per_token
+        self.gate = Router(hidden, args.num_experts)
+        self.switch_mlp = SwitchGLU(
+            latent,
+            args.moe_intermediate_size,
+            args.num_experts,
+            activation=Situ(args.activation_situ_beta or 1.0,
+                            args.activation_situ_linear_beta),
+        )
+
+        self.use_latent = args.routed_expert_hidden_size is not None
+        if self.use_latent:
+            self.routed_expert_down_proj = nn.Linear(hidden, latent, bias=False)
+            self.routed_expert_up_proj = nn.Linear(latent, hidden, bias=False)
+            if args.latent_moe_use_norm:
+                self.routed_expert_norm = nn.RMSNorm(latent, eps=args.rms_norm_eps)
+            else:
+                self.routed_expert_norm = None
+
+        if args.num_shared_experts:
+            self.shared_experts = KimiMLP(
+                args,
+                intermediate_size=args.moe_intermediate_size * args.num_shared_experts,
+            )
+        else:
+            self.shared_experts = None
+
+    def __call__(self, x: mx.array) -> mx.array:
+        # Router reads the full hidden state, BEFORE the latent down-projection.
+        inds, weights = _group_expert_select(
+            self.gate(x),
+            self.gate.e_score_correction_bias,
+            self.top_k,
+            self.args.num_expert_group,
+            self.args.topk_group,
+            self.args.routed_scaling_factor,
+            self.args.moe_renormalize,
+            self.args.moe_router_activation_func,
+        )
+
+        z = self.routed_expert_down_proj(x) if self.use_latent else x
+        y = self.switch_mlp(z, inds)
+        # Top-k weighted sum in latent space, then norm once, then up-project.
+        y = (y * weights[..., None].astype(y.dtype)).sum(axis=-2)
+        if self.use_latent:
+            if self.routed_expert_norm is not None:
+                y = self.routed_expert_norm(y)
+            y = self.routed_expert_up_proj(y)
+
+        if self.shared_experts is not None:
+            y = y + self.shared_experts(x)
+        return y
+
+
+class ShortConv1d(nn.Module):
+    def __init__(self, channels: int, kernel_size: int):
+        super().__init__()
+        self.kernel_size = kernel_size
+        self.conv = nn.Conv1d(
+            in_channels=channels,
+            out_channels=channels,
+            kernel_size=kernel_size,
+            bias=False,
+            groups=channels,
+            padding=0,
+        )
+
+    def __call__(
+        self,
+        x: mx.array,
+        state: Optional[mx.array],
+        mask: Optional[mx.array],
+        lengths: Optional[mx.array],
+    ) -> Tuple[mx.array, mx.array]:
+        if mask is not None:
+            x = mx.where(mask[..., None], x, 0)
+
+        if state is None:
+            state = mx.zeros(
+                (x.shape[0], self.kernel_size - 1, x.shape[-1]), dtype=x.dtype
+            )
+        conv_input = mx.concatenate([state, x], axis=1)
+        out = nn.silu(self.conv(conv_input))
+        n_keep = self.kernel_size - 1
+        if lengths is not None:
+            ends = mx.clip(lengths, 0, x.shape[1])
+            positions = (ends[:, None] + mx.arange(n_keep))[..., None]
+            new_state = mx.take_along_axis(conv_input, positions, axis=1)
+        else:
+            new_state = mx.contiguous(conv_input[:, -n_keep:, :])
+
+        return out, new_state
+
+
+class KimiDeltaAttention(nn.Module):
+    def __init__(self, args: TextArgs, layer_idx: int):
+        super().__init__()
+        cfg = args.linear_attn_config
+
+        self.layer_idx = layer_idx
+        self.num_heads = cfg["num_heads"]
+        self.head_dim = cfg["head_dim"]
+        self.conv_kernel = cfg.get("short_conv_kernel_size", 4)
+        self.use_full_rank_gate = cfg.get("use_full_rank_gate", False)
+        self.gate_lower_bound = cfg.get("gate_lower_bound", None)
+
+        self.projection_dim = self.num_heads * self.head_dim
+        hidden = args.hidden_size
+
+        self.scale = float(self.head_dim) ** -0.5
+
+        self.q_proj = nn.Linear(hidden, self.projection_dim, bias=False)
+        self.k_proj = nn.Linear(hidden, self.projection_dim, bias=False)
+        self.v_proj = nn.Linear(hidden, self.projection_dim, bias=False)
+
+        self.q_conv = ShortConv1d(self.projection_dim, self.conv_kernel)
+        self.k_conv = ShortConv1d(self.projection_dim, self.conv_kernel)
+        self.v_conv = ShortConv1d(self.projection_dim, self.conv_kernel)
+
+        self.f_a_proj = nn.Linear(hidden, self.head_dim, bias=False)
+        self.f_b_proj = nn.Linear(self.head_dim, self.projection_dim, bias=False)
+        self.b_proj = nn.Linear(hidden, self.num_heads, bias=False)
+
+        if self.use_full_rank_gate:
+            self.g_proj = nn.Linear(hidden, self.projection_dim, bias=False)
+        else:
+            self.g_a_proj = nn.Linear(hidden, self.head_dim, bias=False)
+            self.g_b_proj = nn.Linear(self.head_dim, self.projection_dim, bias=False)
+
+        # Checkpoint value is zero-padded to head_dim; sanitize slices to (num_heads,).
+        self.A_log = mx.zeros((self.num_heads,))
+        self.dt_bias = mx.zeros((self.projection_dim,))
+
+        self.o_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+        self.o_proj = nn.Linear(self.projection_dim, hidden, bias=False)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> mx.array:
+        B, T, _ = x.shape
+        dtype = x.dtype
+
+        if cache is not None:
+            q_state, k_state, v_state, ssm_state = cache
+            lengths = cache.lengths
+        else:
+            q_state = k_state = v_state = ssm_state = None
+            lengths = None
+
+        if q_state is None:
+            s = mx.zeros((B, self.conv_kernel - 1, self.projection_dim), dtype=dtype)
+            q_state, k_state, v_state = s, s, s
+
+        q_conv, q_state = self.q_conv(self.q_proj(x), q_state, mask, lengths)
+        k_conv, k_state = self.k_conv(self.k_proj(x), k_state, mask, lengths)
+        v_conv, v_state = self.v_conv(self.v_proj(x), v_state, mask, lengths)
+
+        if cache is not None:
+            cache[0] = q_state
+            cache[1] = k_state
+            cache[2] = v_state
+
+        q = q_conv.reshape(B, T, self.num_heads, self.head_dim)
+        k = k_conv.reshape(B, T, self.num_heads, self.head_dim)
+        v = v_conv.reshape(B, T, self.num_heads, self.head_dim)
+
+        # True L2-norm of q/k (fla's use_qk_l2norm_in_kernel: eps=1e-6 on the
+        # SUM of squares, not the mean), with the readout scale folded into q.
+        q = q * mx.rsqrt((q * q).sum(axis=-1, keepdims=True) + 1e-6) * self.scale
+        k = k * mx.rsqrt((k * k).sum(axis=-1, keepdims=True) + 1e-6)
+
+        a_logits = self.f_b_proj(self.f_a_proj(x)).reshape(
+            B, T, self.num_heads, self.head_dim
+        )
+        beta = mx.sigmoid(self.b_proj(x).reshape(B, T, self.num_heads))
+
+        A_log = self.A_log.reshape(self.num_heads, 1)
+        dt_bias = self.dt_bias.reshape(self.num_heads, self.head_dim)
+        if self.gate_lower_bound is not None:
+            g = _compute_g_bounded(A_log, a_logits, dt_bias, self.gate_lower_bound)
+        else:
+            g = _compute_g_softplus(A_log, a_logits, dt_bias)
+
+        if ssm_state is None:
+            ssm_state = mx.zeros(
+                (B, self.num_heads, self.head_dim, self.head_dim), dtype=mx.float32
+            )
+
+        use_kernel = (
+            not self.training
+            and mx.default_device() == mx.gpu
+            and mx.metal.is_available()
+        )
+        if use_kernel:
+            out, ssm_state = gated_delta_kernel(q, k, v, g, beta, ssm_state, mask)
+        else:
+            out, ssm_state = gated_delta_ops(q, k, v, g, beta, ssm_state, mask)
+
+        if cache is not None:
+            cache[3] = ssm_state
+            cache.advance(T)
+
+        if self.use_full_rank_gate:
+            gate = self.g_proj(x)
+        else:
+            gate = self.g_b_proj(self.g_a_proj(x))
+        gate = gate.reshape(B, T, self.num_heads, self.head_dim)
+
+        out = (
+            self.o_norm(out.reshape(B, T, self.num_heads, self.head_dim))
+            * mx.sigmoid(gate)
+        ).reshape(B, T, -1)
+        return self.o_proj(out)
+
+
+class KimiMLAAttention(nn.Module):
+    """DeepSeek-style MLA, fully NoPE, with q-LoRA and a sigmoid output gate."""
+
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.args = args
+        self.num_heads = args.num_attention_heads
+        self.qk_nope_head_dim = args.qk_nope_head_dim
+        self.qk_rope_head_dim = args.qk_rope_head_dim
+        self.q_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+        self.v_head_dim = args.v_head_dim
+        self.kv_lora_rank = args.kv_lora_rank
+        self.use_output_gate = args.mla_use_output_gate
+        self.scale = self.q_head_dim**-0.5
+
+        hidden = args.hidden_size
+        if args.q_lora_rank is not None:
+            self.q_a_proj = nn.Linear(hidden, args.q_lora_rank, bias=False)
+            self.q_a_layernorm = nn.RMSNorm(args.q_lora_rank, eps=args.rms_norm_eps)
+            self.q_b_proj = nn.Linear(
+                args.q_lora_rank, self.num_heads * self.q_head_dim, bias=False
+            )
+        else:
+            self.q_proj = nn.Linear(
+                hidden, self.num_heads * self.q_head_dim, bias=False
+            )
+
+        self.kv_a_proj_with_mqa = nn.Linear(
+            hidden,
+            args.kv_lora_rank + self.qk_rope_head_dim,
+            bias=False,
+        )
+        self.kv_a_layernorm = nn.RMSNorm(args.kv_lora_rank, eps=args.rms_norm_eps)
+        self.embed_q = MultiLinear(
+            self.qk_nope_head_dim, args.kv_lora_rank, self.num_heads
+        )
+        self.unembed_out = MultiLinear(
+            args.kv_lora_rank, self.v_head_dim, self.num_heads
+        )
+        if self.use_output_gate:
+            self.g_proj = nn.Linear(
+                hidden, self.num_heads * self.v_head_dim, bias=False
+            )
+        self.o_proj = nn.Linear(self.num_heads * self.v_head_dim, hidden, bias=False)
+
+    def __call__(
+        self,
+        x: mx.array,
+        mask: Optional[mx.array] = None,
+        cache: Optional[KVCache] = None,
+    ) -> mx.array:
+        B, L, _ = x.shape
+
+        if self.args.q_lora_rank is not None:
+            q = self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x)))
+        else:
+            q = self.q_proj(x)
+        q = q.reshape(B, L, self.num_heads, self.q_head_dim).transpose(0, 2, 1, 3)
+        q_nope, q_pe = mx.split(q, [self.qk_nope_head_dim], axis=-1)
+
+        compressed_kv = self.kv_a_proj_with_mqa(x)
+        compressed_kv, k_pe = mx.split(compressed_kv, [self.kv_lora_rank], axis=-1)
+        k_pe = k_pe.reshape(B, L, 1, self.qk_rope_head_dim).transpose(0, 2, 1, 3)
+        kv_latent = self.kv_a_layernorm(compressed_kv)
+
+        kv_latent = mx.expand_dims(kv_latent, axis=1)
+
+        if cache is not None:
+            kv_latent, k_pe = cache.update_and_fetch(kv_latent, k_pe)
+
+        # NoPE: q_pe/k_pe carry no rotation; their scores fold into the mask.
+        pe_scores = (q_pe * self.scale) @ k_pe.swapaxes(-1, -2)
+        if mask is not None:
+            pe_scores = mx.where(
+                mask,
+                pe_scores,
+                mx.array(mx.finfo(pe_scores.dtype).min, pe_scores.dtype),
+            )
+
+        if L == 1:
+            q_nope = self.embed_q(q_nope)
+            k = v = kv_latent
+        else:
+            k = self.embed_q(kv_latent, transpose=False)
+            v = self.unembed_out(kv_latent)
+
+        output = scaled_dot_product_attention(
+            q_nope, k, v, cache=cache, scale=self.scale, mask=pe_scores
+        )
+
+        if L == 1:
+            output = self.unembed_out(output)
+
+        output = output.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        if self.use_output_gate:
+            output = output * mx.sigmoid(self.g_proj(x))
+        return self.o_proj(output)
+
+
+def _apply_attn_res(
+    h: mx.array,
+    block_residual: mx.array,
+    proj_weight: mx.array,
+    norm_weight: mx.array,
+    eps: float,
+) -> mx.array:
+    """Softmax-mix the current stream with the block-boundary snapshots.
+
+    Scores: RMS-normalized (weightless) candidates dotted with the fused
+    ``norm.weight * proj.weight`` vector. The mixture is over the RAW
+    (un-normalized) candidates — mixing the normalized ones is wrong.
+    """
+    v = mx.concatenate([block_residual, h[..., None, :]], axis=-2)  # (B,L,nb+1,H)
+    vf = v.astype(mx.float32)
+    k = vf * mx.rsqrt(mx.mean(vf * vf, axis=-1, keepdims=True) + eps)
+    score_w = norm_weight.astype(mx.float32) * proj_weight.reshape(-1).astype(
+        mx.float32
+    )
+    scores = (k * score_w).sum(axis=-1)  # (B,L,nb+1)
+    probs = mx.softmax(scores, axis=-1, precise=True)
+    out = (probs[..., None] * vf).sum(axis=-2)
+    return out.astype(h.dtype)
+
+
+class KimiDecoderLayer(nn.Module):
+    def __init__(self, args: TextArgs, layer_idx: int):
+        super().__init__()
+        self.layer_idx = layer_idx
+        self.attn_res_block_size = args.attn_res_block_size
+        self.rms_norm_eps = args.rms_norm_eps
+
+        kda_layers = args.linear_attn_config["kda_layers"]
+        self.is_linear = (layer_idx + 1) in kda_layers
+
+        if self.is_linear:
+            self.self_attn = KimiDeltaAttention(args, layer_idx)
+        else:
+            self.self_attn = KimiMLAAttention(args)
+
+        if (
+            args.num_experts > 0
+            and layer_idx >= args.first_k_dense_replace
+            and layer_idx % args.moe_layer_freq == 0
+        ):
+            self.mlp = LatentMoE(args)
+        else:
+            self.mlp = KimiMLP(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+        if self.attn_res_block_size is not None:
+            hidden = args.hidden_size
+            self.self_attention_res_norm = nn.RMSNorm(hidden, eps=args.rms_norm_eps)
+            self.self_attention_res_proj = nn.Linear(hidden, 1, bias=False)
+            self.mlp_res_norm = nn.RMSNorm(hidden, eps=args.rms_norm_eps)
+            self.mlp_res_proj = nn.Linear(hidden, 1, bias=False)
+
+    def __call__(
+        self,
+        x: mx.array,
+        block_residual: Optional[mx.array] = None,
+        mask: Optional[mx.array] = None,
+        cache: Optional[Any] = None,
+    ) -> Tuple[mx.array, Optional[mx.array]]:
+        if self.attn_res_block_size is None:
+            y = self.self_attn(self.input_layernorm(x), mask, cache)
+            h = x + y
+            return h + self.mlp(self.post_attention_layernorm(h)), block_residual
+
+        prefix_sum = x
+        if block_residual.shape[-2] > 0:
+            h = _apply_attn_res(
+                prefix_sum,
+                block_residual,
+                self.self_attention_res_proj.weight,
+                self.self_attention_res_norm.weight,
+                self.rms_norm_eps,
+            )
+        else:
+            h = prefix_sum
+
+        if self.layer_idx % self.attn_res_block_size == 0:
+            # Stash the PRE-mix stream and reset it: the old stream survives
+            # only inside block_residual from here on.
+            block_residual = mx.concatenate(
+                [block_residual, prefix_sum[..., None, :]], axis=-2
+            )
+            prefix_sum = None
+
+        a = self.self_attn(self.input_layernorm(h), mask, cache)
+        prefix_sum = a if prefix_sum is None else prefix_sum + a
+
+        h = _apply_attn_res(
+            prefix_sum,
+            block_residual,
+            self.mlp_res_proj.weight,
+            self.mlp_res_norm.weight,
+            self.rms_norm_eps,
+        )
+        f = self.mlp(self.post_attention_layernorm(h))
+        return prefix_sum + f, block_residual
+
+
+class KimiK3TextModel(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [
+            KimiDecoderLayer(args, i) for i in range(args.num_hidden_layers)
+        ]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        if args.attn_res_block_size is not None:
+            self.output_attn_res_norm = nn.RMSNorm(
+                args.hidden_size, eps=args.rms_norm_eps
+            )
+            self.output_attn_res_proj = nn.Linear(args.hidden_size, 1, bias=False)
+
+        kda_layers = args.linear_attn_config["kda_layers"]
+        self.ssm_idx = kda_layers[0] - 1 if kda_layers else None
+        self.attn_idx = None
+        for i in range(args.num_hidden_layers):
+            if (i + 1) not in kda_layers:
+                self.attn_idx = i
+                break
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        h = self.embed_tokens(inputs)
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        ssm_mask = (
+            create_ssm_mask(h, cache[self.ssm_idx]) if self.ssm_idx is not None
+            else None
+        )
+        attn_mask = (
+            create_attention_mask(h, cache[self.attn_idx], return_array=True)
+            if self.attn_idx is not None
+            else None
+        )
+
+        block_residual = None
+        if self.args.attn_res_block_size is not None:
+            B, L = h.shape[:2]
+            block_residual = mx.zeros((B, L, 0, h.shape[-1]), dtype=h.dtype)
+
+        for layer, layer_cache in zip(self.layers, cache):
+            mask = ssm_mask if layer.is_linear else attn_mask
+            h, block_residual = layer(
+                h, block_residual=block_residual, mask=mask, cache=layer_cache
+            )
+
+        if self.args.attn_res_block_size is not None:
+            h = _apply_attn_res(
+                h,
+                block_residual,
+                self.output_attn_res_proj.weight,
+                self.output_attn_res_norm.weight,
+                self.args.rms_norm_eps,
+            )
+        return self.norm(h)
+
+
+class LanguageModel(nn.Module):
+    def __init__(self, args: TextArgs):
+        super().__init__()
+        self.args = args
+        self.model = KimiK3TextModel(args)
+        if args.tie_word_embeddings:
+            self.lm_head = None
+        else:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        out = self.model(inputs, cache)
+        if self.lm_head is None:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.text_args = TextArgs.from_dict(args.text_config or {})
+        self.language_model = LanguageModel(self.text_args)
+
+    def __call__(
+        self,
+        inputs: mx.array,
+        cache: Optional[List[Any]] = None,
+    ) -> mx.array:
+        return self.language_model(inputs, cache)
+
+    @property
+    def layers(self):
+        return self.language_model.model.layers
+
+    def make_cache(self):
+        caches: List[Any] = []
+        for layer in self.layers:
+            if layer.is_linear:
+                caches.append(ArraysCache(size=4))
+            else:
+                caches.append(KVCache())
+        return caches
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        args = self.text_args
+        weights = {
+            k: v
+            for k, v in weights.items()
+            if not k.startswith(("vision_tower.", "mm_projector."))
+            and ".mtp" not in k
+        }
+
+        if args.tie_word_embeddings:
+            weights.pop("language_model.lm_head.weight", None)
+
+        for layer_idx, layer in enumerate(self.layers):
+            prefix = f"language_model.model.layers.{layer_idx}"
+
+            if isinstance(layer.mlp, LatentMoE):
+                src_prefix = f"{prefix}.block_sparse_moe"
+                dst_prefix = f"{prefix}.mlp"
+                for src, dst in [
+                    ("w1", "gate_proj"),
+                    ("w2", "down_proj"),
+                    ("w3", "up_proj"),
+                ]:
+                    packed = f"{src_prefix}.experts.0.{src}.weight_packed"
+                    plain = f"{src_prefix}.experts.0.{src}.weight"
+                    if packed in weights:
+                        # compressed-tensors mxfp4: uint8 nibbles view as uint32
+                        # (bit-identical to mx.quantize mode="mxfp4"); E8M0
+                        # uint8 scales pass through raw. No biases.
+                        weights[f"{dst_prefix}.switch_mlp.{dst}.weight"] = mx.stack(
+                            [
+                                weights.pop(
+                                    f"{src_prefix}.experts.{e}.{src}.weight_packed"
+                                ).view(mx.uint32)
+                                for e in range(args.num_experts)
+                            ]
+                        )
+                        weights[f"{dst_prefix}.switch_mlp.{dst}.scales"] = mx.stack(
+                            [
+                                weights.pop(
+                                    f"{src_prefix}.experts.{e}.{src}.weight_scale"
+                                )
+                                for e in range(args.num_experts)
+                            ]
+                        )
+                    elif plain in weights:
+                        weights[f"{dst_prefix}.switch_mlp.{dst}.weight"] = mx.stack(
+                            [
+                                weights.pop(f"{src_prefix}.experts.{e}.{src}.weight")
+                                for e in range(args.num_experts)
+                            ]
+                        )
+
+                for name in (
+                    "shared_experts.gate_proj",
+                    "shared_experts.up_proj",
+                    "shared_experts.down_proj",
+                    "routed_expert_down_proj",
+                    "routed_expert_up_proj",
+                    "routed_expert_norm",
+                    "gate",
+                ):
+                    src_key = f"{src_prefix}.{name}.weight"
+                    if src_key in weights:
+                        weights[f"{dst_prefix}.{name}.weight"] = weights.pop(src_key)
+
+                bias_key = f"{src_prefix}.gate.e_score_correction_bias"
+                if bias_key in weights:
+                    weights[f"{dst_prefix}.gate.e_score_correction_bias"] = weights.pop(
+                        bias_key
+                    )
+
+            attn = getattr(layer, "self_attn", None)
+            attn_prefix = f"{prefix}.self_attn"
+            if isinstance(attn, KimiDeltaAttention):
+                for src_name, dst_name in (
+                    ("q_conv1d", "q_conv"),
+                    ("k_conv1d", "k_conv"),
+                    ("v_conv1d", "v_conv"),
+                ):
+                    src_key = f"{attn_prefix}.{src_name}.weight"
+                    if src_key in weights:
+                        w = weights.pop(src_key)
+                        if w.ndim == 3:
+                            w = w.moveaxis(2, 1)
+                        weights[f"{attn_prefix}.{dst_name}.conv.weight"] = w
+                a_key = f"{attn_prefix}.A_log"
+                if a_key in weights:
+                    a = weights[a_key].reshape(-1)
+                    if a.shape[0] != attn.num_heads:
+                        # Stored zero-padded to head_dim; only the first
+                        # num_heads entries are real (verified: tail is all 0).
+                        a = a[: attn.num_heads]
+                    weights[a_key] = a
+                dt_key = f"{attn_prefix}.dt_bias"
+                if dt_key in weights and weights[dt_key].ndim > 1:
+                    weights[dt_key] = mx.reshape(weights[dt_key], (-1,))
+
+            kv_b_key = f"{attn_prefix}.kv_b_proj.weight"
+            if kv_b_key in weights:
+                qk_nope = args.qk_nope_head_dim
+                v_head = args.v_head_dim
+                head_dim = qk_nope + v_head
+                num_heads = args.num_attention_heads
+
+                quantized = f"{attn_prefix}.kv_b_proj.scales" in weights
+                v = weights.pop(kv_b_key)
+
+                if quantized:
+                    dims = args.kv_lora_rank
+                    scales = weights.pop(f"{attn_prefix}.kv_b_proj.scales")
+                    biases = weights.pop(f"{attn_prefix}.kv_b_proj.biases", None)
+                    bits = (v.shape[-1] * 32) // dims
+                    group_size = dims // scales.shape[-1]
+                    v = mx.dequantize(
+                        v, scales, biases, bits=bits, group_size=group_size
+                    )
+
+                v = v.reshape(num_heads, head_dim, -1)
+                wk = mx.contiguous(v[:, :qk_nope, :].swapaxes(-1, -2))
+                wv = mx.contiguous(v[:, qk_nope:, :])
+
+                if quantized:
+                    wk, wk_s, wk_b = mx.quantize(wk, bits=bits, group_size=group_size)
+                    wv, wv_s, wv_b = mx.quantize(wv, bits=bits, group_size=group_size)
+                    weights[f"{attn_prefix}.embed_q.scales"] = wk_s
+                    weights[f"{attn_prefix}.embed_q.biases"] = wk_b
+                    weights[f"{attn_prefix}.unembed_out.scales"] = wv_s
+                    weights[f"{attn_prefix}.unembed_out.biases"] = wv_b
+
+                weights[f"{attn_prefix}.embed_q.weight"] = wk
+                weights[f"{attn_prefix}.unembed_out.weight"] = wv
+
+        return weights
+
+    @property
+    def cast_predicate(self):
+        def predicate(path: str):
+            if "e_score_correction_bias" in path:
+                return False
+            if path.endswith("A_log") or path.endswith("dt_bias"):
+                return False
+            return True
+
+        return predicate
+
+    @property
+    def quant_predicate(self):
+        def predicate(path, _):
+            if path.endswith("mlp.gate"):
+                return False
+            return True
+
+        return predicate

--- a/plan.py
+++ b/plan.py
@@ -162,11 +162,24 @@ def _attention_layers(cfg: dict) -> tuple:
       attention layer and `M`/`E` are Mamba/MLP. Only 8 of its 88 layers are
       attention; reading `num_hidden_layers` instead over-predicts KV by 11x.
     * `full_attention_interval` — older hybrids.
+    * `linear_attn_config.full_attn_layers` — Kimi Linear / Kimi K3 KDA
+      hybrids: an explicit (1-based) list of the full-attention (MLA) layers;
+      everything else is KDA linear attention with a fixed-size recurrent
+      state. K3: 24 of 93 layers — assuming dense over-predicts KV ~4x even
+      before MLA's latent geometry (see kv_bytes) is accounted for.
 
     Everything else is assumed dense full-attention.
     """
     c = _text_config(cfg)
     n_layers = c.get("num_hidden_layers")
+
+    lac = c.get("linear_attn_config")
+    if isinstance(lac, dict) and isinstance(lac.get("full_attn_layers"), list):
+        n_full = len(lac["full_attn_layers"])
+        n_kda = len(lac.get("kda_layers") or [])
+        n_total = n_layers or (n_full + n_kda)
+        return n_full, 0, n_total, \
+            f"KDA hybrid: {n_full}/{n_total} full-attention (MLA)"
 
     types = c.get("layer_types")
     if isinstance(types, list) and types:
@@ -214,9 +227,32 @@ def kv_bytes(cfg: dict, context: int, kv_bits: int | None = None) -> tuple:
         # TurboQuant KV-quant stores kv_bits/16 of the fp16 payload (+ scales,
         # which are small); --kv-bits 8 halving KV matches the measured 35B.
         itemsize = 2.0 * (kv_bits / 16.0)
-    per_layer_token = 2 * n_kv * head_dim * itemsize
+
+    kv_rank = _pos_int(c.get("kv_lora_rank"), 0)
+    if kv_rank:
+        # MLA caches the shared latent (kv_lora_rank) + the MQA rope key —
+        # once per layer, NOT per head, and K/V share it. Kimi K3: 576 dims
+        # ≈ 1.2 KB/token/layer vs the 48 KB the dense formula would charge.
+        rope_dim = _pos_int(c.get("qk_rope_head_dim"), 0)
+        per_layer_token = (kv_rank + rope_dim) * itemsize
+        note += ", MLA latent KV"
+    else:
+        per_layer_token = 2 * n_kv * head_dim * itemsize
 
     total = n_full * context * per_layer_token
+
+    lac = c.get("linear_attn_config")
+    if isinstance(lac, dict) and isinstance(lac.get("kda_layers"), list):
+        # KDA layers hold a fixed-size recurrent state (heads × head_dim² fp32
+        # + short-conv tails) that doesn't grow with context but isn't free:
+        # ~450 MB on K3. Charge it as a constant.
+        kh = _pos_int(lac.get("num_heads"), n_kv or 0)
+        kd = _pos_int(lac.get("head_dim"), head_dim or 0)
+        ck = _pos_int(lac.get("short_conv_kernel_size"), 4)
+        total += len(lac["kda_layers"]) * (
+            kh * kd * kd * 4.0 + 3 * (ck - 1) * kh * kd * 2.0
+        )
+        note += f" + fixed KDA state ({len(lac['kda_layers'])} layers)"
     if n_slide:
         # an absent/zero/negative/garbage window means "not windowed" -> full
         # context. Never let it shrink the total: that under-predicts, and
@@ -437,7 +473,8 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
                 "expert_down_bits"),
             "n_layers": n_layers,
             "n_experts": c.get("num_experts"),
-            "experts_per_tok": c.get("num_experts_per_tok"),
+            "experts_per_tok": c.get("num_experts_per_tok")
+            or c.get("num_experts_per_token"),  # Kimi K3 spelling
             "is_moe": is_moe,
             **fp,
         },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,8 @@ dependencies = [
 eval = ["datasets", "transformers"]
 dev = ["pytest", "build", "twine"]
 vlm = ["mlx-vlm>=0.6.3"]
+# Kimi K3 ships a tiktoken-based tokenizer that needs blobfile to load.
+kimi = ["tiktoken", "blobfile"]
 
 [project.urls]
 Homepage = "https://github.com/manjunathshiva/turboquant-mlx"

--- a/quantize_model.py
+++ b/quantize_model.py
@@ -9,6 +9,7 @@ Handles the full pipeline:
 
 import gc
 import math
+from functools import partial
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -55,8 +56,13 @@ def _should_quantize(path: str, module: nn.Module) -> bool:
         return False
     if not isinstance(module, nn.Linear):
         return False
-    _, input_dims = module.weight.shape
+    output_dims, input_dims = module.weight.shape
     if input_dims < 32:
+        return False
+    if output_dims < 32:
+        # Scalar/score projections (e.g. Kimi K3's AttnRes *_res_proj rows,
+        # shape (1, hidden)) — quantization noise on a softmax score vector
+        # is all pain for ~0 bytes saved.
         return False
     return True
 
@@ -68,23 +74,29 @@ def _is_switch_linear(module: nn.Module) -> bool:
     return isinstance(module, (SwitchLinear, QuantizedSwitchLinear))
 
 
+def _dequantize_switch_expert(module, e: int) -> mx.array:
+    """Dequantize a single expert of a QuantizedSwitchLinear to float."""
+    return mx.dequantize(
+        module.weight[e],
+        module.scales[e],
+        module.biases[e] if module.biases is not None else None,
+        module.group_size,
+        module.bits,
+        mode=module.mode,
+    )
+
+
 def _dequantize_switch_linear(module) -> mx.array:
     """Dequantize a QuantizedSwitchLinear back to float weights.
 
     Returns (num_experts, output_dims, input_dims) float16 tensor.
+    NOTE: materializes ALL experts — prefer the per-expert path
+    (``partial(_dequantize_switch_expert, module)``) for large MoEs.
     """
-    experts = []
-    for e in range(module.num_experts):
-        w_deq = mx.dequantize(
-            module.weight[e],
-            module.scales[e],
-            module.biases[e] if module.biases is not None else None,
-            module.group_size,
-            module.bits,
-            mode=module.mode,
-        )
-        experts.append(w_deq)
-    return mx.stack(experts, axis=0)
+    return mx.stack(
+        [_dequantize_switch_expert(module, e) for e in range(module.num_experts)],
+        axis=0,
+    )
 
 
 def _is_router(path: str) -> bool:
@@ -181,9 +193,11 @@ def turboquant_quantize(
                 num_experts = module.num_experts
                 output_dims = module.output_dims
                 has_bias = "bias" in module
-                print(f"[INFO] Dequantizing QuantizedSwitchLinear {path} ({num_experts} experts, {module.mode} {module.bits}b -> float)")
-                float_weight = _dequantize_switch_linear(module)
-                mx.eval(float_weight)
+                print(f"[INFO] Dequantizing QuantizedSwitchLinear {path} ({num_experts} experts, {module.mode} {module.bits}b -> float, per-expert)")
+                # Lazy per-expert dequant: materializing the whole stacked
+                # float tensor costs ~30 GB on an 896-expert layer; one
+                # expert at a time stays flat (~0.4 GB).
+                float_weight = partial(_dequantize_switch_expert, module)
             else:
                 float_weight = module.weight
                 input_dims = module.weight.shape[-1]
@@ -231,6 +245,7 @@ def turboquant_quantize(
                 float_weight=float_weight,
                 bias=bias_tensor,
                 ternary=use_ternary,
+                weight_shape=(num_experts, output_dims, input_dims),
             )
             # Replace immediately and release all references
             mx.eval(pq_switch.parameters())

--- a/serve.py
+++ b/serve.py
@@ -534,6 +534,8 @@ def _extract_stream_args(argv):
     parser.add_argument("--max-active-experts", type=int, default=4)
     parser.add_argument("--prefetch-workers", type=int, default=8)
     parser.add_argument("--prefetch-ahead", type=int, default=0)
+    parser.add_argument("--no-fanout", dest="fanout", action="store_false",
+                        default=True)
     parser.add_argument("--pin-file", default=None)
     parser.add_argument("--no-hotlist", dest="use_hotlist", action="store_false",
                         default=True)
@@ -564,6 +566,7 @@ def _extract_stream_args(argv):
         use_page_cache=ns.use_page_cache,
         prefetch_workers=ns.prefetch_workers,
         prefetch_ahead=ns.prefetch_ahead,
+        fanout=ns.fanout,
         pin_file=ns.pin_file,
         use_hotlist=ns.use_hotlist,
         wire_memory=ns.wire_memory,

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -141,9 +141,17 @@ def _cap_active_experts(layers, max_active: int) -> None:
             mlp.top_k = new_k
             changed.append(native)
     if changed:
-        print(f"[stream] K-reduction: capped router top_k {changed[0]}->{min(changed[0], max_active)} "
+        native = changed[0]
+        print(f"[stream] K-reduction: capped router top_k {native}->{min(native, max_active)} "
               f"on {len(changed)} MoE blocks (~2x less disk I/O; pass "
               f"max_active_experts=0 / --max-active-experts 0 to use native routing)")
+        if native > 2 * max_active:
+            # Halving K was measured byte-identical (Qwen 8->4); deeper cuts
+            # are unvalidated. Kimi K3's native top-16 at the default cap of 4
+            # would be a 4x truncation — flag it rather than silently degrade.
+            print(f"[stream] WARNING: top_k cut {native}->{max_active} is more "
+                  f"aggressive than the validated 2x — quality may degrade; "
+                  f"consider --max-active-experts {native // 2} or higher")
 
 
 # Auto cache budget (ds4-style): size the expert cache from what the GPU can

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -269,6 +269,7 @@ def _pin_spec_to_layers(spec: dict) -> "tuple[dict, list]":
 
 def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
                    prefetch_workers: int = 8, prefetch_ahead: int = 0,
+                   fanout: bool = True,
                    pin_file: str | None = None, max_active_experts: int = 4,
                    use_page_cache: bool | None = None, use_hotlist: bool = True,
                    preload_pins: bool = True, wire_memory: bool = False,
@@ -288,6 +289,10 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
     prefetch_workers parallelizes per-layer expert reads (1 = serial baseline).
     prefetch_ahead speculatively prefetches this many upcoming layers' experts
     (predicted from the previous token's routing); 0 disables prefetch.
+    fanout submits each layer's known expert misses to the read pool as soon
+    as the router has chosen them, so the other projections' reads overlap
+    compute (--no-fanout for bandwidth-bound external storage, where the
+    coalesced serial path wins; the saturation throttle also disables it).
     pin_file is an optional JSON {"pin": [[layer, expert], ...]} of hot experts
     to keep permanently resident (never LRU-evicted) — see calibrate_experts.py.
     When it is None and the model directory ships a ``hot_experts.json`` (same
@@ -355,6 +360,7 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
         reader, int(cache_budget_gb * 1e9),
         prefetch_workers=prefetch_workers,
         prefetch_ahead=prefetch_ahead,
+        fanout=fanout,
         usage_profile=profile,
     )
     # Fold this run into the persisted history at exit. Registered rather than

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -436,9 +436,12 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
                 scales_key=skey,
                 cache=cache,
                 layer_idx=i,
-                # one trigger per layer fires the next-layer prefetch; gate_proj
-                # is first in _PROJS so it fires with maximum lead time.
-                is_trigger=(proj == _PROJS[0]),
+                # One trigger per layer fires the same-layer miss fan-out and
+                # the next-layer prefetch. It must be the FIRST projection the
+                # MoE block EXECUTES — SwitchGLU runs up_proj, then gate_proj,
+                # then down_proj — or every up_proj miss is read serially
+                # before the fan-out even fires.
+                is_trigger=(proj == "up_proj"),
                 trit=res.trit,
             )
             setattr(sm, proj, st)

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -75,6 +75,13 @@ def main():
                         "helps only on fast NVMe with spare bandwidth, ~neutral on a "
                         "saturated USB bus). Set 1 to enable; it self-disables if the "
                         "storage proves bandwidth-bound.")
+    p.add_argument("--no-fanout", dest="fanout", action="store_false",
+                   default=True,
+                   help="Disable the same-layer read fan-out (submitting a layer's "
+                        "known expert misses to the read pool at layer start). "
+                        "Fan-out overlaps reads with compute on internal SSD but "
+                        "trades away coalesced serial reads — disable on "
+                        "bandwidth-bound external storage.")
     p.add_argument("--pin-file", default=None,
                    help="JSON {'pin': [[layer, expert], ...]} of hot experts to keep "
                         "permanently resident (from calibrate_experts.py). Without it, "
@@ -131,6 +138,7 @@ def main():
     model, tok, cache = load_streaming(
         args.model, cache_budget_gb=args.cache_budget_gb, fast=args.fast,
         prefetch_workers=args.prefetch_workers, prefetch_ahead=args.prefetch_ahead,
+        fanout=args.fanout,
         pin_file=args.pin_file, max_active_experts=args.max_active_experts,
         use_page_cache=args.use_page_cache, use_hotlist=args.use_hotlist,
         learn_experts=args.learn_experts, usage_file=args.usage_file,

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -392,6 +392,8 @@ class ExpertCache:
             try:
                 fut.result()
             except Exception:
+                # A failed read leaves no staging entry; the miss path
+                # below reloads this expert synchronously.
                 pass
             with self._lock:
                 buf = self._staging.pop(ck, None)

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -51,6 +51,15 @@ class ExpertCache:
     and ``eval`` stay on the calling thread, so the produced tensors are
     bit-identical to the serial path.
 
+    **Same-layer fan-out** (``fanout=True``, needs the pool): once a layer's
+    router has chosen its experts, the other projections' misses are submitted
+    to the pool immediately so their reads overlap the earlier projections'
+    compute. These are critical-path reads (counted in ``misses`` /
+    ``bytes_read`` and annotated by ``fanout_hits``), not speculation. Fan-out
+    trades the coalesced serial read path for parallelism — a win on internal
+    SSD, a likely loss on bandwidth-bound external storage, so it can be
+    disabled (``--no-fanout``) and the saturation throttle also turns it off.
+
     **Speculative prefetch** (``prefetch_ahead > 0``): when a layer starts we
     kick off *background* disk reads for the experts the previous token used at
     the next layer(s) — a near-free, high-accuracy predictor because MoE routing
@@ -63,7 +72,7 @@ class ExpertCache:
     """
 
     def __init__(self, reader, budget_bytes: int, *, prefetch_workers: int = 8,
-                 prefetch_ahead: int = 1,
+                 prefetch_ahead: int = 1, fanout: bool = True,
                  staging_budget_bytes: int = 1_500_000_000,
                  pin_keys=None, usage_profile=None):
         self.reader = reader
@@ -72,11 +81,13 @@ class ExpertCache:
         self._od: "OrderedDict[tuple, tuple]" = OrderedDict()
         # stats
         self.hits = 0             # served resident from _od
-        self.misses = 0           # critical-path disk reads
-        self.prefetch_hits = 0    # served from a completed background prefetch
-        self.bytes_read = 0           # critical-path bytes
-        self.bytes_prefetched = 0     # background prefetch bytes
-        self.prefetched = 0           # experts prefetched
+        self.misses = 0           # critical-path disk reads (incl. fan-out)
+        self.prefetch_hits = 0    # served from a completed SPECULATIVE prefetch
+        self.fanout_hits = 0      # misses whose read ran on the pool (subset of misses)
+        self.prefetch_errors = 0  # background reads that raised (fell back to sync)
+        self.bytes_read = 0           # critical-path bytes (incl. fan-out reads)
+        self.bytes_prefetched = 0     # speculative background bytes
+        self.prefetched = 0           # experts speculatively prefetched
         self.prefetch_dropped = 0     # prefetched then evicted from staging unused
         self.read_runs = 0            # coalesced range reads issued (critical path)
         self.expert_reads = 0         # experts loaded on the critical path
@@ -84,6 +95,13 @@ class ExpertCache:
         self._workers = max(1, int(prefetch_workers))
         self._pool = (ThreadPoolExecutor(max_workers=self._workers)
                       if self._workers > 1 else None)
+        # same-layer fan-out: submit a layer's known expert misses to the pool
+        # at layer start so each projection's gather awaits parallel reads
+        # instead of reading serially. Needs the pool; --no-fanout turns it off
+        # (bandwidth-bound storage prefers the coalesced serial path), and the
+        # saturation throttle below turns it off too.
+        self._fanout = bool(fanout) and self._pool is not None
+        self._fanout_keys: set = set()   # cks submitted by fan-out (not speculation)
         # speculative-prefetch state (needs the pool to run in background)
         self._prefetch_ahead = max(0, int(prefetch_ahead)) if self._pool else 0
         # saturation throttle: after warming up, if prefetch is rescuing too few
@@ -128,28 +146,37 @@ class ExpertCache:
         """Called once per layer per token (from the trigger projection).
 
         First fans out THIS layer's known expert set across the read pool for
-        all of the layer's projections: gather awaits in-flight reads instead
-        of re-reading, so every miss in the layer is read in parallel by the
-        pool rather than serially at each projection's call site. Unlike the
-        speculative next-layer path this is not a prediction — the router has
-        already chosen these experts. (Skipped for prefill-sized selections,
-        which would overflow the staging area; prefill misses already coalesce
-        into large runs per projection.)
+        the layer's *other* projections (``trigger_wkey`` — the projection this
+        call came from — is skipped: its gather runs next on the calling thread
+        and keeps the coalesced-run read path): gather awaits in-flight reads
+        instead of re-reading, so every miss in the layer is read in parallel
+        by the pool rather than serially at each projection's call site. Unlike
+        the speculative next-layer path this is not a prediction — the router
+        has already chosen these experts — so the reads are accounted as
+        critical-path (``misses``/``bytes_read``, annotated by ``fanout_hits``).
+        (Skipped for prefill-sized selections, which would overflow the staging
+        area; prefill misses already coalesce into large runs per projection.)
 
         Then prefetches the next layer(s)' predicted experts in the background
         and records this layer's selection for the *next* token to predict from.
         """
-        if self._pool is not None and len(experts) <= 64:
-            self._prefetch_layer(layer_idx, experts)
+        if self._fanout and len(experts) <= 64:
+            self._prefetch_layer(layer_idx, experts, skip_wkey=trigger_wkey,
+                                 speculative=False)
         # once enough has been prefetched, judge whether it's worth continuing
         if (self._prefetch_ahead and not self._throttle_decided
                 and self.prefetched >= self._throttle_warmup):
             self._throttle_decided = True
             rescue = self.prefetch_hits / max(1, self.prefetch_hits + self.misses)
             if rescue < self._throttle_min_rescue:
+                # Bandwidth-bound storage: speculation's reads arrive too late
+                # and fan-out's per-expert pool reads lose to the coalesced
+                # serial path — stop both from competing for the bus.
                 self._prefetch_ahead = 0
-                print(f"[stream] prefetch self-disabled: rescue rate {rescue:.0%} < "
-                      f"{self._throttle_min_rescue:.0%} (storage appears bandwidth-bound)")
+                self._fanout = False
+                print(f"[stream] prefetch + fan-out self-disabled: rescue rate "
+                      f"{rescue:.0%} < {self._throttle_min_rescue:.0%} "
+                      f"(storage appears bandwidth-bound)")
         if self._prefetch_ahead:
             for nxt in range(layer_idx + 1, layer_idx + 1 + self._prefetch_ahead):
                 pred = self._last_experts.get(nxt)
@@ -157,7 +184,8 @@ class ExpertCache:
                     self._prefetch_layer(nxt, pred)
         self._last_experts[layer_idx] = experts
 
-    def _prefetch_layer(self, layer_idx: int, predicted: list, skip_wkey=None):
+    def _prefetch_layer(self, layer_idx: int, predicted: list, skip_wkey=None,
+                        speculative: bool = True):
         keys = self._layer_keys.get(layer_idx)
         if not keys or self._pool is None:
             return
@@ -171,8 +199,12 @@ class ExpertCache:
                     if (ck in self._od or ck in self._pinned
                             or ck in self._staging or ck in self._inflight):
                         continue
+                    if not speculative:
+                        # same-layer fan-out: tag so gather accounts the claim
+                        # as a (parallelized) critical-path read, not a rescue
+                        self._fanout_keys.add(ck)
                     self._inflight[ck] = self._pool.submit(
-                        self._prefetch_one, wkey, skey, e
+                        self._prefetch_one, wkey, skey, e, speculative
                     )
 
     def record_usage(self, layer_idx: int, routed) -> None:
@@ -200,7 +232,8 @@ class ExpertCache:
             json.dump(self._trace, f)
         return len(self._trace)
 
-    def _prefetch_one(self, wkey: str, skey: str, e: int):
+    def _prefetch_one(self, wkey: str, skey: str, e: int,
+                      speculative: bool = True):
         # disk-only background work; never touches MLX (built later on main thread)
         try:
             wbuf = self.reader.read_expert_np(wkey, e)   # (np_array, mlx_dtype)
@@ -212,16 +245,26 @@ class ExpertCache:
                 # orphan half a pair (drop the weight but keep its scales).
                 self._staging[(wkey, e)] = (wbuf, sbuf)
                 self._staging_bytes += nb
-                self.bytes_prefetched += nb
-                self.prefetched += 1
+                if speculative:
+                    self.bytes_prefetched += nb
+                    self.prefetched += 1
+                else:
+                    # same-layer fan-out: this token needed these bytes no
+                    # matter what — account them as critical-path reads
+                    self.bytes_read += nb
                 # bound staging: drop oldest (mispredicted) entries FIFO
                 while self._staging_bytes > self._staging_cap and len(self._staging) > 1:
                     _, (wb, sb) = self._staging.popitem(last=False)
                     self._staging_bytes -= (wb[0].nbytes + sb[0].nbytes)
                     self.prefetch_dropped += 1
         except Exception:
+            # Read failed on the pool thread. Drop the in-flight marker so
+            # gather's fallback reloads the expert synchronously, and count
+            # it — a disk error must not present as unexplained slowness.
             with self._lock:
                 self._inflight.pop((wkey, e), None)
+                self._fanout_keys.discard((wkey, e))
+                self.prefetch_errors += 1
 
     # -- loading -------------------------------------------------------
     def _load_coalesced(self, miss_pairs):
@@ -361,10 +404,18 @@ class ExpertCache:
                     wbuf, sbuf = self._staging.pop(ck)
                     self._staging_bytes -= (wbuf[0].nbytes + sbuf[0].nbytes)
                     staged.append((e, wbuf, sbuf))
-                    self.prefetch_hits += 1
+                    if ck in self._fanout_keys:
+                        # same-layer fan-out read: critical-path, just done
+                        # by the pool while earlier projections computed
+                        self._fanout_keys.discard(ck)
+                        self.misses += 1
+                        self.fanout_hits += 1
+                    else:
+                        self.prefetch_hits += 1
                 elif ck in self._inflight:
                     inflight.append((e, self._inflight[ck]))
                 else:
+                    self._fanout_keys.discard(ck)  # evicted from staging unclaimed
                     self.misses += 1
                     miss_pairs.append((wkey, skey, e))
 
@@ -393,13 +444,21 @@ class ExpertCache:
                 fut.result()
             except Exception:
                 # A failed read leaves no staging entry; the miss path
-                # below reloads this expert synchronously.
+                # below reloads this expert synchronously. (_prefetch_one
+                # swallows and counts read errors itself, so this is
+                # defensive only.)
                 pass
             with self._lock:
                 buf = self._staging.pop(ck, None)
+                fan = ck in self._fanout_keys
+                self._fanout_keys.discard(ck)
                 if buf is not None:
                     self._staging_bytes -= (buf[0][0].nbytes + buf[1][0].nbytes)
-                    self.prefetch_hits += 1
+                    if fan:
+                        self.misses += 1
+                        self.fanout_hits += 1
+                    else:
+                        self.prefetch_hits += 1
             if buf is not None:
                 wbuf, sbuf = buf
                 w = mx.array(wbuf[0], dtype=wbuf[1])
@@ -445,19 +504,25 @@ class ExpertCache:
             self._inflight.clear()
 
     def stats(self):
+        # Same-layer fan-out reads count into misses/bytes_read (annotated by
+        # fanout_hits): they are this token's unavoidable disk reads, merely
+        # parallelized — so hit_rate keeps meaning "no same-token disk read"
+        # and stays comparable across models with and without fan-out.
         served = self.hits + self.prefetch_hits   # neither incurred critical-path disk
         tot = served + self.misses
         return {
-            # effective (latency) hit-rate: fraction served without a blocking read
+            # effective (latency) hit-rate: fraction served without a same-token read
             "hit_rate": (served / tot) if tot else 0.0,
             "cache_hit_rate": (self.hits / tot) if tot else 0.0,
             "prefetch_hit_rate": (self.prefetch_hits / tot) if tot else 0.0,
             "hits": self.hits,
             "prefetch_hits": self.prefetch_hits,
+            "fanout_hits": self.fanout_hits,
             "pin_hits": self._pin_hits,
             "misses": self.misses,
             "prefetched": self.prefetched,
             "prefetch_dropped": self.prefetch_dropped,
+            "prefetch_errors": self.prefetch_errors,
             "resident_experts": len(self._od) + len(self._pinned),
             "pinned_experts": len(self._pinned),
             "preload_experts": self.preload_experts,

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -99,7 +99,7 @@ class ExpertCache:
         self._staging_cap = max(0, int(staging_budget_bytes))
         self._staging: "OrderedDict[tuple, tuple]" = OrderedDict()  # key -> (np_buf, dt)
         self._staging_bytes = 0
-        self._inflight: set = set()
+        self._inflight: dict = {}            # key -> Future (gather awaits these)
         self._lock = threading.Lock()        # guards _staging / _inflight / stats
         self._layer_keys: dict = {}          # layer_idx -> [(wkey, skey), ...]
         self._last_experts: dict = {}        # layer_idx -> experts (previous token)
@@ -124,12 +124,23 @@ class ExpertCache:
         the predictor can prefetch all of them for the next layer at once."""
         self._layer_keys[layer_idx] = list(proj_keys)
 
-    def on_layer_start(self, layer_idx: int, experts: list):
+    def on_layer_start(self, layer_idx: int, experts: list, trigger_wkey=None):
         """Called once per layer per token (from the trigger projection).
 
-        Prefetches the next layer(s)' predicted experts in the background, then
-        records this layer's selection for the *next* token to predict from.
+        First fans out THIS layer's known expert set across the read pool for
+        all of the layer's projections: gather awaits in-flight reads instead
+        of re-reading, so every miss in the layer is read in parallel by the
+        pool rather than serially at each projection's call site. Unlike the
+        speculative next-layer path this is not a prediction — the router has
+        already chosen these experts. (Skipped for prefill-sized selections,
+        which would overflow the staging area; prefill misses already coalesce
+        into large runs per projection.)
+
+        Then prefetches the next layer(s)' predicted experts in the background
+        and records this layer's selection for the *next* token to predict from.
         """
+        if self._pool is not None and len(experts) <= 64:
+            self._prefetch_layer(layer_idx, experts)
         # once enough has been prefetched, judge whether it's worth continuing
         if (self._prefetch_ahead and not self._throttle_decided
                 and self.prefetched >= self._throttle_warmup):
@@ -146,20 +157,23 @@ class ExpertCache:
                     self._prefetch_layer(nxt, pred)
         self._last_experts[layer_idx] = experts
 
-    def _prefetch_layer(self, layer_idx: int, predicted: list):
+    def _prefetch_layer(self, layer_idx: int, predicted: list, skip_wkey=None):
         keys = self._layer_keys.get(layer_idx)
         if not keys or self._pool is None:
             return
         with self._lock:
             for wkey, skey in keys:
+                if wkey == skip_wkey:
+                    continue
                 for e in predicted:
                     ck = (wkey, e)
                     # already resident (LRU or pinned), staged, or being read
                     if (ck in self._od or ck in self._pinned
                             or ck in self._staging or ck in self._inflight):
                         continue
-                    self._inflight.add(ck)
-                    self._pool.submit(self._prefetch_one, wkey, skey, e)
+                    self._inflight[ck] = self._pool.submit(
+                        self._prefetch_one, wkey, skey, e
+                    )
 
     def record_usage(self, layer_idx: int, routed) -> None:
         """One forward's flat routing array (repeats an expert once per token).
@@ -193,7 +207,7 @@ class ExpertCache:
             sbuf = self.reader.read_expert_np(skey, e)
             nb = wbuf[0].nbytes + sbuf[0].nbytes
             with self._lock:
-                self._inflight.discard((wkey, e))
+                self._inflight.pop((wkey, e), None)
                 # Store both projections under one key so eviction can never
                 # orphan half a pair (drop the weight but keep its scales).
                 self._staging[(wkey, e)] = (wbuf, sbuf)
@@ -207,7 +221,7 @@ class ExpertCache:
                     self.prefetch_dropped += 1
         except Exception:
             with self._lock:
-                self._inflight.discard((wkey, e))
+                self._inflight.pop((wkey, e), None)
 
     # -- loading -------------------------------------------------------
     def _load_coalesced(self, miss_pairs):
@@ -332,6 +346,7 @@ class ExpertCache:
         # resident set, and the prefetch staging area; load the rest in a batch.
         miss_pairs = []
         staged = []  # (expert, wbuf, sbuf) — read in background, build here
+        inflight = []  # (expert, future) — being read right now; await, don't re-read
         with self._lock:
             for e in experts:
                 ck = (wkey, e)
@@ -347,6 +362,8 @@ class ExpertCache:
                     self._staging_bytes -= (wbuf[0].nbytes + sbuf[0].nbytes)
                     staged.append((e, wbuf, sbuf))
                     self.prefetch_hits += 1
+                elif ck in self._inflight:
+                    inflight.append((e, self._inflight[ck]))
                 else:
                     self.misses += 1
                     miss_pairs.append((wkey, skey, e))
@@ -365,6 +382,40 @@ class ExpertCache:
             for ck, entry in loaded.items():
                 self._insert(ck, entry)
                 self.bytes_read += entry[2]
+
+        # Await reads that were already in flight (same-layer fan-out or
+        # speculative prefetch). The bytes arrive via the background pool; we
+        # only build the MLX arrays here. Falls back to a synchronous load if
+        # a completed entry was evicted from staging before we could claim it.
+        for e, fut in inflight:
+            ck = (wkey, e)
+            try:
+                fut.result()
+            except Exception:
+                pass
+            with self._lock:
+                buf = self._staging.pop(ck, None)
+                if buf is not None:
+                    self._staging_bytes -= (buf[0][0].nbytes + buf[1][0].nbytes)
+                    self.prefetch_hits += 1
+            if buf is not None:
+                wbuf, sbuf = buf
+                w = mx.array(wbuf[0], dtype=wbuf[1])
+                s = mx.array(sbuf[0], dtype=sbuf[1])
+                mx.eval(w, s)
+                self._insert(ck, (w, s, w.nbytes + s.nbytes))
+                continue
+            with self._lock:
+                already = ck in self._od or ck in self._pinned
+                if already:
+                    self.hits += 1
+                else:
+                    self.misses += 1
+            if not already:
+                loaded = self._load_coalesced([(wkey, skey, e)])
+                for lck, entry in loaded.items():
+                    self._insert(lck, entry)
+                    self.bytes_read += entry[2]
 
         # Build the stack *before* evicting so freshly loaded slices are still
         # present (and held by ``ws``/``ss``, so eviction can't free them out
@@ -513,7 +564,9 @@ class StreamingSwitchLinear(nn.Module):
         # expert set is known (only the trigger projection, once per token), and
         # record the selection for calibration on decode steps (1 token).
         if self._is_trigger:
-            self._cache.on_layer_start(self._layer_idx, sel)
+            self._cache.on_layer_start(
+                self._layer_idx, sel, trigger_wkey=self._weight_key
+            )
             self._cache.record_usage(self._layer_idx, idx_global)
             if n_tokens == 1:
                 self._cache.record_trace(self._layer_idx, sel)

--- a/tests/test_expert_naming.py
+++ b/tests/test_expert_naming.py
@@ -25,6 +25,10 @@ from turboquant_mlx.plan import footprint
 _QWEN = "model.layers.3.mlp.switch_mlp.{proj}.{suffix}"      # qwen3_5_moe/deepseek
 _LAGUNA = "model.layers.3.mlp.experts.{proj}.{suffix}"       # laguna SwitchGLU
 _SHARED = "model.layers.3.mlp.shared_experts.{proj}.{suffix}"  # dense, resident
+# Kimi K3 as converted: language_model wrapper prefix + switch_mlp container.
+_K3 = "language_model.model.layers.3.mlp.switch_mlp.{proj}.{suffix}"
+# K3's always-resident latent-MoE plumbing must NOT be classified streamable.
+_K3_LATENT = "language_model.model.layers.3.mlp.routed_expert_down_proj.{suffix}"
 
 
 def test_counts_switch_mlp_keys():
@@ -111,7 +115,7 @@ def test_plan_and_loader_agree_on_the_same_index():
         def __init__(self, idx):
             self._index = {k: _Loc(*v) for k, v in idx.items()}
 
-    for template in (_QWEN, _LAGUNA, _SHARED):
+    for template in (_QWEN, _LAGUNA, _SHARED, _K3):
         idx = _index(template)
         assert footprint(idx)["expert_bytes"] == _streamed_expert_bytes(
             _Reader(idx)), f"plan/loader disagree on {template}"
@@ -193,3 +197,16 @@ def test_real_laguna_index_if_present():
     orphaned = sorted(l for l in router if expert[l] == 0)
     assert not orphaned, (
         f"layers {orphaned} would permute the router but not the experts")
+
+
+def test_counts_kimi_k3_wrapped_keys():
+    """K3's converted keys carry the language_model wrapper prefix."""
+    for suffix in ("weight", "scales"):
+        assert is_streamed_expert_key(_K3.format(proj="gate_proj", suffix=suffix))
+
+
+def test_k3_latent_projections_stay_resident():
+    """routed_expert_{down,up}_proj / routed_expert_norm run on every token and
+    live outside the expert stack — paging them would break every forward."""
+    for suffix in ("weight", "scales"):
+        assert not is_streamed_expert_key(_K3_LATENT.format(suffix=suffix))

--- a/tests/test_kimi_k3.py
+++ b/tests/test_kimi_k3.py
@@ -10,9 +10,8 @@ quantized layout, A_log de-padding, vision-tower drop, idempotence).
 """
 
 import mlx.core as mx
-import pytest
 
-import turboquant_mlx.compat  # noqa: F401 — registers kimi_k3 with mlx-lm
+import turboquant_mlx.compat as compat  # importing applies the mlx-lm patches
 from turboquant_mlx.models import kimi_k3 as k3
 
 HIDDEN = 64
@@ -74,6 +73,7 @@ def make_model():
 def test_get_classes_resolves_kimi_k3():
     from mlx_lm.utils import _get_classes
 
+    compat._register_kimi_k3_model()  # idempotent; already ran at import
     model_class, args_class = _get_classes(tiny_config())
     assert model_class is k3.Model
     assert args_class is k3.ModelArgs

--- a/tests/test_kimi_k3.py
+++ b/tests/test_kimi_k3.py
@@ -1,0 +1,309 @@
+# Copyright 2026 Manjunath Janardhan
+"""Tiny-config tests for the Kimi K3 model port (torch-free, CI-safe).
+
+Real-weight logit parity vs the HF reference (fp32, layers 0-3, 32-expert
+subset) is validated separately by a local torch-dependent harness — these
+tests pin the structural contracts: model_type dispatch, hybrid layer/cache
+typing, the AttnRes forward protocol, and sanitize's key normalization
+(per-expert -> stacked, w1/w3/w2 -> gate/up/down_proj, mxfp4 packed -> MLX
+quantized layout, A_log de-padding, vision-tower drop, idempotence).
+"""
+
+import mlx.core as mx
+import pytest
+
+import turboquant_mlx.compat  # noqa: F401 — registers kimi_k3 with mlx-lm
+from turboquant_mlx.models import kimi_k3 as k3
+
+HIDDEN = 64
+LATENT = 32
+MOE_INTER = 64
+N_EXPERTS = 8
+
+
+def tiny_config():
+    return {
+        "model_type": "kimi_k3",
+        "text_config": {
+            "model_type": "kimi_linear",
+            "vocab_size": 128,
+            "hidden_size": HIDDEN,
+            "intermediate_size": 128,
+            "num_hidden_layers": 5,
+            "num_attention_heads": 4,
+            "num_key_value_heads": 4,
+            "rms_norm_eps": 1e-5,
+            "hidden_act": "situ",
+            "linear_attn_config": {
+                "num_heads": 4,
+                "head_dim": 16,
+                "short_conv_kernel_size": 4,
+                "use_full_rank_gate": True,
+                "gate_lower_bound": -5.0,
+                "kda_layers": [1, 2, 3, 5],  # 1-based; 0-based layer 3 is MLA
+                "full_attn_layers": [4],
+            },
+            "q_lora_rank": 24,
+            "kv_lora_rank": 16,
+            "qk_nope_head_dim": 16,
+            "qk_rope_head_dim": 8,
+            "v_head_dim": 16,
+            "mla_use_nope": True,
+            "mla_use_output_gate": True,
+            "num_experts": N_EXPERTS,
+            "num_experts_per_token": 2,
+            "num_shared_experts": 2,
+            "moe_intermediate_size": MOE_INTER,
+            "first_k_dense_replace": 1,
+            "routed_expert_hidden_size": LATENT,
+            "latent_moe_use_norm": True,
+            "attn_res_block_size": 2,  # boundaries at layers 0, 2, 4
+            "activation_situ_beta": 4.0,
+            "activation_situ_linear_beta": 25.0,
+        },
+    }
+
+
+def make_model():
+    cfg = tiny_config()
+    model = k3.Model(k3.ModelArgs.from_dict(cfg))
+    mx.eval(model.parameters())
+    return model
+
+
+def test_get_classes_resolves_kimi_k3():
+    from mlx_lm.utils import _get_classes
+
+    model_class, args_class = _get_classes(tiny_config())
+    assert model_class is k3.Model
+    assert args_class is k3.ModelArgs
+
+
+def test_layer_and_mlp_typing():
+    model = make_model()
+    kinds = ["KDA" if l.is_linear else "MLA" for l in model.layers]
+    assert kinds == ["KDA", "KDA", "KDA", "MLA", "KDA"]
+    mlps = [type(l.mlp).__name__ for l in model.layers]
+    assert mlps == ["KimiMLP"] + ["LatentMoE"] * 4
+
+
+def test_make_cache_matches_layer_types():
+    from mlx_lm.models.cache import ArraysCache, KVCache
+
+    model = make_model()
+    cache = model.make_cache()
+    assert [type(c) for c in cache] == [
+        ArraysCache,
+        ArraysCache,
+        ArraysCache,
+        KVCache,
+        ArraysCache,
+    ]
+
+
+def test_forward_prefill_and_decode():
+    model = make_model()
+    cache = model.make_cache()
+    tokens = mx.array([[1, 5, 9, 3, 7, 2]])
+    logits = model(tokens, cache=cache)
+    mx.eval(logits)
+    assert logits.shape == (1, 6, 128)
+    assert not bool(mx.isnan(logits).any())
+
+    tok = mx.argmax(logits[:, -1:], axis=-1)
+    step = model(tok, cache=cache)
+    mx.eval(step)
+    assert step.shape == (1, 1, 128)
+    assert not bool(mx.isnan(step).any())
+
+
+def test_prefill_matches_incremental_decode():
+    model = make_model()
+    tokens = mx.array([[1, 5, 9, 3, 7, 2]])
+
+    cache_a = model.make_cache()
+    full = model(tokens, cache=cache_a)
+
+    cache_b = model.make_cache()
+    model(tokens[:, :-1], cache=cache_b)
+    step = model(tokens[:, -1:], cache=cache_b)
+
+    diff = float(mx.abs(full[:, -1] - step[:, 0]).max())
+    assert diff < 2e-2, f"prefill/decode divergence {diff}"
+
+
+def _checkpoint_style_weights(model):
+    """Synthesize a checkpoint-shaped weight dict (per-expert w1/w3/w2 under
+    block_sparse_moe, padded A_log, conv1d layout, kv_b_proj unsplit, plus a
+    vision tower to drop) matching the tiny config."""
+    args = model.text_args
+    lac = args.linear_attn_config
+    n_heads, head_dim = lac["num_heads"], lac["head_dim"]
+    proj = n_heads * head_dim
+    w = {}
+
+    def rnd(*shape):
+        return mx.random.normal(shape=shape) * 0.02
+
+    w["vision_tower.encoder.blocks.0.wqkv.weight"] = rnd(8, 8)
+    w["mm_projector.proj.0.weight"] = rnd(8, 8)
+
+    for i, layer in enumerate(model.layers):
+        p = f"language_model.model.layers.{i}"
+        w[f"{p}.input_layernorm.weight"] = mx.ones((HIDDEN,))
+        w[f"{p}.post_attention_layernorm.weight"] = mx.ones((HIDDEN,))
+        for res in ("self_attention_res", "mlp_res"):
+            w[f"{p}.{res}_norm.weight"] = mx.ones((HIDDEN,))
+            w[f"{p}.{res}_proj.weight"] = rnd(1, HIDDEN)
+
+        if layer.is_linear:
+            for name in ("q_proj", "k_proj", "v_proj"):
+                w[f"{p}.self_attn.{name}.weight"] = rnd(proj, HIDDEN)
+            for name in ("q_conv1d", "k_conv1d", "v_conv1d"):
+                w[f"{p}.self_attn.{name}.weight"] = rnd(proj, 1, 4)
+            w[f"{p}.self_attn.f_a_proj.weight"] = rnd(head_dim, HIDDEN)
+            w[f"{p}.self_attn.f_b_proj.weight"] = rnd(proj, head_dim)
+            w[f"{p}.self_attn.b_proj.weight"] = rnd(n_heads, HIDDEN)
+            w[f"{p}.self_attn.g_proj.weight"] = rnd(proj, HIDDEN)
+            # zero-padded to head_dim, as in the real checkpoint
+            w[f"{p}.self_attn.A_log"] = mx.concatenate(
+                [rnd(n_heads), mx.zeros((head_dim - n_heads,))]
+            )
+            w[f"{p}.self_attn.dt_bias"] = rnd(proj)
+            w[f"{p}.self_attn.o_norm.weight"] = mx.ones((head_dim,))
+            w[f"{p}.self_attn.o_proj.weight"] = rnd(HIDDEN, proj)
+        else:
+            q_head = args.qk_nope_head_dim + args.qk_rope_head_dim
+            w[f"{p}.self_attn.q_a_proj.weight"] = rnd(args.q_lora_rank, HIDDEN)
+            w[f"{p}.self_attn.q_a_layernorm.weight"] = mx.ones((args.q_lora_rank,))
+            w[f"{p}.self_attn.q_b_proj.weight"] = rnd(
+                args.num_attention_heads * q_head, args.q_lora_rank
+            )
+            w[f"{p}.self_attn.kv_a_proj_with_mqa.weight"] = rnd(
+                args.kv_lora_rank + args.qk_rope_head_dim, HIDDEN
+            )
+            w[f"{p}.self_attn.kv_a_layernorm.weight"] = mx.ones((args.kv_lora_rank,))
+            w[f"{p}.self_attn.kv_b_proj.weight"] = rnd(
+                args.num_attention_heads * (args.qk_nope_head_dim + args.v_head_dim),
+                args.kv_lora_rank,
+            )
+            w[f"{p}.self_attn.g_proj.weight"] = rnd(
+                args.num_attention_heads * args.v_head_dim, HIDDEN
+            )
+            w[f"{p}.self_attn.o_proj.weight"] = rnd(
+                HIDDEN, args.num_attention_heads * args.v_head_dim
+            )
+
+        if type(layer.mlp).__name__ == "LatentMoE":
+            mp = f"{p}.block_sparse_moe"
+            w[f"{mp}.gate.weight"] = rnd(N_EXPERTS, HIDDEN)
+            w[f"{mp}.gate.e_score_correction_bias"] = mx.zeros(
+                (N_EXPERTS,), dtype=mx.float32
+            )
+            w[f"{mp}.routed_expert_down_proj.weight"] = rnd(LATENT, HIDDEN)
+            w[f"{mp}.routed_expert_up_proj.weight"] = rnd(HIDDEN, LATENT)
+            w[f"{mp}.routed_expert_norm.weight"] = mx.ones((LATENT,))
+            for name, (o, i_) in (
+                ("gate_proj", (MOE_INTER * 2, HIDDEN)),
+                ("up_proj", (MOE_INTER * 2, HIDDEN)),
+                ("down_proj", (HIDDEN, MOE_INTER * 2)),
+            ):
+                w[f"{mp}.shared_experts.{name}.weight"] = rnd(o, i_)
+            for e in range(N_EXPERTS):
+                w[f"{mp}.experts.{e}.w1.weight"] = rnd(MOE_INTER, LATENT)
+                w[f"{mp}.experts.{e}.w3.weight"] = rnd(MOE_INTER, LATENT)
+                w[f"{mp}.experts.{e}.w2.weight"] = rnd(LATENT, MOE_INTER)
+        else:
+            for name, (o, i_) in (
+                ("gate_proj", (128, HIDDEN)),
+                ("up_proj", (128, HIDDEN)),
+                ("down_proj", (HIDDEN, 128)),
+            ):
+                w[f"{p}.mlp.{name}.weight"] = rnd(o, i_)
+
+    w["language_model.model.embed_tokens.weight"] = rnd(128, HIDDEN)
+    w["language_model.model.norm.weight"] = mx.ones((HIDDEN,))
+    w["language_model.model.output_attn_res_norm.weight"] = mx.ones((HIDDEN,))
+    w["language_model.model.output_attn_res_proj.weight"] = rnd(1, HIDDEN)
+    w["language_model.lm_head.weight"] = rnd(128, HIDDEN)
+    return w
+
+
+def test_sanitize_normalizes_checkpoint_layout():
+    model = make_model()
+    raw = _checkpoint_style_weights(model)
+    out = model.sanitize(dict(raw))
+
+    assert not any(k.startswith(("vision_tower.", "mm_projector.")) for k in out)
+    assert not any(".block_sparse_moe." in k for k in out)
+
+    stacked = out["language_model.model.layers.1.mlp.switch_mlp.gate_proj.weight"]
+    assert stacked.shape == (N_EXPERTS, MOE_INTER, LATENT)
+    assert (
+        "language_model.model.layers.1.mlp.gate.e_score_correction_bias" in out
+    )
+    a_log = out["language_model.model.layers.0.self_attn.A_log"]
+    assert a_log.shape == (4,)  # de-padded from head_dim=16 to num_heads=4
+    conv = out["language_model.model.layers.0.self_attn.q_conv.conv.weight"]
+    assert conv.shape == (64, 4, 1)  # (C, K, 1) after moveaxis
+    assert "language_model.model.layers.3.self_attn.embed_q.weight" in out
+    assert "language_model.model.layers.3.self_attn.kv_b_proj.weight" not in out
+
+    # the sanitized dict must load cleanly and run
+    model.load_weights(list(out.items()), strict=True)
+    logits = model(mx.array([[1, 2, 3]]))
+    mx.eval(logits)
+    assert not bool(mx.isnan(logits).any())
+
+
+def test_sanitize_is_idempotent():
+    model = make_model()
+    once = model.sanitize(_checkpoint_style_weights(model))
+    twice = model.sanitize(dict(once))
+    assert set(once) == set(twice)
+    for k in once:
+        assert once[k].shape == twice[k].shape
+        assert bool((once[k] == twice[k]).all()), f"{k} changed on second sanitize"
+
+
+def test_sanitize_mxfp4_packed_experts():
+    """Packed uint8 experts view to uint32 weights + raw uint8 scales."""
+    model = make_model()
+    raw = _checkpoint_style_weights(model)
+    # replace layer 1's float experts with an mxfp4-packed layout
+    mp = "language_model.model.layers.1.block_sparse_moe"
+    for e in range(N_EXPERTS):
+        for mat, (o, i_) in (
+            ("w1", (MOE_INTER, LATENT)),
+            ("w3", (MOE_INTER, LATENT)),
+            ("w2", (LATENT, MOE_INTER)),
+        ):
+            raw.pop(f"{mp}.experts.{e}.{mat}.weight")
+            wq, sq = mx.quantize(
+                mx.random.normal(shape=(o, i_)) * 0.02,
+                group_size=32,
+                bits=4,
+                mode="mxfp4",
+            )
+            raw[f"{mp}.experts.{e}.{mat}.weight_packed"] = wq.view(mx.uint8)
+            raw[f"{mp}.experts.{e}.{mat}.weight_scale"] = sq
+
+    out = model.sanitize(raw)
+    w = out["language_model.model.layers.1.mlp.switch_mlp.gate_proj.weight"]
+    s = out["language_model.model.layers.1.mlp.switch_mlp.gate_proj.scales"]
+    assert w.dtype == mx.uint32 and w.shape == (N_EXPERTS, MOE_INTER, LATENT // 8)
+    assert s.dtype == mx.uint8 and s.shape == (N_EXPERTS, MOE_INTER, LATENT // 32)
+
+
+def test_situ_activation_matches_reference_formula():
+    import math
+
+    beta, lb = 4.0, 25.0
+    g, u = 1.7, -3.2
+    want = (beta * math.tanh(g / beta) * (1 / (1 + math.exp(-g)))) * (
+        lb * math.tanh(u / lb)
+    )
+    got = float(
+        k3.situ_mul(mx.array([g]), mx.array([u]), beta, lb)[0]
+    )
+    assert abs(got - want) < 1e-6

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -494,3 +494,55 @@ class TestPartialCache:
         pl = build_plan(p, wired_gb=10.5, ram_gb=16)
         assert any("UNDER-counted" in w for w in pl["warnings"])
         assert "UNDER-counted" in render(pl)
+
+
+K3_TEXT = {
+    # Kimi K3 geometry (moonshotai/Kimi-K3 text_config), the KDA/MLA dialect:
+    # layer lists are 1-based; only the 24 MLA layers hold growing KV, and MLA
+    # caches the shared latent + rope key once per layer, not per head.
+    "num_hidden_layers": 93,
+    "num_attention_heads": 96,
+    "num_key_value_heads": 96,
+    "kv_lora_rank": 512,
+    "qk_rope_head_dim": 64,
+    "head_dim": None,
+    "hidden_size": 7168,
+    "linear_attn_config": {
+        "num_heads": 96,
+        "head_dim": 128,
+        "short_conv_kernel_size": 4,
+        "kda_layers": [i for i in range(1, 94) if i % 4 != 0 and i != 93],
+        "full_attn_layers": [i for i in range(4, 93, 4)] + [93],
+    },
+}
+
+
+class TestKDAHybrid:
+    def test_kda_hybrid_reads_full_attn_layers(self):
+        cfg = {"text_config": K3_TEXT}
+        n_full, n_slide, n_layers, note = _attention_layers(cfg)
+        assert (n_full, n_slide, n_layers) == (24, 0, 93)
+        assert "KDA" in note
+
+    def test_mla_latent_kv_geometry(self):
+        """The dense formula (2*96 heads*128 dim) over-predicts K3's KV ~160x:
+        MLA caches (kv_lora_rank + qk_rope_head_dim) once per layer."""
+        cfg = {"text_config": K3_TEXT}
+        context = 65536
+        total, per_tok, note = kv_bytes(cfg, context)
+        lac = K3_TEXT["linear_attn_config"]
+        fixed_kda = len(lac["kda_layers"]) * (
+            96 * 128 * 128 * 4.0 + 3 * 3 * 96 * 128 * 2.0
+        )
+        grow = 24 * context * (512 + 64) * 2.0
+        assert total == pytest.approx(grow + fixed_kda)
+        assert "MLA latent" in note and "KDA state" in note
+        # sanity: a 1M-token context stays under 30 GB of KV
+        total_1m, *_ = kv_bytes(cfg, 1_048_576)
+        assert total_1m < 30 * GB
+
+    def test_kda_fixed_state_is_charged_at_zero_context(self):
+        """The recurrent state exists before the first token; never report 0."""
+        cfg = {"text_config": K3_TEXT}
+        total, *_ = kv_bytes(cfg, 1)
+        assert total > 0.4 * GB

--- a/tests/test_stream_cache.py
+++ b/tests/test_stream_cache.py
@@ -81,6 +81,83 @@ def test_eviction_respects_budget():
     assert cache.cur <= 200 + 48
 
 
+class FailingReader(FakeReader):
+    """FakeReader that raises on selected (key, expert) reads."""
+
+    def __init__(self, fail_keys=(), **kw):
+        super().__init__(**kw)
+        self.fail = set(fail_keys)
+
+    def read_expert_np(self, key: str, expert: int):
+        if (key, expert) in self.fail:
+            raise OSError("injected disk error")
+        return super().read_expert_np(key, expert)
+
+
+def test_fanout_skips_trigger_and_counts_as_critical_path():
+    # Same-layer fan-out must (a) skip the trigger projection — its gather
+    # runs next on the calling thread and keeps the coalesced read path —
+    # and (b) account pool-read claims as misses + fanout_hits, never as
+    # prefetch_hits, so hit_rate keeps meaning "no same-token disk read".
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=4)
+    cache.register_layer(0, [("L0.up.weight", "L0.up.scales"),
+                             ("L0.gate.weight", "L0.gate.scales"),
+                             ("L0.down.weight", "L0.down.scales")])
+    cache.on_layer_start(0, [1, 2], trigger_wkey="L0.up.weight")
+    with cache._lock:
+        assert ("L0.up.weight", 1) not in cache._inflight
+        assert ("L0.up.weight", 1) not in cache._staging
+    cache.gather("L0.up.weight", "L0.up.scales", [1, 2])
+    assert cache.misses == 2 and cache.fanout_hits == 0
+    cache.gather("L0.gate.weight", "L0.gate.scales", [1, 2])
+    cache.gather("L0.down.weight", "L0.down.scales", [1, 2])
+    assert cache.misses == 6
+    assert cache.fanout_hits == 4
+    assert cache.prefetch_hits == 0
+    assert cache.bytes_prefetched == 0 and cache.bytes_read > 0
+    assert cache.stats()["hit_rate"] == 0.0
+
+
+def test_no_fanout_flag_disables_layer_fanout():
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9,
+                        prefetch_workers=4, fanout=False)
+    cache.register_layer(0, [("a.weight", "a.scales"),
+                             ("b.weight", "b.scales")])
+    cache.on_layer_start(0, [0, 1], trigger_wkey="a.weight")
+    with cache._lock:
+        assert not cache._inflight and not cache._staging
+    cache.gather("b.weight", "b.scales", [0, 1])
+    assert cache.fanout_hits == 0 and cache.misses == 2
+
+
+def test_throttle_disables_fanout_too():
+    # When the saturation throttle judges storage bandwidth-bound it must
+    # stop BOTH speculation and the same-layer fan-out from competing for
+    # the bus (fan-out has no other kill switch besides --no-fanout).
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9,
+                        prefetch_workers=2, prefetch_ahead=1)
+    cache.prefetched = cache._throttle_warmup
+    cache.misses = 1000  # rescue rate 0%
+    cache.on_layer_start(0, [], trigger_wkey=None)
+    assert cache._prefetch_ahead == 0
+    assert cache._fanout is False
+
+
+def test_background_read_error_counted_and_recovered():
+    # A failed background read must be visible (prefetch_errors) and must
+    # fall back to a synchronous load with correct content, not hang or lose
+    # the expert.
+    rd = FailingReader(fail_keys=[("b.weight", 2)])
+    cache = ExpertCache(rd, budget_bytes=10**9, prefetch_workers=1)
+    cache._prefetch_one("b.weight", "b.scales", 2)  # direct: deterministic
+    assert cache.prefetch_errors == 1
+    assert cache.stats()["prefetch_errors"] == 1
+    rd.fail.clear()
+    w, _ = cache.gather("b.weight", "b.scales", [2])
+    assert cache.misses == 1
+    assert int(np.array(w)[0][0]) == 20  # expert 2 -> 2*10 at column 0
+
+
 def test_prefetch_staging_hit():
     # A staged expert (weight+scales held under one key) is served from the
     # staging area without a critical-path miss, and its content matches a

--- a/tests/test_tokenizer_trust.py
+++ b/tests/test_tokenizer_trust.py
@@ -1,0 +1,45 @@
+"""Regression tests for the K3 tokenizer trust gate (compat.is_local_kimi_k3).
+
+Contract (PR review blocker): trust_remote_code is auto-injected ONLY for a
+local directory whose config.json declares model_type == "kimi_k3". Any other
+local model, hub repo id, or missing/corrupt config must be left alone —
+downloading tokenizer code and executing it are separate trust decisions,
+and a blanket local-directory default collapses them.
+"""
+
+import json
+
+import turboquant_mlx.compat as compat
+
+
+def _model_dir(tmp_path, model_type):
+    d = tmp_path / "model"
+    d.mkdir()
+    (d / "config.json").write_text(json.dumps({"model_type": model_type}))
+    return d
+
+
+def test_local_kimi_k3_dir_is_trusted(tmp_path):
+    assert compat.is_local_kimi_k3(_model_dir(tmp_path, "kimi_k3")) is True
+
+
+def test_other_local_model_is_not_trusted(tmp_path):
+    # the review's repro: a local qwen3_moe dir must NOT execute its own code
+    assert compat.is_local_kimi_k3(_model_dir(tmp_path, "qwen3_moe")) is False
+
+
+def test_hub_repo_id_is_not_trusted():
+    assert compat.is_local_kimi_k3("moonshotai/Kimi-K3") is False
+
+
+def test_dir_without_config_is_not_trusted(tmp_path):
+    d = tmp_path / "empty"
+    d.mkdir()
+    assert compat.is_local_kimi_k3(d) is False
+
+
+def test_corrupt_config_fails_safe(tmp_path):
+    d = tmp_path / "corrupt"
+    d.mkdir()
+    (d / "config.json").write_text("{not json")
+    assert compat.is_local_kimi_k3(d) is False


### PR DESCRIPTION
Adds support for moonshotai/Kimi-K3 — 2.8T total / 104B active parameters, 896 experts (top-16), 93 layers (69 KDA linear-attention + 24 gated MLA), 1M context — the largest open-weight model to date, and the first 3T-class model to run on a single consumer Mac.
  
Closes #70.

## Results (M4 Max, 128 GB, internal SSD)

| | Measured |
|---|---|
| Source checkpoint (mxfp4 compressed-tensors) | 1.56 TB, 96 shards |
| Conversion (`--bits 3 -g 64 --ternary-experts --expert-down-bits 4 --streaming`) | **25.7 min**, flat memory |
| Converted build | **931 GB** (903.5 GB streamable experts + 27.8 GB resident) |
| Decode (cold cache, `--cache-budget-gb auto` = 84.7 GB) | 0.36 tok/s, 53.3% hit rate |
| Peak memory | 113.2 GB (planner projected 113.5) |
| Output | coherent ("The sky is blue because" → Rayleigh scattering) |
  
 ## Results (Mac Studio, 512 GB, internal SSD)

Same 931 GB build, `iogpu.wired_limit_mb=512000`, 200-token decode of "Explain how Rayleigh scattering works." with `--no-chat-template`:

| | Measured |
|---|---|
| Expert cache (`--cache-budget-gb auto`) | **506 GB** (56% of the 903.5 GB expert pool) |
| Decode — native top-16 (`--prefetch-workers 16`) | **1.18 tok/s**, 99.6% hit rate, 13.4 GB critical reads |
| Decode — 2× K-cut top-8 (`--max-active-experts 8 --prefetch-workers 16`) | **2.30 tok/s**, 100% hit rate, **0.0 GB critical reads** |
| Peak memory | 530 GB (top-16) · 400 GB (top-8) |
| Prefetch-worker knee | 16 (8 serializes ≈ −30%; 32 is flat — not disk-bandwidth-bound past 16) |
| Output | coherent + accurate (Rayleigh λ⁻⁴, blue sky / red sunset, thinking mode) |

## Commit 1 — model port + converter path

- `models/kimi_k3.py`: KDA with K3's bounded "safe gate" (`lower_bound·σ(exp(A_log)·(a+dt_bias))` - a *replacement* for the softplus form, semantics cross-checked against fla and Moonshot's vLLM K3 kernels), full-rank output gate, A_log de-padding (checkpoint stores per-head [96] zero-padded to [128]); NoPE MLA with q-LoRA and sigmoid output gate; Stable LatentMoE (experts in a 3584-d latent behind shared projections, top-k combined in latent space); AttnRes; `situ` activation. `sanitize` normalizes everything to the existing streaming layout (`block_sparse_moe`→`mlp`, `w1/w3/w2`→ `gate/up/down_proj`, 896 per-expert mxfp4 tensors stacked via `weight_packed.view(uint32)` - verified bit-exact vs compressed-tensors), so **the streaming core needed zero changes**.
- `compat.py`: `kimi_k3` dispatch registration; route compressed-tensors `mxfp4-pack-quantized` to `mode="mxfp4"` (mlx-lm hardcodes affine - will file upstream); `trust_remote_code` for local-directory tokenizers.
- Converter: per-expert lazy dequant of pre-quantized MoEs (measured ~30 GB → ~0.4 GB peak per 896-expert projection); protect AttnRes score rows and always-on `shared_experts`/`routed_expert_*` from the expert quant tiers.

## Commit 2 — planner + streaming

- `plan.py`: KDA-hybrid dialect (1-based `full_attn_layers`), MLA latent KV geometry (fixes a ~160x KV over-prediction → false "WILL NOT RUN"), fixed KDA recurrent-state accounting, `num_experts_per_token` spelling.
- `stream/loader.py`: warn when K-reduction cuts native top_k by more than the validated 2x (K3 is top-16; the default cap of 4 would be a silent 4x truncation).

## Validation

- fp32 logit parity vs Moonshot's reference implementation on **real checkpoint weights** (layers 0–3, 32-expert subset): max diff ≤2.7e-6 per layer, teacher-forced and free-running (torch harness runs the HF reference on CPU via a pure-torch fla stub; available on request).
- mxfp4 decode verified bit-exact against compressed-tensors 0.17.1 on synthetic full-code coverage + real expert tensors.
- Full suite green: 402 passed (16 new: dispatch, hybrid cache typing, AttnRes forward, sanitize layout/idempotence/mxfp4, KDA/MLA planner geometry, expert-naming drift guard incl. latent projections staying resident).

## Scope / follow-ups

- **Text-only v1** — the vision tower is dropped at conversion (K3's own quantization `ignore` list already excludes it); a `convert_vlm` path can follow.
- README architecture-table row + model card with these numbers can land here or in a follow-up, maintainer's preference.
- MTP/nextn: K3 ships none (`num_nextn_predict_layers: 0`) — nothing to do.
