### PR TITLE
feat: sarvam_moe architecture support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,29 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Verified against the HF reference at ≤ 2.7e-6 fp32 forward parity, with a
   bit-exact mxfp4 unpack check.
 
+- **`sarvam_moe` architecture support** (Sarvam AI's sarvam-30b and any later
+  model of that type). mlx-lm has no module for it, so `compat.py` aliases our
+  port in the same way it already does for Laguna. The port is verified three
+  ways against the fp32 reference: full key/shape coverage of all 7122 source
+  tensors, layer-1 output parity at 5.4e-7, and whole-model logit agreement.
+
+  Two details of this architecture are easy to get wrong and are pinned by
+  tests. The checkpoint is Megatron-style, so attention arrives as a single
+  fused `attention.query_key_value` matrix — the reference views it as
+  `(heads + 2*kv_heads, head_dim)` and splits on the head axis, which makes a
+  plain row split exact, but a Q/K/V mis-slice still produces a model that
+  loads and generates plausible-looking text. Routing is DeepSeek-V3-style:
+  sigmoid scores with `expert_bias` added **for selection only**, so the bias
+  must not leak into the combine weights. The router is deliberately not an
+  `nn.Linear`, which keeps the quantizer's module walk from quantizing it.
+
+  Note on quantization: at 4-bit this model degenerates on long generations,
+  measured as a rate over repeated trials at temp 0.7 / top_p 0.9 —
+  **TurboQuant 4-bit degenerated 8/15 (53%), mlx-lm affine 4-bit 15/15
+  (100%)**. TurboQuant is clearly the better of the two, and neither is good
+  enough to ship, so no quantized sarvam build is published. Use a higher bit
+  width and validate long-form output on your own prompts.
+
 - **`--fanout` on `stream_generate` and `serve`** — same-layer read fan-out:
   once a layer's router has chosen its experts, the other projections' misses
   are submitted to the read pool at layer start so their reads overlap the

--- a/compat.py
+++ b/compat.py
@@ -83,54 +83,35 @@ def _patch_nemotron_h_pattern():
                 break
 
 
-def _register_laguna_model():
-    """Register the MLX Laguna model so mlx-lm's ``_get_classes`` can find it.
+def _register_local_model(model_type: str, module_name: str = None):
+    """Register one of our MLX ports so mlx-lm's ``_get_classes`` can find it.
 
     mlx-lm dispatches a checkpoint's ``model_type`` via
-    ``importlib.import_module(f"mlx_lm.models.{model_type}")``. Poolside's Laguna
-    architecture has no upstream mlx-lm module yet, so we alias our
-    implementation into ``sys.modules`` under that name — ``importlib`` consults
-    ``sys.modules`` first, so this makes ``load_turboquant`` (and plain mlx-lm)
-    resolve ``laguna`` to our ``Model`` / ``ModelArgs``. Idempotent, and
-    self-disables the moment mlx-lm ships native Laguna support.
+    ``importlib.import_module(f"mlx_lm.models.{model_type}")``. Architectures with
+    no upstream mlx-lm module (Poolside's Laguna, Moonshot's Kimi K3, Sarvam AI's
+    MoE) are aliased into ``sys.modules`` under that name — for K3 the alias is on
+    the *wrapper* type its config declares at top level, not the ``kimi_linear``
+    text tower inside ``text_config`` that mlx-lm already knows. ``importlib``
+    consults ``sys.modules`` first,
+    so this makes ``load_turboquant`` (and plain mlx-lm) resolve the type to our
+    ``Model`` / ``ModelArgs``. Idempotent, and self-disables per architecture the
+    moment mlx-lm ships native support for it.
     """
+    import importlib
     import sys
 
-    if "mlx_lm.models.laguna" in sys.modules:
+    target = f"mlx_lm.models.{model_type}"
+    if target in sys.modules:
         return
     try:
-        import mlx_lm.models.laguna  # noqa: F401 — native support exists; defer
+        importlib.import_module(target)  # native support exists; defer to it
         return
     except ImportError:
         pass
 
-    from turboquant_mlx.models import laguna as _laguna
-
-    sys.modules["mlx_lm.models.laguna"] = _laguna
-
-
-def _register_kimi_k3_model():
-    """Register the MLX Kimi K3 model so mlx-lm's ``_get_classes`` can find it.
-
-    Same mechanism as :func:`_register_laguna_model`: K3 checkpoints carry
-    ``model_type: "kimi_k3"`` at the top level (the text tower inside
-    ``text_config`` is ``kimi_linear``, which mlx-lm knows, but the wrapper is
-    what ``_get_classes`` dispatches on). Idempotent; self-disables the moment
-    mlx-lm ships native support.
-    """
-    import sys
-
-    if "mlx_lm.models.kimi_k3" in sys.modules:
-        return
-    try:
-        import mlx_lm.models.kimi_k3  # noqa: F401 — native support exists; defer
-        return
-    except ImportError:
-        pass
-
-    from turboquant_mlx.models import kimi_k3 as _kimi_k3
-
-    sys.modules["mlx_lm.models.kimi_k3"] = _kimi_k3
+    sys.modules[target] = importlib.import_module(
+        f"turboquant_mlx.models.{module_name or model_type}"
+    )
 
 
 def _patch_compressed_tensors_mxfp4():
@@ -284,8 +265,9 @@ def _patch_glm47_tool_name_strip():
 
 
 _patch_nemotron_h_pattern()
-_register_laguna_model()
-_register_kimi_k3_model()
+_register_local_model("laguna")
+_register_local_model("kimi_k3")
+_register_local_model("sarvam_moe")
 _patch_compressed_tensors_mxfp4()
 _patch_kimi_k3_tokenizer_trust()
 _patch_glm47_tool_name_strip()

--- a/models/sarvam_moe.py
+++ b/models/sarvam_moe.py
@@ -1,0 +1,345 @@
+# Copyright 2026 Manjunath Janardhan
+"""MLX implementation of Sarvam AI's MoE architecture (``model_type: "sarvam_moe"``).
+
+Ported from the ``transformers`` ``SarvamMoEForCausalLM`` reference shipped in the
+checkpoint's own ``modeling_sarvam_moe.py``. The forward pass itself is ordinary —
+GQA attention with QK-norm, then a sigmoid-routed MoE with a shared expert — but the
+*checkpoint naming* is Megatron-style rather than Llama-style, so most of the work
+happens in :meth:`Model.sanitize`:
+
+* **Fused QKV** — the checkpoint stores one ``attention.query_key_value.weight``
+  of shape ``(num_heads + 2 * num_kv_heads) * head_dim, hidden``. The reference
+  reshapes to ``(..., n_heads_total, head_dim)`` and splits along the *head* axis,
+  so the rows are contiguous blocks of Q, then K, then V, and a plain row split
+  reproduces it exactly. We split it here into standard ``q_proj`` / ``k_proj`` /
+  ``v_proj`` so downstream tooling sees conventional names.
+* **``attention.dense`` -> ``self_attn.o_proj``**, ``query_layernorm`` /
+  ``key_layernorm`` -> ``q_norm`` / ``k_norm``, ``model.word_embeddings`` ->
+  ``model.embed_tokens``.
+* **Per-expert tensors** — ``mlp.experts.7.gate_proj.weight`` (2D, one per expert)
+  are stacked into ``SwitchGLU``'s ``(E, out, in)`` form.
+
+Naming matters beyond aesthetics: :meth:`TurboQuantConfig.bits_for_path` resolves
+``--attn-bits`` by looking for an ``self_attn`` / ``attention`` path segment, so a
+non-standard attention container would make the flag a silent no-op (the bug that
+bit us on Nemotron's ``mixer.*`` paths).
+
+Routing follows DeepSeek-V3: sigmoid scores, ``expert_bias`` added for *selection
+only*, top-k weights renormalized to sum 1, then scaled by ``routed_scaling_factor``.
+``n_group``/``topk_group`` are both 1 in the released config, which makes the
+reference's ``group_limited_topk`` degenerate to a plain top-k; we assert that rather
+than reimplementing the grouped path.
+"""
+
+from dataclasses import dataclass
+from typing import Dict
+
+import mlx.core as mx
+import mlx.nn as nn
+
+from mlx_lm.models.base import BaseModelArgs, create_attention_mask
+from mlx_lm.models.switch_layers import SwitchGLU
+
+
+@dataclass
+class ModelArgs(BaseModelArgs):
+    model_type: str
+    vocab_size: int
+    hidden_size: int
+    intermediate_size: int
+    num_hidden_layers: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    rms_norm_eps: float
+    num_experts: int
+    num_experts_per_tok: int
+    moe_intermediate_size: int
+    rope_theta: float
+    first_k_dense_replace: int = 1
+    num_shared_experts: int = 1
+    moe_shared_expert_intermediate_size: int = 0
+    routed_scaling_factor: float = 1.0
+    score_function: str = "sigmoid"
+    n_group: int = 1
+    topk_group: int = 1
+    norm_topk_prob: bool = True
+    use_qk_norm: bool = True
+    use_bias: bool = False
+    use_qkv_bias: bool = False
+    max_position_embeddings: int = 131072
+    tie_word_embeddings: bool = False
+
+    def __post_init__(self):
+        if self.score_function != "sigmoid":
+            raise ValueError(
+                f"unsupported score_function {self.score_function!r} "
+                "(only 'sigmoid' is implemented)"
+            )
+        if self.n_group != 1 or self.topk_group != 1:
+            raise ValueError(
+                f"grouped expert routing (n_group={self.n_group}, "
+                f"topk_group={self.topk_group}) is not implemented; the released "
+                "sarvam_moe configs use 1/1, which is plain top-k"
+            )
+        if not self.moe_shared_expert_intermediate_size:
+            # reference: moe_intermediate_size * num_shared_experts
+            self.moe_shared_expert_intermediate_size = (
+                self.moe_intermediate_size * self.num_shared_experts
+            )
+
+
+class MLP(nn.Module):
+    def __init__(self, hidden_size: int, intermediate_size: int):
+        super().__init__()
+        self.gate_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.up_proj = nn.Linear(hidden_size, intermediate_size, bias=False)
+        self.down_proj = nn.Linear(intermediate_size, hidden_size, bias=False)
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return self.down_proj(nn.silu(self.gate_proj(x)) * self.up_proj(x))
+
+
+class Attention(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.num_heads = args.num_attention_heads
+        self.num_kv_heads = args.num_key_value_heads
+        self.head_dim = args.head_dim
+        self.scale = self.head_dim**-0.5
+        self.use_qk_norm = args.use_qk_norm
+
+        self.q_proj = nn.Linear(
+            args.hidden_size, self.num_heads * self.head_dim, bias=args.use_qkv_bias
+        )
+        self.k_proj = nn.Linear(
+            args.hidden_size, self.num_kv_heads * self.head_dim, bias=args.use_qkv_bias
+        )
+        self.v_proj = nn.Linear(
+            args.hidden_size, self.num_kv_heads * self.head_dim, bias=args.use_qkv_bias
+        )
+        self.o_proj = nn.Linear(
+            self.num_heads * self.head_dim, args.hidden_size, bias=args.use_bias
+        )
+
+        if self.use_qk_norm:
+            self.q_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+            self.k_norm = nn.RMSNorm(self.head_dim, eps=args.rms_norm_eps)
+
+        self.rope = nn.RoPE(self.head_dim, traditional=False, base=args.rope_theta)
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        B, L, _ = x.shape
+
+        q = self.q_proj(x).reshape(B, L, self.num_heads, -1).transpose(0, 2, 1, 3)
+        k = self.k_proj(x).reshape(B, L, self.num_kv_heads, -1).transpose(0, 2, 1, 3)
+        v = self.v_proj(x).reshape(B, L, self.num_kv_heads, -1).transpose(0, 2, 1, 3)
+
+        # reference applies QK-norm per head *before* RoPE
+        if self.use_qk_norm:
+            q = self.q_norm(q)
+            k = self.k_norm(k)
+
+        if cache is not None:
+            q = self.rope(q, offset=cache.offset)
+            k = self.rope(k, offset=cache.offset)
+            k, v = cache.update_and_fetch(k, v)
+        else:
+            q = self.rope(q)
+            k = self.rope(k)
+
+        out = mx.fast.scaled_dot_product_attention(
+            q, k, v, scale=self.scale, mask=mask
+        )
+        out = out.transpose(0, 2, 1, 3).reshape(B, L, -1)
+        return self.o_proj(out)
+
+
+class Router(nn.Module):
+    """Sigmoid router with a selection-only bias.
+
+    Deliberately *not* an ``nn.Linear``: the quantizer walks the module tree for
+    linear layers, and the router must stay in full precision (the checkpoint keeps
+    it fp32 even in otherwise-bf16 mirrors, matching ``router_dtype: fp32``).
+    """
+
+    def __init__(self, hidden_size: int, num_experts: int):
+        super().__init__()
+        self.weight = mx.zeros((num_experts, hidden_size))
+        self.expert_bias = mx.zeros((num_experts,))
+
+    def __call__(self, x: mx.array) -> mx.array:
+        return x @ self.weight.T
+
+
+class SarvamMoE(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.top_k = args.num_experts_per_tok
+        self.route_scale = args.routed_scaling_factor
+        self.norm_topk_prob = args.norm_topk_prob
+
+        self.gate = Router(args.hidden_size, args.num_experts)
+        self.experts = SwitchGLU(
+            args.hidden_size, args.moe_intermediate_size, args.num_experts
+        )
+        self.shared_experts = MLP(
+            args.hidden_size, args.moe_shared_expert_intermediate_size
+        )
+
+    def __call__(self, x: mx.array) -> mx.array:
+        logits = self.gate(x.astype(mx.float32))
+        scores = mx.sigmoid(logits)
+
+        # expert_bias steers *selection* only; the combine weights use raw scores
+        selection = scores + self.gate.expert_bias.astype(mx.float32)
+        k = self.top_k
+        inds = mx.argpartition(-selection, kth=k - 1, axis=-1)[..., :k]
+
+        weights = mx.take_along_axis(scores, inds, axis=-1)
+        if self.norm_topk_prob and k > 1:
+            weights = weights / (weights.sum(axis=-1, keepdims=True) + 1e-20)
+        weights = (weights * self.route_scale).astype(x.dtype)
+
+        y = self.experts(x, inds)
+        y = (y * weights[..., None]).sum(axis=-2).astype(x.dtype)
+        return y + self.shared_experts(x)
+
+
+class DecoderLayer(nn.Module):
+    def __init__(self, args: ModelArgs, layer_idx: int):
+        super().__init__()
+        self.self_attn = Attention(args)
+        if layer_idx < args.first_k_dense_replace:
+            self.mlp = MLP(args.hidden_size, args.intermediate_size)
+        else:
+            self.mlp = SarvamMoE(args)
+
+        self.input_layernorm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+        self.post_attention_layernorm = nn.RMSNorm(
+            args.hidden_size, eps=args.rms_norm_eps
+        )
+
+    def __call__(self, x: mx.array, mask=None, cache=None) -> mx.array:
+        h = x + self.self_attn(self.input_layernorm(x), mask, cache)
+        return h + self.mlp(self.post_attention_layernorm(h))
+
+
+class SarvamMoEModel(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.embed_tokens = nn.Embedding(args.vocab_size, args.hidden_size)
+        self.layers = [DecoderLayer(args, i) for i in range(args.num_hidden_layers)]
+        self.norm = nn.RMSNorm(args.hidden_size, eps=args.rms_norm_eps)
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        h = self.embed_tokens(inputs)
+
+        if cache is None:
+            cache = [None] * len(self.layers)
+
+        mask = create_attention_mask(h, cache[0])
+
+        for layer, c in zip(self.layers, cache):
+            h = layer(h, mask, c)
+
+        return self.norm(h)
+
+
+class Model(nn.Module):
+    def __init__(self, args: ModelArgs):
+        super().__init__()
+        self.args = args
+        self.model_type = args.model_type
+        self.model = SarvamMoEModel(args)
+        if not args.tie_word_embeddings:
+            self.lm_head = nn.Linear(args.hidden_size, args.vocab_size, bias=False)
+
+    def __call__(self, inputs: mx.array, cache=None) -> mx.array:
+        out = self.model(inputs, cache)
+        if self.args.tie_word_embeddings:
+            return self.model.embed_tokens.as_linear(out)
+        return self.lm_head(out)
+
+    def sanitize(self, weights: Dict[str, mx.array]) -> Dict[str, mx.array]:
+        """Map Megatron-style checkpoint names onto this module's parameters.
+
+        The fused ``query_key_value`` split is the load-bearing part. The reference
+        views the projection output as ``(B, L, n_heads + 2 * n_kv, head_dim)`` and
+        splits on the head axis, so along the weight's *row* axis the layout is
+        ``[Q heads | K heads | V heads]`` in contiguous blocks — a plain row split at
+        ``n_heads * head_dim`` and ``+ n_kv * head_dim`` is exact, not an approximation.
+        """
+        import re
+
+        a = self.args
+        q_rows = a.num_attention_heads * a.head_dim
+        kv_rows = a.num_key_value_heads * a.head_dim
+
+        expert_re = re.compile(
+            r"^(.*\.mlp\.experts)\.(\d+)\.(gate|up|down)_proj\.weight$"
+        )
+        per_expert: Dict[str, Dict[str, Dict[int, mx.array]]] = {}
+        new: Dict[str, mx.array] = {}
+
+        renames = {
+            ".attention.dense.": ".self_attn.o_proj.",
+            ".attention.query_layernorm.": ".self_attn.q_norm.",
+            ".attention.key_layernorm.": ".self_attn.k_norm.",
+        }
+
+        for k, v in weights.items():
+            if "rotary_emb.inv_freq" in k:
+                continue
+
+            m = expert_re.match(k)
+            if m is not None:
+                prefix, idx, proj = m.group(1), int(m.group(2)), m.group(3)
+                per_expert.setdefault(prefix, {}).setdefault(proj, {})[idx] = v
+                continue
+
+            if k.endswith(".attention.query_key_value.weight"):
+                base = k[: -len("attention.query_key_value.weight")] + "self_attn."
+                expected = q_rows + 2 * kv_rows
+                if v.shape[0] != expected:
+                    raise ValueError(
+                        f"{k}: expected {expected} rows for fused QKV "
+                        f"(Q {q_rows} + K {kv_rows} + V {kv_rows}), got {v.shape[0]}"
+                    )
+                new[base + "q_proj.weight"] = v[:q_rows]
+                new[base + "k_proj.weight"] = v[q_rows : q_rows + kv_rows]
+                new[base + "v_proj.weight"] = v[q_rows + kv_rows :]
+                continue
+
+            if k == "model.word_embeddings.weight":
+                new["model.embed_tokens.weight"] = v
+                continue
+
+            for old, sub in renames.items():
+                if old in k:
+                    k = k.replace(old, sub)
+                    break
+            new[k] = v
+
+        # stack per-expert 2D weights -> (E, out, in) for SwitchGLU
+        for prefix, projs in per_expert.items():
+            for proj, by_idx in projs.items():
+                stacked = mx.stack([by_idx[i] for i in range(len(by_idx))], axis=0)
+                new[f"{prefix}.{proj}_proj.weight"] = stacked
+
+        if self.args.tie_word_embeddings:
+            new.pop("lm_head.weight", None)
+        return new
+
+    @property
+    def layers(self):
+        return self.model.layers
+
+    @property
+    def cast_predicate(self):
+        # the router is fp32 by design (`router_dtype: fp32`); keep it out of casts
+        def predicate(k):
+            return not (k.endswith("mlp.gate.weight") or k.endswith("expert_bias"))
+
+        return predicate

--- a/tests/test_kimi_k3.py
+++ b/tests/test_kimi_k3.py
@@ -73,7 +73,7 @@ def make_model():
 def test_get_classes_resolves_kimi_k3():
     from mlx_lm.utils import _get_classes
 
-    compat._register_kimi_k3_model()  # idempotent; already ran at import
+    compat._register_local_model("kimi_k3")  # idempotent; already ran at import
     model_class, args_class = _get_classes(tiny_config())
     assert model_class is k3.Model
     assert args_class is k3.ModelArgs

--- a/tests/test_sarvam_moe.py
+++ b/tests/test_sarvam_moe.py
@@ -1,0 +1,277 @@
+# Copyright 2026 Manjunath Janardhan
+"""Tests for the Sarvam AI MoE port (``model_type: "sarvam_moe"``).
+
+The load-bearing risk in this port is :meth:`Model.sanitize`: the checkpoint is
+Megatron-named, so a wrong fused-QKV split or expert stacking order still produces
+*correctly shaped* parameters and would only show up as garbage generations. These
+tests pin the mapping against the reference semantics rather than against shapes.
+"""
+
+import numpy as np
+import pytest
+
+import mlx.core as mx
+
+from turboquant_mlx.models.sarvam_moe import Model, ModelArgs
+
+
+def _tiny_config(**over):
+    cfg = dict(
+        model_type="sarvam_moe",
+        vocab_size=64,
+        hidden_size=16,
+        intermediate_size=32,
+        num_hidden_layers=3,
+        num_attention_heads=4,
+        num_key_value_heads=2,
+        head_dim=4,
+        rms_norm_eps=1e-6,
+        num_experts=6,
+        num_experts_per_tok=2,
+        moe_intermediate_size=8,
+        rope_theta=8000000.0,
+        first_k_dense_replace=1,
+        num_shared_experts=1,
+        routed_scaling_factor=2.5,
+        score_function="sigmoid",
+        norm_topk_prob=True,
+        use_qk_norm=True,
+    )
+    cfg.update(over)
+    return cfg
+
+
+def _model(**over):
+    return Model(ModelArgs.from_dict(_tiny_config(**over)))
+
+
+def test_get_classes_resolves_sarvam_moe():
+    """importing compat must make mlx-lm dispatch `sarvam_moe` to our port."""
+    import turboquant_mlx.compat  # noqa: F401 — registers the alias
+    from mlx_lm.utils import _get_classes
+
+    ModelCls, ArgsCls = _get_classes({"model_type": "sarvam_moe"})
+    assert ModelCls is Model
+    assert ArgsCls is ModelArgs
+
+
+def test_fused_qkv_split_matches_reference_semantics():
+    """The row split must reproduce the reference's head-axis split exactly.
+
+    Reference does ``qkv.view(B, L, n_heads + 2*n_kv, head_dim).split(...,dim=-2)``.
+    Applied to the weight, that means rows are contiguous ``[Q | K | V]`` blocks.
+    Encoding each row with its own index makes a wrong (e.g. interleaved) split
+    detectable, where a shape-only check would pass.
+    """
+    m = _model()
+    a = m.args
+    q_rows = a.num_attention_heads * a.head_dim
+    kv_rows = a.num_key_value_heads * a.head_dim
+    total = q_rows + 2 * kv_rows
+
+    # row i is filled with the value i
+    w = mx.array(np.arange(total, dtype=np.float32)[:, None]
+                 * np.ones((1, a.hidden_size), dtype=np.float32))
+    out = m.sanitize({"model.layers.0.attention.query_key_value.weight": w})
+
+    q = np.array(out["model.layers.0.self_attn.q_proj.weight"])[:, 0]
+    k = np.array(out["model.layers.0.self_attn.k_proj.weight"])[:, 0]
+    v = np.array(out["model.layers.0.self_attn.v_proj.weight"])[:, 0]
+
+    assert np.array_equal(q, np.arange(0, q_rows))
+    assert np.array_equal(k, np.arange(q_rows, q_rows + kv_rows))
+    assert np.array_equal(v, np.arange(q_rows + kv_rows, total))
+
+
+def test_fused_qkv_rejects_wrong_row_count():
+    m = _model()
+    bad = mx.zeros((7, m.args.hidden_size))
+    with pytest.raises(ValueError, match="fused QKV"):
+        m.sanitize({"model.layers.0.attention.query_key_value.weight": bad})
+
+
+def test_experts_stack_in_expert_order():
+    """Per-expert 2D tensors must stack by index, not by dict iteration order."""
+    m = _model()
+    a = m.args
+    weights = {}
+    # feed them in shuffled order; expert i is filled with the value i
+    for i in reversed(range(a.num_experts)):
+        weights[f"model.layers.1.mlp.experts.{i}.gate_proj.weight"] = mx.full(
+            (a.moe_intermediate_size, a.hidden_size), float(i)
+        )
+    out = m.sanitize(weights)
+    stacked = np.array(out["model.layers.1.mlp.experts.gate_proj.weight"])
+
+    assert stacked.shape == (a.num_experts, a.moe_intermediate_size, a.hidden_size)
+    assert np.array_equal(stacked[:, 0, 0], np.arange(a.num_experts, dtype=np.float32))
+
+
+def test_sanitize_renames():
+    m = _model()
+    h = m.args.hidden_size
+    out = m.sanitize({
+        "model.word_embeddings.weight": mx.zeros((m.args.vocab_size, h)),
+        "model.layers.0.attention.dense.weight": mx.zeros((h, h)),
+        "model.layers.0.attention.query_layernorm.weight": mx.zeros((m.args.head_dim,)),
+        "model.layers.0.attention.key_layernorm.weight": mx.zeros((m.args.head_dim,)),
+    })
+    assert set(out) == {
+        "model.embed_tokens.weight",
+        "model.layers.0.self_attn.o_proj.weight",
+        "model.layers.0.self_attn.q_norm.weight",
+        "model.layers.0.self_attn.k_norm.weight",
+    }
+
+
+def test_first_k_dense_replace_places_dense_layers():
+    m = _model(first_k_dense_replace=2)
+    kinds = [type(layer.mlp).__name__ for layer in m.layers]
+    assert kinds == ["MLP", "MLP", "SarvamMoE"]
+
+
+def test_router_bias_steers_selection_only():
+    """expert_bias must change *which* experts run, never the combine weights.
+
+    Driven through the real ``SarvamMoE.__call__`` and discriminated against the
+    wrong answer: with a large bias on one expert, combining with *biased* weights
+    and with *unbiased* weights give visibly different outputs, so the test can
+    assert the module matches one and not the other. (Renormalization hides the
+    difference in the weight *sum* — both sum to ``route_scale`` — so a test that
+    only checked the sum would pass either way.)
+    """
+    m = _model()
+    moe = m.layers[1].mlp
+    hidden, n_exp = m.args.hidden_size, m.args.num_experts
+
+    bias = np.zeros(n_exp, dtype=np.float32)
+    bias[4] = 10.0
+    moe.gate.expert_bias = mx.array(bias)
+    mx.eval(m.parameters())
+
+    x = mx.random.normal((1, 3, hidden))
+    y = moe(x)
+
+    # reference: selection from biased scores, combine from raw scores
+    scores = mx.sigmoid(moe.gate(x.astype(mx.float32)))
+    sel = scores + moe.gate.expert_bias.astype(mx.float32)
+    inds = mx.argpartition(-sel, kth=moe.top_k - 1, axis=-1)[..., : moe.top_k]
+    assert 4 in np.array(inds).ravel().tolist(), "biased expert must be selected"
+
+    expert_out = moe.experts(x, inds)
+    shared = moe.shared_experts(x)
+
+    def combine(src):
+        w = mx.take_along_axis(src, inds, axis=-1)
+        w = w / (w.sum(axis=-1, keepdims=True) + 1e-20) * moe.route_scale
+        return (expert_out * w[..., None]).sum(axis=-2).astype(x.dtype) + shared
+
+    right, wrong = combine(scores), combine(sel)
+    mx.eval(y, right, wrong)
+
+    # the two references must actually differ, or the assertion below is vacuous
+    assert float(mx.abs(right - wrong).max()) > 1e-3
+    assert float(mx.abs(y - right).max()) < 1e-5
+    assert float(mx.abs(y - wrong).max()) > 1e-3
+
+
+def test_qk_norm_applied_before_rope():
+    """Pin the QK-norm / RoPE order to the reference's.
+
+    RMSNorm and RoPE do not commute, and both orderings are internally consistent
+    (decode still matches prefill either way), so nothing else in this file would
+    notice a flip. This pins the order read off the reference
+    ``SarvamMoEAttention.forward``: split -> QK-norm -> RoPE.
+
+    The norm weights must be non-trivial for this to test anything: RMSNorm's
+    ``1/RMS`` factor is a scalar and RoPE is a rotation (norm-preserving), so with
+    the default all-ones weight the two orderings genuinely coincide and any such
+    test is vacuous. Only the learned per-dimension weight breaks the commutation.
+
+    Note this pins the *ordering*, it does not prove the port as a whole — that is
+    what the logit-parity check against the HF reference on real weights is for.
+    """
+    m = _model()
+    attn = m.layers[0].self_attn
+    attn.q_norm.weight = mx.random.uniform(0.5, 1.5, (m.args.head_dim,))
+    attn.k_norm.weight = mx.random.uniform(0.5, 1.5, (m.args.head_dim,))
+    mx.eval(m.parameters())
+
+    B, L = 1, 4
+    x = mx.random.normal((B, L, m.args.hidden_size))
+    got = attn(x)
+
+    nh, nkv, hd = attn.num_heads, attn.num_kv_heads, attn.head_dim
+
+    def manual(norm_first: bool):
+        q = attn.q_proj(x).reshape(B, L, nh, -1).transpose(0, 2, 1, 3)
+        k = attn.k_proj(x).reshape(B, L, nkv, -1).transpose(0, 2, 1, 3)
+        v = attn.v_proj(x).reshape(B, L, nkv, -1).transpose(0, 2, 1, 3)
+        if norm_first:
+            q, k = attn.q_norm(q), attn.k_norm(k)
+            q, k = attn.rope(q), attn.rope(k)
+        else:
+            q, k = attn.rope(q), attn.rope(k)
+            q, k = attn.q_norm(q), attn.k_norm(k)
+        o = mx.fast.scaled_dot_product_attention(q, k, v, scale=attn.scale, mask=None)
+        return attn.o_proj(o.transpose(0, 2, 1, 3).reshape(B, L, -1))
+
+    right, wrong = manual(True), manual(False)
+    mx.eval(got, right, wrong)
+
+    assert float(mx.abs(right - wrong).max()) > 1e-4, "orderings must differ"
+    assert float(mx.abs(got - right).max()) < 1e-5
+    assert float(mx.abs(got - wrong).max()) > 1e-4
+
+
+def test_decode_matches_prefill():
+    """Incremental decode must reproduce the last prefill position (RoPE offset)."""
+    from mlx_lm.models.cache import make_prompt_cache
+
+    m = _model()
+    mx.eval(m.parameters())
+    toks = [1, 2, 3, 4, 5]
+
+    full = m(mx.array([toks]))
+    cache = make_prompt_cache(m)
+    step = None
+    for t in toks:
+        step = m(mx.array([[t]]), cache=cache)
+    mx.eval(full, step)
+
+    assert float(mx.abs(step[0, -1] - full[0, -1]).max()) < 2e-4
+
+
+def test_attn_bits_reaches_attention_paths():
+    """Guard the Nemotron trap: --attn-bits must not be a silent no-op here.
+
+    ``bits_for_path`` keys on a ``self_attn`` / ``attention`` path segment, so the
+    port's attention container name has to be one of those.
+    """
+    from turboquant_mlx.config import TurboQuantConfig
+
+    cfg = TurboQuantConfig(bits=2, attn_bits=3)
+    assert cfg.bits_for_path("model.layers.0.self_attn.q_proj") == 3
+    assert cfg.bits_for_path("model.layers.1.mlp.experts.gate_proj") == 2
+
+    m = _model()
+    assert hasattr(m.layers[0], "self_attn")
+
+
+def test_router_excluded_from_casts():
+    m = _model()
+    pred = m.cast_predicate
+    assert not pred("model.layers.1.mlp.gate.weight")
+    assert not pred("model.layers.1.mlp.gate.expert_bias")
+    # expert projections named *_proj must still be castable
+    assert pred("model.layers.1.mlp.experts.gate_proj.weight")
+
+
+@pytest.mark.parametrize("over", [
+    {"score_function": "softmax"},
+    {"n_group": 8, "topk_group": 4},
+])
+def test_unsupported_routing_rejected(over):
+    """Fail loudly rather than silently mis-routing on a config we cannot serve."""
+    with pytest.raises(ValueError):
+        ModelArgs.from_dict(_tiny_config(**over))


### PR DESCRIPTION
Adds `models/sarvam_moe.py` so mlx-lm can load Sarvam AI's MoE architecture (sarvam-30b and later models of that type), plus the tests that pin it.

`compat.py` aliases the port into `sys.modules` under the name mlx-lm's `_get_classes` looks for — the same mechanism already used for Laguna. That function is generalized here into `_register_local_model(model_type, module_name=None)`, so a third architecture costs one line instead of a copied function, and each one still self-disables the moment mlx-lm ships native support.

## Verification

The port is checked three ways against the fp32 reference, not just "it generates text":

| check | result |
|---|---|
| key/shape coverage of all 7122 source tensors | 0 missing / 0 extra / 0 mismatched |
| layer-1 output parity vs the HF reference | 5.4e-7 |
| whole-model logit agreement | matches the reference's own behaviour |

The reference is 128 GB fp32, so the parity harness streams one decoder layer at a time (~15 GB peak) rather than loading the model.

## What the tests actually guard

Two details of this architecture load cleanly and generate plausible text when implemented wrong, so both are pinned by tests that were mutation-checked — each fails on the deliberately broken version:

- **Fused QKV split.** The checkpoint is Megatron-style: attention arrives as a single `attention.query_key_value` matrix. The reference views it as `(heads + 2*kv_heads, head_dim)` and splits on the head axis, which makes a plain row split exact — but a K/V swap is invisible to any shape check.
- **Router bias.** Routing is DeepSeek-V3-style: sigmoid scores with `expert_bias` added **for selection only**, weights renormalized after top-k and scaled by `routed_scaling_factor`. Letting the bias reach the combine weights is a small numeric diff with no structural signature. The router is deliberately not an `nn.Linear` so the quantizer's module walk leaves it in full precision.

Expert stacking is also ordered by index rather than dict order, and QK-norm is applied before RoPE.

Full suite: 404 passed.

## On quantization

No quantized sarvam build is published, and the changelog says so plainly. At 4-bit this model degenerates on long generations. Measured as a **degeneration rate** over repeated trials at temp 0.7 / top_p 0.9 — single-shot verdicts were noise, since the same prompt collapsed in one run and was clean in the next:

| build | essay | math | Hindi | total degenerated |
|---|---|---|---|---|
| TurboQuant 4-bit | 3/5 | 4/5 | 1/5 | **8/15 (53%)** |
| mlx-lm affine 4-bit | 5/5 | 5/5 | 5/5 | **15/15 (100%)** |

Lower is better. TurboQuant beats mlx-lm affine decisively here — affine collapsed on every single trial — which is a genuine positive for the method even though neither build is good enough to publish as a model. The failure signatures differ by method (digit runs vs underscore runs), so this is quantization noise steering the collapse rather than one shared bug.

The architecture support is independently useful: it is what lets mlx-lm load sarvam at all.