### PR TITLE
fix(stream): make same-layer fan-out opt-in (--fanout), and log the K3 merge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,52 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Kimi K3 (2.8T MoE) support**, contributed by
+  [@anders94](https://github.com/anders94) in
+  [#71](https://github.com/manjunathshiva/turboquant-mlx/pull/71). MLX model
+  port (69 KDA linear-attention + 24 gated-NoPE MLA layers, LatentMoE experts
+  behind shared down/up projections), an mxfp4 compressed-tensors conversion
+  path, planner and expert-streaming coverage, and a model card for a 931 GB
+  `tq3a-tqTe-down4-g64` build that streams from disk on a 512 GB Mac Studio.
+  Verified against the HF reference at ≤ 2.7e-6 fp32 forward parity, with a
+  bit-exact mxfp4 unpack check.
+
+- **`--fanout` on `stream_generate` and `serve`** — same-layer read fan-out:
+  once a layer's router has chosen its experts, the other projections' misses
+  are submitted to the read pool at layer start so their reads overlap the
+  earlier projections' compute. Off by default. It trades away the coalesced
+  serial read path, which is a measured win on a fast internal SSD with spare
+  bandwidth and a loss on bandwidth-bound external storage, and unlike
+  `--prefetch-ahead` it has no self-disable: the saturation throttle judges by
+  rescue rate, and fan-out has none to judge (its claims are accounted as
+  misses by design). Measure it on your own storage.
+
+### Fixed
+
+- **The streaming layer trigger fired on the wrong projection.** It fired on
+  `_PROJS[0]` (`gate_proj`), but `SwitchGLU.__call__` executes `up_proj` first,
+  so every layer's prefetch was kicked off one projection late. Applies to
+  every streaming model, not just K3. Caught by @anders94.
+
 ### Changed
+
+- **Always-on MoE plumbing is now exempt from the `--mlp-bits` tier.**
+  `bits_for_path` returns the base `--bits` for `shared_experts` and
+  latent-MoE `routed_expert_*` projections: unlike a routed expert (1 of many,
+  chosen top-k), these run on every token, so dropping them into a sub-2-bit
+  expert tier costs quality across the whole stream for a rounding-error size
+  saving. Affects new hybrid conversions of models with shared experts
+  (DeepSeek family); existing checkpoints are unaffected, since bit width is
+  recovered from the on-disk codebook rather than re-derived.
+
+- **`trust_remote_code` is auto-injected only for local Kimi K3 checkpoints.**
+  The new `compat.is_local_kimi_k3()` gate requires a local *directory* whose
+  `config.json` declares `model_type: "kimi_k3"`; hub repo ids, other local
+  models, and missing or corrupt configs are left to transformers' explicit
+  opt-in, and a `trust_remote_code` passed by the caller always wins.
+  Downloading tokenizer code and executing it are separate trust decisions.
 
 - **`--cache-budget-gb auto` is no longer double-conservative, and `plan` now
   predicts what the loader actually does.** The two computed the budget

--- a/model_card_kimi_k3.md
+++ b/model_card_kimi_k3.md
@@ -54,7 +54,7 @@ Measured on a **Mac Studio (M-series, 512 GB)** with `iogpu.wired_limit_mb=51200
 
 The `--max-active-experts 8` lever (native top-16 → top-8) roughly halves per-token expert I/O for a ~2× decode speed-up at no observed quality cost. Prefetch parallelism matters: 16 workers is the knee — at 8 the reads serialize and lose ~30%, past 16 there's no further gain (decode is no longer disk-bandwidth-bound).
 
-> **Stats-accounting note:** the hit-rate and critical-read columns above were measured when same-layer fan-out reads (pool reads for experts the router has already chosen this token) were counted as prefetch hits. Current builds count those reads as critical-path (`misses`/`bytes_read`, annotated by `fanout_hits` in `stats()`), the same meaning hit-rate has for every other streaming model in this repo — so the same runs now report a lower hit-rate and non-zero critical GB. The tok/s numbers are unaffected; only the accounting changed. Fan-out itself is on by default and can be disabled with `--no-fanout` (recommended on bandwidth-bound external storage, where the coalesced serial read path wins).
+> **Stats-accounting note:** the hit-rate and critical-read columns above were measured when same-layer fan-out reads (pool reads for experts the router has already chosen this token) were counted as prefetch hits. Current builds count those reads as critical-path (`misses`/`bytes_read`, annotated by `fanout_hits` in `stats()`), the same meaning hit-rate has for every other streaming model in this repo — so the same runs now report a lower hit-rate and non-zero critical GB. The tok/s numbers are unaffected; only the accounting changed. Fan-out itself is **opt-in (`--fanout`)**: it was measured on this machine's internal SSD, where there is spare bandwidth to parallelize into, and it trades away the coalesced serial read path that wins on bandwidth-bound external storage. The numbers above were measured with fan-out on.
 
 ### Recommended invocation
 
@@ -66,8 +66,10 @@ python3 -m turboquant_mlx.stream.stream_generate \
     --model ./Kimi-K3-tq3a-tqTe-down4-g64 \
     --prompt "Explain how Rayleigh scattering works." \
     --max-tokens 500 --cache-budget-gb auto \
-    --max-active-experts 8 --prefetch-workers 16
+    --max-active-experts 8 --prefetch-workers 16 --fanout
 ```
+
+`--fanout` matches how the numbers above were measured. Drop it if the model lives on external storage — there the coalesced serial read path wins, and fan-out does not self-disable.
 
 Kimi K3 uses a tiktoken-based tokenizer — install `tiktoken` and `blobfile` alongside TurboQuant-MLX.
 

--- a/serve.py
+++ b/serve.py
@@ -534,8 +534,7 @@ def _extract_stream_args(argv):
     parser.add_argument("--max-active-experts", type=int, default=4)
     parser.add_argument("--prefetch-workers", type=int, default=8)
     parser.add_argument("--prefetch-ahead", type=int, default=0)
-    parser.add_argument("--no-fanout", dest="fanout", action="store_false",
-                        default=True)
+    parser.add_argument("--fanout", action="store_true", default=False)
     parser.add_argument("--pin-file", default=None)
     parser.add_argument("--no-hotlist", dest="use_hotlist", action="store_false",
                         default=True)

--- a/stream/loader.py
+++ b/stream/loader.py
@@ -269,7 +269,7 @@ def _pin_spec_to_layers(spec: dict) -> "tuple[dict, list]":
 
 def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
                    prefetch_workers: int = 8, prefetch_ahead: int = 0,
-                   fanout: bool = True,
+                   fanout: bool = False,
                    pin_file: str | None = None, max_active_experts: int = 4,
                    use_page_cache: bool | None = None, use_hotlist: bool = True,
                    preload_pins: bool = True, wire_memory: bool = False,
@@ -289,10 +289,12 @@ def load_streaming(model_path, cache_budget_gb=3.0, fast: bool = False,
     prefetch_workers parallelizes per-layer expert reads (1 = serial baseline).
     prefetch_ahead speculatively prefetches this many upcoming layers' experts
     (predicted from the previous token's routing); 0 disables prefetch.
-    fanout submits each layer's known expert misses to the read pool as soon
-    as the router has chosen them, so the other projections' reads overlap
-    compute (--no-fanout for bandwidth-bound external storage, where the
-    coalesced serial path wins; the saturation throttle also disables it).
+    fanout (--fanout, off by default) submits each layer's known expert misses
+    to the read pool as soon as the router has chosen them, so the other
+    projections' reads overlap compute. Opt-in for the same reason as
+    prefetch_ahead: it trades the coalesced serial read path for parallelism,
+    which wins on a fast internal SSD with spare bandwidth and loses on
+    bandwidth-bound external storage.
     pin_file is an optional JSON {"pin": [[layer, expert], ...]} of hot experts
     to keep permanently resident (never LRU-evicted) — see calibrate_experts.py.
     When it is None and the model directory ships a ``hot_experts.json`` (same

--- a/stream/stream_generate.py
+++ b/stream/stream_generate.py
@@ -75,13 +75,14 @@ def main():
                         "helps only on fast NVMe with spare bandwidth, ~neutral on a "
                         "saturated USB bus). Set 1 to enable; it self-disables if the "
                         "storage proves bandwidth-bound.")
-    p.add_argument("--no-fanout", dest="fanout", action="store_false",
-                   default=True,
-                   help="Disable the same-layer read fan-out (submitting a layer's "
-                        "known expert misses to the read pool at layer start). "
-                        "Fan-out overlaps reads with compute on internal SSD but "
-                        "trades away coalesced serial reads — disable on "
-                        "bandwidth-bound external storage.")
+    p.add_argument("--fanout", action="store_true", default=False,
+                   help="Enable the same-layer read fan-out: submit a layer's known "
+                        "expert misses to the read pool at layer start so the other "
+                        "projections' reads overlap compute. Off by default; it "
+                        "trades away the coalesced serial read path, which wins on "
+                        "a fast internal SSD with spare bandwidth and loses on "
+                        "bandwidth-bound external storage. Unlike --prefetch-ahead "
+                        "it does not self-disable, so measure it on your storage.")
     p.add_argument("--pin-file", default=None,
                    help="JSON {'pin': [[layer, expert], ...]} of hot experts to keep "
                         "permanently resident (from calibrate_experts.py). Without it, "
@@ -221,6 +222,13 @@ def main():
     print(f"[stream] disk: critical_read={s['bytes_read_gb']:.1f} GB "
           f"prefetched={s['bytes_prefetched_gb']:.1f} GB total={s['bytes_total_gb']:.1f} GB "
           f"| prefetched_experts={s['prefetched']} dropped_unused={s['prefetch_dropped']}")
+    if s['fanout_hits'] or s['prefetch_errors']:
+        # fan-out reads are critical-path (they sit inside misses/critical_read);
+        # they were merely parallelized, so surface them rather than let the
+        # hit_rate above look worse for no visible reason.
+        print(f"[stream] fan-out: {s['fanout_hits']} of {s['misses']} misses read in "
+              f"parallel at layer start | background read errors="
+              f"{s['prefetch_errors']}")
     print(f"[stream] coalescing: {s['expert_reads']} expert-loads in {s['read_runs']} "
           f"range-reads = {s['experts_per_read']:.2f} experts/read")
 

--- a/stream/streaming_switch.py
+++ b/stream/streaming_switch.py
@@ -51,14 +51,22 @@ class ExpertCache:
     and ``eval`` stay on the calling thread, so the produced tensors are
     bit-identical to the serial path.
 
-    **Same-layer fan-out** (``fanout=True``, needs the pool): once a layer's
-    router has chosen its experts, the other projections' misses are submitted
-    to the pool immediately so their reads overlap the earlier projections'
-    compute. These are critical-path reads (counted in ``misses`` /
-    ``bytes_read`` and annotated by ``fanout_hits``), not speculation. Fan-out
-    trades the coalesced serial read path for parallelism — a win on internal
-    SSD, a likely loss on bandwidth-bound external storage, so it can be
-    disabled (``--no-fanout``) and the saturation throttle also turns it off.
+    **Same-layer fan-out** (``fanout=True``, needs the pool, **off by
+    default**): once a layer's router has chosen its experts, the other
+    projections' misses are submitted to the pool immediately so their reads
+    overlap the earlier projections' compute. These are critical-path reads
+    (counted in ``misses`` / ``bytes_read`` and annotated by ``fanout_hits``),
+    not speculation.
+
+    Fan-out trades the coalesced serial read path for parallelism — measured a
+    win on a 512 GB Mac Studio's internal SSD, expected a loss on
+    bandwidth-bound external storage, where the bus is already the wall. It is
+    opt-in (``--fanout``) for the same reason ``--prefetch-ahead`` is: there is
+    no in-process signal that can tell the two regimes apart. The saturation
+    throttle below *can* clear it, but only once speculation is also running —
+    the throttle judges by rescue rate, and fan-out has no rescue rate to
+    judge (its claims are accounted as misses by design). Do not rely on the
+    throttle as fan-out's kill switch; ``--fanout`` is a per-machine choice.
 
     **Speculative prefetch** (``prefetch_ahead > 0``): when a layer starts we
     kick off *background* disk reads for the experts the previous token used at
@@ -72,7 +80,7 @@ class ExpertCache:
     """
 
     def __init__(self, reader, budget_bytes: int, *, prefetch_workers: int = 8,
-                 prefetch_ahead: int = 1, fanout: bool = True,
+                 prefetch_ahead: int = 1, fanout: bool = False,
                  staging_budget_bytes: int = 1_500_000_000,
                  pin_keys=None, usage_profile=None):
         self.reader = reader
@@ -97,9 +105,9 @@ class ExpertCache:
                       if self._workers > 1 else None)
         # same-layer fan-out: submit a layer's known expert misses to the pool
         # at layer start so each projection's gather awaits parallel reads
-        # instead of reading serially. Needs the pool; --no-fanout turns it off
-        # (bandwidth-bound storage prefers the coalesced serial path), and the
-        # saturation throttle below turns it off too.
+        # instead of reading serially. Needs the pool, and is opt-in (--fanout):
+        # bandwidth-bound storage prefers the coalesced serial path, and nothing
+        # in-process can tell the two regimes apart (see the class docstring).
         self._fanout = bool(fanout) and self._pool is not None
         self._fanout_keys: set = set()   # cks submitted by fan-out (not speculation)
         # speculative-prefetch state (needs the pool to run in background)
@@ -145,7 +153,8 @@ class ExpertCache:
     def on_layer_start(self, layer_idx: int, experts: list, trigger_wkey=None):
         """Called once per layer per token (from the trigger projection).
 
-        First fans out THIS layer's known expert set across the read pool for
+        First, when fan-out is enabled (``--fanout``, off by default), fans out
+        THIS layer's known expert set across the read pool for
         the layer's *other* projections (``trigger_wkey`` — the projection this
         call came from — is skipped: its gather runs next on the calling thread
         and keeps the coalesced-run read path): gather awaits in-flight reads
@@ -171,11 +180,15 @@ class ExpertCache:
             if rescue < self._throttle_min_rescue:
                 # Bandwidth-bound storage: speculation's reads arrive too late
                 # and fan-out's per-expert pool reads lose to the coalesced
-                # serial path — stop both from competing for the bus.
+                # serial path — stop both from competing for the bus. Note this
+                # branch only runs while speculation is on: with --fanout alone
+                # there is no rescue rate to judge, which is why fan-out is
+                # opt-in rather than on-with-a-safety-net.
                 self._prefetch_ahead = 0
-                self._fanout = False
-                print(f"[stream] prefetch + fan-out self-disabled: rescue rate "
-                      f"{rescue:.0%} < {self._throttle_min_rescue:.0%} "
+                was_fanout, self._fanout = self._fanout, False
+                print(f"[stream] prefetch{' + fan-out' if was_fanout else ''} "
+                      f"self-disabled: rescue rate {rescue:.0%} < "
+                      f"{self._throttle_min_rescue:.0%} "
                       f"(storage appears bandwidth-bound)")
         if self._prefetch_ahead:
             for nxt in range(layer_idx + 1, layer_idx + 1 + self._prefetch_ahead):

--- a/tests/test_stream_cache.py
+++ b/tests/test_stream_cache.py
@@ -99,7 +99,8 @@ def test_fanout_skips_trigger_and_counts_as_critical_path():
     # runs next on the calling thread and keeps the coalesced read path —
     # and (b) account pool-read claims as misses + fanout_hits, never as
     # prefetch_hits, so hit_rate keeps meaning "no same-token disk read".
-    cache = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=4)
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9, prefetch_workers=4,
+                        fanout=True)
     cache.register_layer(0, [("L0.up.weight", "L0.up.scales"),
                              ("L0.gate.weight", "L0.gate.scales"),
                              ("L0.down.weight", "L0.down.scales")])
@@ -118,29 +119,49 @@ def test_fanout_skips_trigger_and_counts_as_critical_path():
     assert cache.stats()["hit_rate"] == 0.0
 
 
-def test_no_fanout_flag_disables_layer_fanout():
-    cache = ExpertCache(FakeReader(), budget_bytes=10**9,
-                        prefetch_workers=4, fanout=False)
-    cache.register_layer(0, [("a.weight", "a.scales"),
-                             ("b.weight", "b.scales")])
-    cache.on_layer_start(0, [0, 1], trigger_wkey="a.weight")
-    with cache._lock:
-        assert not cache._inflight and not cache._staging
-    cache.gather("b.weight", "b.scales", [0, 1])
-    assert cache.fanout_hits == 0 and cache.misses == 2
+def test_fanout_is_off_unless_asked_for():
+    # Fan-out is opt-in (--fanout): it trades the coalesced serial read path
+    # for parallelism, and nothing in-process can tell a fast internal SSD
+    # from a saturated external bus. Default must be the pre-fan-out path.
+    for kwargs in ({}, {"fanout": False}):
+        cache = ExpertCache(FakeReader(), budget_bytes=10**9,
+                            prefetch_workers=4, **kwargs)
+        assert cache._fanout is False
+        cache.register_layer(0, [("a.weight", "a.scales"),
+                                 ("b.weight", "b.scales")])
+        cache.on_layer_start(0, [0, 1], trigger_wkey="a.weight")
+        with cache._lock:
+            assert not cache._inflight and not cache._staging
+        cache.gather("b.weight", "b.scales", [0, 1])
+        assert cache.fanout_hits == 0 and cache.misses == 2
 
 
 def test_throttle_disables_fanout_too():
     # When the saturation throttle judges storage bandwidth-bound it must
-    # stop BOTH speculation and the same-layer fan-out from competing for
-    # the bus (fan-out has no other kill switch besides --no-fanout).
+    # stop BOTH speculation and the same-layer fan-out from competing for the
+    # bus. This only reaches fan-out while speculation is also running: the
+    # throttle judges by rescue rate and fan-out has none, which is exactly
+    # why fan-out is opt-in rather than on-with-a-safety-net.
     cache = ExpertCache(FakeReader(), budget_bytes=10**9,
-                        prefetch_workers=2, prefetch_ahead=1)
+                        prefetch_workers=2, prefetch_ahead=1, fanout=True)
     cache.prefetched = cache._throttle_warmup
     cache.misses = 1000  # rescue rate 0%
     cache.on_layer_start(0, [], trigger_wkey=None)
     assert cache._prefetch_ahead == 0
     assert cache._fanout is False
+
+
+def test_throttle_cannot_reach_fanout_without_speculation():
+    # Documents the gap the opt-in default exists for: with --prefetch-ahead 0
+    # (the default) the throttle block never evaluates, so an enabled fan-out
+    # runs for the whole session no matter how bandwidth-bound the storage is.
+    cache = ExpertCache(FakeReader(), budget_bytes=10**9,
+                        prefetch_workers=2, prefetch_ahead=0, fanout=True)
+    cache.misses = 10**6  # as bandwidth-bound as it gets
+    cache.register_layer(0, [("a.weight", "a.scales")])
+    cache.on_layer_start(0, [0], trigger_wkey=None)
+    assert cache._fanout is True
+    assert cache._throttle_decided is False
 
 
 def test_background_read_error_counted_and_recovered():


### PR DESCRIPTION
Follow-up to #71, which I merged as `fb26a67`.

## Fan-out becomes opt-in

#71 landed same-layer read fan-out **on by default**, which changes read
behaviour for every streaming model, not just K3. Two reasons that's the
wrong default:

**It trades away the coalesced serial read path.** Fan-out was measured a win
on a 512 GB Mac Studio's internal SSD, where there is spare bandwidth to
parallelize into. On bandwidth-bound external storage the bus is already the
wall, and parallel per-expert reads lose to coalesced runs. `--prefetch-ahead`
defaults to `0` for exactly this reason and says so in its help text.

**Its advertised safety net cannot fire under default flags.** Two independent
reasons:

- the throttle block is gated on `if self._prefetch_ahead …`, and
  `--prefetch-ahead` defaults to `0` in all three places
  (`stream/loader.py`, `stream/stream_generate.py`, `serve.py`), so the block
  never evaluates;
- fan-out deliberately doesn't increment `prefetched`, so the
  `prefetched >= 2000` warmup never trips either.

And it couldn't work even if reached: the throttle judges by **rescue rate**,
and fan-out has no rescue rate — its claims are accounted as `misses` by
design, which is the correct accounting #71 introduced. There is no
in-process signal that separates the two storage regimes.

So: `--fanout`, off by default. The throttle still clears it when speculation
is running (harmless, occasionally right), but the docstrings no longer claim
a self-disable fan-out doesn't have. One test pins the default off; a second
pins the gap itself, so the reasoning survives the next person reading the
throttle.

`stream_generate` now prints `fanout_hits` / `prefetch_errors` when non-zero —
fan-out reads sit *inside* `misses`/`critical_read`, so without that line an
enabled fan-out just makes `hit_rate` look worse with nothing to explain it.

## CHANGELOG

#71 landed without `[Unreleased]` entries. Added: K3 support (credited),
the `up_proj` trigger fix, the `shared_experts` / `routed_expert_*` exemption
from `--mlp-bits` — which quietly changes new hybrid conversions of
DeepSeek-family models, existing checkpoints unaffected — and the
`trust_remote_code` gate.

Model card now carries `--fanout` in the recommended invocation, since that's
how its numbers were measured.

## Verification

412 tests pass locally on Apple Silicon; both CLIs verified to parse the new
flag and default to off.