### PR TITLE
feat: Muse Glimmer (Meta 30B dense VLM) + fused dense batched kernel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,79 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **Muse Glimmer (Meta, dense 30B VLM) support** — `muse_glimmer`, a
+  29.8B-parameter dense multimodal model with Gemma2-style sandwich norms,
+  gated attention, a 3:1 sliding(2048)/full attention pattern with NoPE on the
+  full-attention layers, and a 1.9B ViT-G/14 perception encoder. Converts
+  through `convert_vlm`.
+
+  At **matched 4-bit**, `tq4-g64` measures **PPL 4.3315 in 14.88 GiB** against
+  `mlx-community/Muse-Glimmer-30B-4bit`'s **4.3798 in 19.88 GiB** — better
+  quality in 25% less space, while quantizing the embedding and vision tower
+  that the affine build leaves at bf16. Decode is 2.4–2.8× slower, the usual
+  codebook-vs-affine trade.
+
+  The MLX model classes come from
+  [Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838), which is
+  **not merged and not on PyPI** — see the README for the pinned install.
+
+- **`polar_qmm`: fused dense batched GEMM on packed weights.**
+  `PolarQuantizedLinear` previously had a fused kernel only for single-vector
+  decode; every batch > 1, meaning all of prefill, fell back to
+  `polar_dequantize_weight` + GEMM and materialized the weight at ~14 bytes per
+  parameter. The new kernel decodes in registers and writes nothing, and is
+  dispatched for `2 <= n_tokens <= 256` with `output_dims >= 512` — bounds set
+  by measurement (9.3× faster than dequant+GEMM at N=2–8 on wide MLP
+  projections, 0.41× at N=2048 where MLX's tuned GEMM wins, 0.5–0.8× when the
+  output is too narrow to fill the GPU). `TURBOQUANT_QMM_MAX_TOKENS` overrides
+  the token bound for memory-constrained machines.
+
+  On Muse-Glimmer-30B tq3, prefill peak over resident weights at 64 tokens
+  drops **3.86 GB → 0.62 GB** and prefill runs **23.1 → 73.9 tok/s**. Benefits
+  every dense TurboQuant model, not just this one. Perplexity is unchanged
+  (5.0454 dequant vs 5.0452 fused — fp32 accumulate vs fp16 GEMM).
+
+- Rotation-fusion config entries may be **parent-qualified**
+  (`"self_attn.gate_proj"`), and qualified entries are matched before bare leaf
+  names. Muse Glimmer is the first architecture with the same leaf name under
+  two parents in one block — a sigmoid attention output gate and a SwiGLU gate,
+  reading different norms — which the old leaf-only match would have fused into
+  the wrong norm.
+
+- `convert_vlm` gained `--extras-bits` / `--extras-group-size`.
+  `--quantize-extras` was hard-wired to 8-bit; on models where the extras are a
+  large share (Muse Glimmer's embedding + vision tower are 3.3B params) that is
+  the difference between ~3.9 GB and ~1.8 GB.
+
+### Fixed
+
+- **`turboquant-plan` under-estimated prefill workspace**, which on small
+  machines turned a will-not-run into a false `RESIDENT` verdict. It modelled
+  attention scratch only, missing (1) the `lm_head` output for the chunk —
+  often the largest term on a big-vocab model, 0.77 GB at 202048 vocab × 2048
+  tokens — and (2) polar weight dequantization for dense TurboQuant layers
+  above the fused kernel's token bound. On Muse-Glimmer-30B at 16K context the
+  estimate goes 2.15 GB → 6.70 GB, against a measured 6.39 GB. **Existing
+  plan output for other models will change**: every model gains the logits
+  term, and dense TurboQuant models gain the dequantization term. MoE expert
+  dequantization is still not modelled.
+
+- `muse_glimmer`'s `lm_head` is kept out of the polar path. At
+  202048 × 6656 = 1.345B parameters it is 10× the largest MLP matrix, so the
+  dequantize-on-prefill fallback cost **18.84 GB of transient peak alone** to
+  save 0.21 GB on disk. Routing it to affine cut prefill peak over weights
+  from 20.06 GB to 3.86 GB for +0.16 GiB, with prefill slightly faster.
+
+- Muse Glimmer's `embed_tokens` is a `NormedEmbedding` — an `nn.Embedding`
+  subclass that RMS-normalizes the row it looks up. It inherits
+  `to_quantized`, which returns a plain `QuantizedEmbedding` and **silently
+  drops the normalization**. It now quantizes through a norm-preserving
+  subclass on both the convert and load sides. (mlx-vlm sidesteps this by
+  refusing to quantize the module at all, which is most of why a "4-bit" Muse
+  Glimmer weighs 19.88 GiB.)
+
 ## [0.19.0] - 2026-08-04
 
 Two new architectures, both of which mlx-lm has no module for. **Kimi K3**

--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, 
 | Laguna-S-2.1 (118B) | [Affine 4-bit](https://huggingface.co/mlx-community/Laguna-S-2.1-4bit) | 4 | — | ~64 GB | *Exceeds Metal's ~56 GB working set — won't load* |
 | **[Laguna-S-2.1 (118B, ternary experts)](https://huggingface.co/manjunathshiva/Laguna-S-2.1-tqTe-g64)** | **TQ 3-attn / ternary trit-packed experts, gs=64** | **1.6/3 mix** | **—** | **~27 GB** | **~12.5 tok/s · fully resident on 64 GB with ~25 GB spare · Opencode pass** |
 | **Kimi K3 (2.8T MoE)** | **TQ 3-attn / ternary experts / 4-bit expert-down, gs=64** | **1.6/3/4 mix** | **—** | **931 GB** | **2.3 tok/s (Mac Studio 512 GB, top-8) · 1.2 tok/s at native top-16 · streams experts from disk** |
+| Muse Glimmer (30B dense VLM) | [Affine 4-bit](https://huggingface.co/mlx-community/Muse-Glimmer-30B-4bit) | 4 | 4.3798 | 19.88 GiB | 26.1 tok/s · leaves embedding + vision tower at bf16 |
+| **Muse Glimmer (30B dense VLM)** | **TurboQuant, gs=64** | **4** | **4.3315** | **14.88 GiB** | **9.4 tok/s · better PPL than affine 4-bit in 25% less space** |
+| **Muse Glimmer (30B dense VLM)** | **TurboQuant, gs=64** | **3** | **5.0454** | **12.53 GiB** | **10.9 tok/s · smallest coherent build** |
 
 ## Key Results — KV Cache Compression
 
@@ -140,6 +143,11 @@ pip install "turboquant-mlx-full[eval]"   # perplexity benchmarking (datasets, t
 pip install "turboquant-mlx-full[vlm]"    # multimodal / diffusion models via mlx-vlm
 pip install "turboquant-mlx-full[kimi]"   # Kimi K3's tiktoken-based tokenizer
 ```
+
+> **Muse Glimmer needs an unreleased mlx-vlm.** Its MLX model classes live in
+> [Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838), which is
+> not merged and not on PyPI, so `[vlm]` alone will not load it. See
+> [Muse Glimmer](#muse-glimmer-30b-dense-vlm) for the pinned install.
 
 ## Quick Start
 
@@ -1351,6 +1359,71 @@ whole-model logit agreement.
 > neither is good enough to ship. Use a higher bit width and validate long-form
 > output on your own prompts before relying on it.
 
+### Muse Glimmer (30B dense VLM)
+
+[Muse Glimmer](https://huggingface.co/meta-models/Muse-Glimmer-30B) is Meta
+Superintelligence Lab's 29.8B-parameter dense multimodal model, built for
+agentic work on consumer hardware. Architecturally it is Gemma2-style sandwich
+norms plus **gated attention** (a sigmoid output gate alongside Q/K/V), a 3:1
+sliding(2048)/full attention pattern with **NoPE on the full-attention layers**,
+final logit softcapping, and a 1.9B ViT-G/14 perception encoder.
+
+**This is the one case where TurboQuant beats MLX's affine quantizer outright
+on quality**, at matched bit width — and does it while quantizing more of the
+model:
+
+| build | size | PPL ↓ | decode | notes |
+|---|---|---|---|---|
+| `mlx-community/Muse-Glimmer-30B-4bit` | 19.88 GiB | 4.3798 | 26.1 tok/s | embedding + vision tower stay bf16 |
+| **TurboQuant `tq4-g64`** | **14.88 GiB** | **4.3315** | 9.4 tok/s | everything quantized |
+| TurboQuant `tq3-g64` | 12.53 GiB | 5.0454 | 10.9 tok/s | smallest coherent build |
+
+800-token fixed-passage perplexity, greedy, M4 Max. The affine build is 2.4–2.8×
+faster to decode — the usual codebook-vs-affine trade. **Do not read the tq3 row
+as a TurboQuant deficiency**: the gap there is the 3-bit step, which is exactly
+what the matched-4-bit control isolates.
+
+Most of the affine build's extra 5 GB is the embedding and the vision tower,
+which mlx-vlm declines to quantize. `embed_tokens` is a `NormedEmbedding` whose
+inherited `to_quantized` would silently drop its RMS normalization; TurboQuant
+quantizes it through a norm-preserving subclass instead.
+
+```bash
+# The MLX model classes are not released yet — pin the PR.
+uv venv --python 3.12 .venv-mg
+VIRTUAL_ENV=$PWD/.venv-mg uv pip install \
+    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm.git@c7416a4bcb"
+VIRTUAL_ENV=$PWD/.venv-mg uv pip install "turboquant-mlx-full[vlm]"
+# mlx-vlm's Muse Glimmer needs transformers 5.15, above our mlx-lm pin:
+VIRTUAL_ENV=$PWD/.venv-mg uv pip install --no-deps "transformers==5.15.0"
+
+python -m turboquant_mlx.convert_vlm \
+  --hf-path meta-models/Muse-Glimmer-30B \
+  --mlx-path ./Muse-Glimmer-30B-tq4-g64 \
+  --bits 4 --group-size 64 --quantize-extras --extras-bits 4
+
+python -m turboquant_mlx.generate_vlm \
+  --model ./Muse-Glimmer-30B-tq4-g64 --prompt "..." --max-tokens 256
+```
+
+`--extras-bits 4` matters here: the embedding and vision tower are 3.3B
+parameters between them, ~3.9 GB at the 8-bit default versus ~1.8 GB at 4-bit.
+
+> **16 GB Macs: not yet.** `tq3` needs ~14.8 GB peak against a ~14.4 GB
+> raisable ceiling — close, but over. The obvious next step down does **not**
+> work: a `tq3a-tq2e-g64` hybrid fits at 9.63 GiB but measures **PPL 7.5547**
+> (vs 5.0454) and visibly corrupts text, the same way 2-bit experts failed on
+> 32-expert GPT-OSS-20B. 2-bit on a *dense* MLP is not a usable tier. Note that
+> Meta's own smallest Apple Silicon artifact is 17.95 GB, text-only and without
+> the drafter, so nothing official fits a 16 GB machine either.
+
+Muse Glimmer also ships a [DFlash block-diffusion
+drafter](https://huggingface.co/meta-models/Muse-Glimmer-30B-assistant) (5.11 GB,
+5 layers, block 16, tapping target layers {1,13,25,37,49}). It is not wired up
+here. Worth noting it is a *dense* target, which is the regime where DFlash
+speculation paid off in earlier testing rather than the MoE regime where it
+did not.
+
 ---
 
 ## How It Works
@@ -1397,6 +1470,7 @@ Options:
 | DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
 | Kimi K3 (KDA linear-attn + gated-NoPE MLA, Stable LatentMoE) | `kimi_k3` | Yes (896 experts, top-16 + 2 shared) | Tested (2.8T: mxfp4 source → 931 GB `tq3a-tqTe-down4-g64`, streams from disk on a 512 GB Mac Studio; does **not** fit resident on any Mac). Custom arch — MLX port shipped here (mlx-lm has no native `kimi_k3`); fp32 forward parity ≤ 2.7e-6 vs transformers. Needs `[kimi]` extra |
 | Sarvam MoE (Megatron-style fused QKV, DeepSeek-V3 routing) | `sarvam_moe` | Yes | Port tested against fp32 (7122/7122 tensors, layer-1 parity 5.4e-7). Custom arch — MLX port shipped here. **No quantized build published**: 4-bit degenerates on long generations (53% of trials; mlx-lm affine 4-bit 100%) |
+| Muse Glimmer (dense VLM: gated attention, sandwich norms, sliding/NoPE mix, ViT-G/14) | `muse_glimmer` | No | Tested (29.8B: `tq4-g64` beats affine 4-bit on PPL — 4.3315 vs 4.3798 — in 25% less space; `tq3-g64` = 12.53 GiB). Structural match verified against the checkpoint, 1436/1436 tensors. Model classes come from the **unmerged** [mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838) — see [Muse Glimmer](#muse-glimmer-30b-dense-vlm) for the pinned install |
 | DiffusionGemma (block-diffusion MoE, via **mlx-vlm**) | `diffusion_gemma` | Yes (128 experts, top-8) | Tested (26B-A4B: convert + block-diffusion sampler, coherent at 3-bit — [HF](https://huggingface.co/manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32)). **Experimental**: decode is much slower than native 4-bit until a batched codebook gather-GEMM kernel lands |
 
 ### mlx-vlm architectures (multimodal / diffusion)

--- a/convert_vlm.py
+++ b/convert_vlm.py
@@ -29,7 +29,9 @@ import turboquant_mlx.compat  # noqa: F401 — registers upstream patches on imp
 import turboquant_mlx.quantize_model as _qm
 from turboquant_mlx.config import TurboQuantConfig
 from turboquant_mlx.quantize_model import turboquant_quantize, _detect_architecture
-from turboquant_mlx.integration.vlm import _require_mlx_vlm, vlm_should_quantize
+from turboquant_mlx.integration.vlm import (
+    _require_mlx_vlm, patch_vlm_arch, vlm_should_quantize,
+)
 
 _AUX_FILES = (
     "tokenizer.json", "tokenizer_config.json", "chat_template.jinja",
@@ -38,6 +40,7 @@ _AUX_FILES = (
 )
 
 # --quantize-extras: affine quantization for the non-TurboQuant remainder.
+# Defaults; override per-conversion with --extras-bits / --extras-group-size.
 _EXTRAS_BITS = 8
 _EXTRAS_GROUP = 64
 
@@ -52,6 +55,8 @@ def convert_vlm(
     attn_bits: int = None,
     mlp_bits: int = None,
     quantize_extras: bool = False,
+    extras_bits: int = _EXTRAS_BITS,
+    extras_group_size: int = _EXTRAS_GROUP,
     protect_expert_layers: list = None,
     protect_bits: int = 3,
 ):
@@ -104,6 +109,7 @@ def convert_vlm(
 
     print(f"[INFO] Loading {hf_path} via mlx-vlm (lazy)")
     config = load_config(hf_path)
+    patch_vlm_arch(config.get("model_type", "").lower())
     model = load_model(hf_path, lazy=True)
 
     arch = _detect_architecture(config)
@@ -136,19 +142,19 @@ def convert_vlm(
                 return False
             if "router" in p or "self_conditioning" in p:
                 return False
-            if hasattr(m, "weight") and m.weight.shape[-1] % _EXTRAS_GROUP != 0:
+            if hasattr(m, "weight") and m.weight.shape[-1] % extras_group_size != 0:
                 return False  # e.g. vision MLP down (4304-wide) stays bf16
             n_extra[0] += 1
             return True
 
-        nn.quantize(model, group_size=_EXTRAS_GROUP, bits=_EXTRAS_BITS,
+        nn.quantize(model, group_size=extras_group_size, bits=extras_bits,
                     class_predicate=_extras_predicate)
         mx.eval(model.parameters())
         config["quantization"]["affine_extras"] = {
-            "bits": _EXTRAS_BITS, "group_size": _EXTRAS_GROUP,
+            "bits": extras_bits, "group_size": extras_group_size,
         }
         print(f"[INFO] Quantized {n_extra[0]} extra modules to "
-              f"{_EXTRAS_BITS}-bit affine (embeddings/dense MLP/vision)")
+              f"{extras_bits}-bit affine (embeddings/dense MLP/vision)")
 
     if protect_expert_layers:
         config["quantization"]["protected_expert_layers"] = sorted(
@@ -189,8 +195,19 @@ def main():
                         help="Override bits for MLP / MoE expert linears")
     parser.add_argument("--quantize-extras", action="store_true",
                         help="Also quantize embeddings, dense MLP and vision "
-                             "tower to 8-bit affine (for memory-constrained "
+                             "tower to affine (for memory-constrained "
                              "machines, e.g. 16 GB Macs)")
+    parser.add_argument("--extras-bits", type=int, default=_EXTRAS_BITS,
+                        choices=[4, 8],
+                        help=f"Bit width for --quantize-extras (default "
+                             f"{_EXTRAS_BITS}). Use 4 when the extras are a big "
+                             f"share of the model — Muse Glimmer's embedding + "
+                             f"vision tower are 3.3B params, ~3.9 GB at 8-bit "
+                             f"vs ~1.8 GB at 4-bit.")
+    parser.add_argument("--extras-group-size", type=int, default=_EXTRAS_GROUP,
+                        choices=[32, 64, 128],
+                        help=f"Group size for --quantize-extras (default "
+                             f"{_EXTRAS_GROUP})")
     parser.add_argument("--protect-expert-layers", type=str, default=None,
                         help="Comma-separated layer indices whose EXPERTS keep "
                              "--protect-bits instead of --bits (quality lift "
@@ -210,6 +227,8 @@ def main():
         attn_bits=args.attn_bits,
         mlp_bits=args.mlp_bits,
         quantize_extras=args.quantize_extras,
+        extras_bits=args.extras_bits,
+        extras_group_size=args.extras_group_size,
         protect_expert_layers=(
             [int(i) for i in args.protect_expert_layers.split(",")]
             if args.protect_expert_layers else None),

--- a/integration/rotation_configs.py
+++ b/integration/rotation_configs.py
@@ -21,9 +21,12 @@ class LayerRotationConfig:
     """Rotation configuration for a single transformer block.
 
     fuse_norm_to_projs: Maps norm layer name -> list of projection layer names
-        whose rotation can be fused into that norm's weight.
+        whose rotation can be fused into that norm's weight. An entry may be a
+        bare leaf name ("q_proj") or a parent-qualified suffix
+        ("self_attn.gate_proj") when the same leaf name appears under two
+        parents in one block — see MUSE_GLIMMER_CONFIG.
     online_rotation_layers: Projection layer names that need online rotation
-        (their inputs pass through non-linearities).
+        (their inputs pass through non-linearities). Same two forms.
     """
     fuse_norm_to_projs: dict[str, list[str]] = field(default_factory=dict)
     online_rotation_layers: list[str] = field(default_factory=list)
@@ -129,6 +132,34 @@ DEEPSEEK_MLA_MOE_CONFIG = LayerRotationConfig(
 )
 
 
+# Muse Glimmer (Meta, dense 30B VLM; lives in mlx-vlm — see convert_vlm).
+# Gemma2-style sandwich norms, but with a GATED attention block:
+#   h   = x + post_attention_layernorm(attn(input_layernorm(x)))
+#   out = h + post_feedforward_layernorm(mlp(pre_feedforward_layernorm(h)))
+# The attention block reads its normed input four times — q/k/v AND a sigmoid
+# output gate (`self_attn.gate_proj`) — so all four fuse into input_layernorm.
+# The two `post_*` norms sit on the residual branch, after the sublayer, and
+# feed no projection at all, so nothing fuses into them.
+#
+# NOTE the leaf-name collision: this block has `self_attn.gate_proj` (attention
+# output gate) AND `mlp.gate_proj` (SwiGLU gate), which take their inputs from
+# two DIFFERENT norms. Both are written parent-qualified so they cannot be
+# confused — a bare "gate_proj" entry would silently fuse the attention gate
+# into the MLP's norm.
+MUSE_GLIMMER_CONFIG = LayerRotationConfig(
+    fuse_norm_to_projs={
+        "input_layernorm": ["q_proj", "k_proj", "v_proj", "self_attn.gate_proj"],
+        "pre_feedforward_layernorm": ["mlp.gate_proj", "up_proj"],
+    },
+    online_rotation_layers=[
+        # o_proj input is attn_out * sigmoid(gate) — non-linear
+        "o_proj",
+        # down_proj input is swiglu(gate, up) — non-linear
+        "down_proj",
+    ],
+)
+
+
 # Registry mapping architecture names to rotation configs
 ROTATION_CONFIGS: dict[str, LayerRotationConfig] = {
     "llama": LLAMA_CONFIG,
@@ -162,6 +193,10 @@ ROTATION_CONFIGS: dict[str, LayerRotationConfig] = {
     # Same pre-norm attn + SwitchGLU-style expert layout as MoE LLaMA; only
     # consulted when fuse_rotations=True (production uses online rotation).
     "diffusion_gemma": MOE_LLAMA_CONFIG,
+    # Muse Glimmer (dense VLM, mlx-vlm). Only consulted when
+    # fuse_rotations=True; production uses online rotation.
+    "muse_glimmer": MUSE_GLIMMER_CONFIG,
+    "muse_glimmer_text": MUSE_GLIMMER_CONFIG,
 }
 
 
@@ -204,6 +239,19 @@ def should_fuse_rotation(
     """
     # Extract the projection name from the path
     proj_name = layer_path.split(".")[-1]
+
+    # Parent-qualified entries ("self_attn.gate_proj") are matched FIRST and
+    # win over bare leaf names. Architectures like muse_glimmer repeat a leaf
+    # name under two parents within one block, and the two copies read
+    # different norms — matching on the leaf alone would fuse one of them into
+    # the wrong norm and silently corrupt the weights.
+    for norm_name, proj_list in config.fuse_norm_to_projs.items():
+        for entry in proj_list:
+            if "." in entry and layer_path.endswith("." + entry):
+                return True, norm_name
+    for entry in config.online_rotation_layers:
+        if "." in entry and layer_path.endswith("." + entry):
+            return False, None
 
     # Check if this projection can be fused into a norm
     for norm_name, proj_list in config.fuse_norm_to_projs.items():

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -38,8 +38,20 @@ def _require_mlx_vlm():
 # and the dense per-layer MLP at >= 8-bit (quant-sensitive); the
 # self-conditioning MLP feeds every denoise step and is tiny. ".mlp." matches
 # only the dense MLP — experts live under ".experts." as SwitchLinear.
+# muse_glimmer: `lm_head` is deliberately left to the affine-extras path rather
+# than polar-quantized. PolarQuantizedLinear has a fused Metal kernel only for
+# the single-vector decode path; ANY batch > 1 (i.e. all of prefill) falls back
+# to polar_dequantize_weight + GEMM, which materializes the weight through
+# several full-size intermediates — measured at ~14 bytes per parameter.
+# lm_head is 202048x6656 = 1.345B params, by far the largest matrix in the
+# model, so that fallback costs **~19 GB of transient peak** during any prefill,
+# versus ~1.9 GB for the largest MLP projection. Polar only buys 0.21 GB of
+# steady-state size over 4-bit affine here. MLX's affine path has a fused
+# quantized matmul for batched input and materializes nothing.
+# Net: -19 GB prefill peak for +0.21 GB on disk.
 VLM_SKIP_PATTERNS: dict[str, tuple[str, ...]] = {
     "diffusion_gemma": ("router", "self_conditioning", "embed_vision", ".mlp."),
+    "muse_glimmer": ("lm_head",),
 }
 
 

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -43,6 +43,70 @@ VLM_SKIP_PATTERNS: dict[str, tuple[str, ...]] = {
 }
 
 
+def _patch_muse_glimmer_normed_embedding() -> None:
+    """Teach Muse Glimmer's ``NormedEmbedding`` how to quantize itself.
+
+    Muse Glimmer's ``embed_tokens`` is an ``nn.Embedding`` subclass that
+    RMS-normalizes the row it looks up. It inherits ``nn.Embedding.to_quantized``,
+    which returns a *plain* ``QuantizedEmbedding`` — silently dropping the
+    normalization and corrupting every activation downstream. mlx-vlm's own
+    ``quant_predicate`` avoids that by refusing to quantize the module at all,
+    which leaves 1.35B params (2.7 GB at bf16) uncompressed and is most of the
+    reason a "4-bit" Muse Glimmer weighs 21.4 GB.
+
+    Returning a norm-preserving subclass instead keeps the maths bit-for-bit
+    identical and makes the module compressible. Both ``convert_vlm`` and
+    ``load_turboquant_vlm`` reach the embedding through ``nn.quantize``, so
+    patching ``to_quantized`` fixes the write and read sides at once.
+
+    Idempotent, and a no-op if mlx-vlm has no muse_glimmer module.
+    """
+    try:
+        from mlx_vlm.models.muse_glimmer import language as _mg
+    except ImportError:
+        return
+    if getattr(_mg.NormedEmbedding, "_tq_patched", False):
+        return
+
+    import mlx.core as mx
+    import mlx.nn as nn
+
+    class QuantizedNormedEmbedding(nn.QuantizedEmbedding):
+        """QuantizedEmbedding that keeps NormedEmbedding's RMS normalization."""
+
+        def __call__(self, x):
+            return self.embed_norm(super().__call__(x))
+
+    def to_quantized(self, group_size=None, bits=None, mode="affine",
+                     quantize_input=False):
+        if quantize_input:
+            raise ValueError("Quantized input is not supported.")
+        num_embeddings, dims = self.weight.shape
+        ql = QuantizedNormedEmbedding(num_embeddings, dims, group_size, bits,
+                                      mode=mode)
+        ql.weight, ql.scales, *biases = mx.quantize(
+            self.weight, group_size, bits, mode=mode
+        )
+        ql.biases = biases[0] if biases else None
+        # Paramless RMSNormNoScale — carries only `eps`, so sharing is safe.
+        ql.embed_norm = self.embed_norm
+        return ql
+
+    _mg.NormedEmbedding.to_quantized = to_quantized
+    _mg.QuantizedNormedEmbedding = QuantizedNormedEmbedding
+    _mg.NormedEmbedding._tq_patched = True
+
+
+def patch_vlm_arch(arch: str) -> None:
+    """Apply per-architecture fixes needed before quantizing OR loading.
+
+    Must run on both sides: the converter decides what ``nn.quantize`` produces,
+    and the loader has to rebuild the very same classes.
+    """
+    if arch in ("muse_glimmer", "muse_glimmer_text"):
+        _patch_muse_glimmer_normed_embedding()
+
+
 def vlm_should_quantize(arch: str, base_predicate):
     """Wrap the converter's _should_quantize with VLM-specific skips."""
     _require_mlx_vlm()
@@ -88,6 +152,8 @@ def load_turboquant_vlm(model_path, lazy=False):
         raise ValueError(f"{model_path} is not a TurboQuant checkpoint")
     tq_config = TurboQuantConfig.from_dict(tq_dict)
     config.pop("quantization_config", None)
+
+    patch_vlm_arch(config.get("model_type", "").lower())
 
     model_class, _ = get_model_and_args(config=config)
     config.setdefault("text_config", config.pop("llm_config", {}))

--- a/kernels/polar_qmm.py
+++ b/kernels/polar_qmm.py
@@ -1,0 +1,184 @@
+"""polar_qmm: batched dense GEMM on packed TurboQuant weights.
+
+Y[n, o] = sum_k x[n, k] * W[o, k]
+
+The dense counterpart to :mod:`polar_gather_qmm`, which does the same thing for
+MoE experts. Without this, ``PolarQuantizedLinear`` had a fused kernel only for
+the single-vector decode path (:mod:`polar_qmv`) and fell back to
+``polar_dequantize_weight`` + ``x @ w.T`` for ANY batch > 1 -- that is, for all
+of prefill. That fallback materializes the weight through several full-size
+intermediates, measured at ~14 bytes per parameter, which is both a large
+transient memory spike and wasted bandwidth. Peak memory is what makes it
+fatal: it is a FIXED cost that appears the instant n_tokens >= 2 and is
+independent of prompt length.
+
+Structure follows polar_gather_qmm: one threadgroup per (16-token tile,
+64-row output block); 256 threads = 64 output rows x 4 word-partitions. Each
+thread walks its output row's packed words with stride 4 (coalesced across
+partitions), unpacks the codes in each word, and FMAs into 16 statically
+indexed per-token accumulators held in registers, against an x tile staged once
+in threadgroup memory. The packed weight is read once per tile and decoded in
+registers; the dequantized matrix is never written to memory.
+"""
+
+import math
+
+import mlx.core as mx
+
+TT = 16    # tokens per tile
+OB = 64    # output rows per block
+NT = 256   # threads per threadgroup
+WC = 32    # packed words per K-chunk
+
+_kernel_cache: dict[tuple, object] = {}
+
+
+def _build_source(bits: int, group_size: int, trit: bool = False) -> str:
+    if trit:
+        n_codes = 3
+        epu = 20              # trits per packed word
+        pow3_init = ", ".join(f"{3 ** i}u" for i in range(20))
+        pow3_decl = f"    const uint pw3[20] = {{{pow3_init}}};\n"
+        code_expr = "(word / pw3[j]) % 3u"   # base-3 digit at slot j
+    else:
+        n_codes = 1 << bits
+        epu = 32 // bits          # codes per packed word
+        mask = (1 << bits) - 1
+        pow3_decl = ""
+        code_expr = f"(word >> (j * {bits}u)) & {mask}u"
+    kc = WC * epu             # cols per chunk
+
+    return f"""
+    uint tid = thread_position_in_threadgroup.x;
+    uint tile = threadgroup_position_in_grid.x;
+    uint oblk = threadgroup_position_in_grid.y;
+
+    uint N = x_shape[0];
+    uint K = x_shape[1];
+    uint O = packed_weight_shape[0];
+    uint pw_cols = packed_weight_shape[1];
+    uint n_groups = scales_shape[1];
+
+    uint t0 = tile * {TT}u;
+    if (t0 >= N) return;                           // tail tile beyond the batch
+
+    uint o = oblk * {OB}u + tid / 4u;
+    uint wpart = tid % 4u;
+
+    threadgroup half xs[{kc}][{TT}];
+    threadgroup float red[{NT}];
+
+    float cb[{n_codes}];
+    #pragma unroll
+    for (uint i = 0; i < {n_codes}u; i++) cb[i] = float(codebook[i]);
+{pow3_decl}
+    float acc[{TT}];
+    #pragma unroll
+    for (uint t = 0; t < {TT}u; t++) acc[t] = 0.0f;
+
+    // Clamp the row used for ADDRESS computation: when O is not a multiple of
+    // {OB}, threads with o >= O must keep participating in the barriers below,
+    // so they compute on row O-1 and the o < O write guard discards their
+    // result. Without the clamp they would read out of bounds.
+    uint safe_o = min(o, O - 1u);
+    uint pw_base = safe_o * pw_cols;
+    uint sc_base = safe_o * n_groups;
+    uint n_chunks = (K + {kc}u - 1u) / {kc}u;
+
+    for (uint c = 0u; c < n_chunks; c++) {{
+        uint k0 = c * {kc}u;
+        uint cols = min((uint){kc}, K - k0);
+
+        // Cooperative stage of the x chunk: xs[kk][t]. Clamp the address
+        // operands so tail tokens and tail columns can never form an
+        // out-of-bounds address even under predicated execution.
+        for (uint i = tid; i < {kc}u * {TT}u; i += {NT}u) {{
+            uint kk = i / {TT}u;
+            uint tt = i % {TT}u;
+            uint tok = t0 + tt;
+            uint safe_tok = tok < N ? tok : 0u;
+            uint safe_kk = kk < cols ? kk : 0u;
+            xs[kk][tt] = (kk < cols && tok < N)
+                ? x[safe_tok * K + k0 + safe_kk] : half(0.0f);
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        uint w0 = k0 / {epu}u;                     // chunk's first word
+        uint n_words = (cols + {epu}u - 1u) / {epu}u;
+        for (uint wi = wpart; wi < n_words; wi += 4u) {{
+            uint word = packed_weight[pw_base + w0 + wi];
+            uint col0 = wi * {epu}u;               // within chunk
+            #pragma unroll
+            for (uint j = 0; j < {epu}u; j++) {{
+                uint col = col0 + j;
+                if (col >= cols) break;
+                uint code = {code_expr};
+                float w = cb[code]
+                    * float(scales[sc_base + (k0 + col) / {group_size}u]);
+                #pragma unroll
+                for (uint t = 0; t < {TT}u; t++) {{
+                    acc[t] = fma(w, float(xs[col][t]), acc[t]);
+                }}
+            }}
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }}
+
+    // reduce the 4 word-partitions per output row, write Y[tok, o]
+    #pragma unroll
+    for (uint t = 0u; t < {TT}u; t++) {{
+        red[tid] = acc[t];
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+        if (wpart == 0u && o < O && (t0 + t) < N) {{
+            float v = red[tid] + red[tid + 1u] + red[tid + 2u] + red[tid + 3u];
+            out[(t0 + t) * O + o] = T(v);
+        }}
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+    }}
+"""
+
+
+def _get_kernel(bits: int, group_size: int, trit: bool = False):
+    key = (bits, group_size, trit)
+    if key not in _kernel_cache:
+        name = (
+            f"polar_qmm_trit_gs{group_size}"
+            if trit
+            else f"polar_qmm_{bits}b_gs{group_size}"
+        )
+        _kernel_cache[key] = mx.fast.metal_kernel(
+            name=name,
+            input_names=["packed_weight", "scales", "codebook", "x"],
+            output_names=["out"],
+            source=_build_source(bits, group_size, trit),
+            ensure_row_contiguous=True,
+        )
+    return _kernel_cache[key]
+
+
+def polar_qmm(packed_weight, scales, codebook, x, bits, group_size, trit=False):
+    """Fused batched quantized matmul: (N, K) @ dequant(W).T -> (N, O).
+
+    Args:
+        packed_weight: (O, pw_cols) uint32 — packed b-bit indices (or trits).
+        scales: (O, n_groups) float16 — per-group RMS scales.
+        codebook: (n_codes,) float16 — Lloyd-Max centroids (3 entries if trit).
+        x: (N, K) float16 — input, N >= 1.
+        bits: Quantization bit-width (2, 3, or 4). Ignored when trit=True.
+        group_size: Elements per quantization group.
+        trit: If True, decode base-3 packing (20 trits/uint32).
+
+    Returns:
+        (N, O) — same dtype as x.
+    """
+    N = int(x.shape[0])
+    O = int(packed_weight.shape[0])
+    kernel = _get_kernel(bits, group_size, trit)
+    return kernel(
+        inputs=[packed_weight, scales, codebook, x],
+        template=[("T", x.dtype)],
+        grid=(math.ceil(N / TT) * NT, math.ceil(O / OB), 1),
+        threadgroup=(NT, 1, 1),
+        output_shapes=[(N, O)],
+        output_dtypes=[x.dtype],
+    )[0]

--- a/layers/polar_linear.py
+++ b/layers/polar_linear.py
@@ -6,6 +6,7 @@ Achieves much better quality at 2-3 bits than standard affine quantization.
 """
 
 import math
+import os
 
 import mlx.core as mx
 import mlx.nn as nn
@@ -17,6 +18,23 @@ from turboquant_mlx.core.polar_quantize import polar_quantize_weight, polar_dequ
 from turboquant_mlx.core.qjl import qjl_quantize, qjl_correct
 # Use Python kernels - native C++ extension has ABI issues with MLX
 from turboquant_mlx.kernels.polar_qmv import polar_qmv
+from turboquant_mlx.kernels.polar_qmm import polar_qmm
+
+# Batched dispatch bounds for the fused polar_qmm kernel, measured on an M4 Max
+# against the dequantize + GEMM path it replaces (3-bit, g64):
+#
+#   shape                N=2    N=8   N=32  N=128  N=512  N=2048   dq spike
+#   mlp gate/up (19968) 9.30x  9.19x  5.81x  1.95x  0.75x   0.41x    1.35 GB
+#   o_proj      ( 6656) 5.81x  5.84x  4.29x  1.81x  0.73x   0.42x    0.12 GB
+#   q_proj      ( 4096) 2.18x  4.44x  2.81x  1.35x  1.88x   0.42x    0.27 GB
+#   k/v_proj    (  256) 0.71x  0.75x  0.79x  0.84x  0.60x   0.51x    0.00 GB
+#
+# Above ~256 tokens MLX's tuned GEMM beats the fused kernel on time, so the
+# default keeps the old path there. Below 512 output dims there are too few
+# 64-row output blocks to fill the GPU, and the weight is small enough that
+# materializing it costs nothing anyway.
+_QMM_MAX_TOKENS = int(os.environ.get("TURBOQUANT_QMM_MAX_TOKENS", "256"))
+_QMM_MIN_OUTPUT_DIMS = 512
 
 
 class PolarQuantizedLinear(nn.Module):
@@ -84,8 +102,12 @@ class PolarQuantizedLinear(nn.Module):
         if self._needs_rotation:
             x = rotate_input(x, self.signs)
 
-        # Decode path: fused Metal kernel (no weight materialization)
-        # Prefill path: software dequant + optimized GEMM
+        # Decode path (1 token): fused matrix-vector kernel.
+        # Small batch: fused matrix-matrix kernel — faster AND allocates
+        #   nothing, because it decodes the packed weight in registers.
+        # Large batch: dequantize + MLX GEMM, which wins on time above
+        #   _QMM_MAX_TOKENS but materializes the full weight (~14 bytes per
+        #   parameter transient — the reason prefill peak dwarfs the model).
         n_vectors = 1 if x.ndim <= 1 else math.prod(x.shape[:-1])
         if n_vectors == 1:
             orig_shape = x.shape
@@ -95,6 +117,15 @@ class PolarQuantizedLinear(nn.Module):
                 x_vec, self.bits, self.group_size,
             )
             y = y.reshape(*orig_shape[:-1], -1) if x.ndim >= 2 else y
+        elif (n_vectors <= _QMM_MAX_TOKENS
+                and self.output_dims >= _QMM_MIN_OUTPUT_DIMS):
+            orig_shape = x.shape
+            y = polar_qmm(
+                self.weight, self.scales, self.codebook,
+                x.reshape(n_vectors, orig_shape[-1]),
+                self.bits, self.group_size,
+            )
+            y = y.reshape(*orig_shape[:-1], -1)
         else:
             # Batched: dequantize and use MLX's optimized GEMM
             w = polar_dequantize_weight(

--- a/plan.py
+++ b/plan.py
@@ -263,15 +263,66 @@ def kv_bytes(cfg: dict, context: int, kv_bits: int | None = None) -> tuple:
     return total, (total / context if context else 0.0), note
 
 
-def prefill_workspace_bytes(cfg: dict, context: int, step: int) -> float:
-    """Transient attention scratch for one prefill chunk (ESTIMATE).
+# Dequantizing a packed polar weight for the batched path costs ~14 bytes per
+# parameter transiently — unpack_indices -> dequantize_scalar -> scale multiply,
+# each a full-size intermediate. Measured on an M4 Max, and consistent across
+# matrices two orders of magnitude apart in size (a 132.9M-param MLP projection
+# cost 1.87 GB; a 1.345B-param lm_head cost 18.84 GB). Roughly two projections
+# are live at once as MLX walks a layer: one full decoder layer measured 3.85 GB
+# against a largest-projection cost of 1.87 GB.
+_POLAR_DEQUANT_BYTES_PER_PARAM = 14.0
+_POLAR_LIVE_PROJECTIONS = 2.0
 
-    Scales with chunk size AND context — which is why a long agent turn can OOM
-    at a chunk size that was fine when the conversation was short.
+# PolarQuantizedLinear routes batches this size or smaller to the fused
+# polar_qmm kernel, which materializes nothing. Keep in sync with
+# layers/polar_linear.py:_QMM_MAX_TOKENS.
+_QMM_MAX_TOKENS = 256
+
+
+def _largest_projection_params(cfg: dict) -> float:
+    """Parameter count of the widest dense projection in one decoder layer."""
+    c = _text_config(cfg)
+    hidden = _pos_int(c.get("hidden_size"), 0)
+    inter = _pos_int(c.get("intermediate_size"), 0)
+    heads = _pos_int(c.get("num_attention_heads"), 0)
+    head_dim = _pos_int(c.get("head_dim"), hidden // heads if heads else 0)
+    return float(max(hidden * inter, hidden * heads * head_dim, 0))
+
+
+def prefill_workspace_bytes(cfg: dict, context: int, step: int,
+                            quant: dict | None = None,
+                            is_moe: bool = False) -> float:
+    """Transient memory for one prefill chunk (ESTIMATE). Three terms:
+
+    1. Attention scratch — scales with chunk size AND context, which is why a
+       long agent turn can OOM at a chunk size that was fine when the
+       conversation was short.
+    2. The lm_head output for the whole chunk. Easy to forget and often the
+       largest term on a big-vocab model: 202048 vocab x 2048 tokens = 0.77 GB.
+    3. Weight dequantization, for TurboQuant DENSE layers only, and only above
+       the fused kernel's token bound. This one is a step function, not a
+       gradient: it appears in full the moment the chunk exceeds
+       _QMM_MAX_TOKENS.
+
+    MoE expert dequantization is NOT modelled — SwitchLinear has its own
+    dequant-all fallback with different residency, so MoE estimates here remain
+    attention + logits only.
     """
     c = _text_config(cfg)
-    heads = c.get("num_attention_heads") or 16
-    return float(step) * float(context) * float(heads) * 2.0
+    heads = _pos_int(c.get("num_attention_heads"), 16)
+    attn = float(step) * float(context) * float(heads) * 2.0
+
+    vocab = _pos_int(c.get("vocab_size"), _pos_int(cfg.get("vocab_size"), 0))
+    logits = float(step) * float(vocab) * 2.0
+
+    dequant = 0.0
+    if (quant and quant.get("mode") == "turboquant" and not is_moe
+            and step > _QMM_MAX_TOKENS):
+        dequant = (_largest_projection_params(cfg)
+                   * _POLAR_DEQUANT_BYTES_PER_PARAM
+                   * _POLAR_LIVE_PROJECTIONS)
+
+    return attn + logits + dequant
 
 
 # --------------------------------------------------------------------------
@@ -386,7 +437,9 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
         # capped it, and activations/fragmentation live here too. Same 2 GB the
         # auto-guards reserve.
         return (fp["total_bytes"] + kv_total
-                + prefill_workspace_bytes(cfg, context, s) + _RESERVE_BYTES)
+                + prefill_workspace_bytes(cfg, context, s,
+                                          cfg.get("quantization"), is_moe)
+                + _RESERVE_BYTES)
 
     # Largest chunk whose projection keeps real headroom under the (possibly
     # raised) ceiling. The 0.95 is deliberate: a chunk size chosen to *just* fit
@@ -402,7 +455,8 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
     if chosen is None:
         chosen = steps[-1]
     peak = peak_at(chosen)
-    workspace = prefill_workspace_bytes(cfg, context, chosen)
+    workspace = prefill_workspace_bytes(cfg, context, chosen,
+                                        cfg.get("quantization"), is_moe)
 
     # ---- verdict -------------------------------------------------------
     needs_bump = False
@@ -443,7 +497,7 @@ def build_plan(model_path: str, context: int = 16384, kv_bits: int | None = None
                      f"here, peaking near {peak_bytes / _GB:.1f} GB)")
     if chosen != 2048:
         flags.append(f"--prefill-step-size {chosen}   (the default 2048 needs "
-                     f"{_gb(prefill_workspace_bytes(cfg, context, 2048))} of "
+                     f"{_gb(prefill_workspace_bytes(cfg, context, 2048, cfg.get('quantization'), is_moe))} of "
                      f"transient workspace at this context)")
     if kv_bits:
         flags.append(f"--kv-bits {kv_bits}")

--- a/tests/test_muse_glimmer.py
+++ b/tests/test_muse_glimmer.py
@@ -90,6 +90,34 @@ def test_gated_attention_takes_the_attention_bit_tier():
     assert cfg.bits_for_path(f"{_L0}.mlp.down_proj") == 2
 
 
+def test_lm_head_is_kept_out_of_the_polar_path():
+    """lm_head must fall to affine, not PolarQuantizedLinear.
+
+    PolarQuantizedLinear only has a fused kernel for single-vector decode; any
+    batch > 1 dequantizes the weight through several full-size intermediates
+    (~14 bytes/param measured). At 202048x6656 = 1.345B params that is ~19 GB of
+    transient peak on every prefill, to save 0.21 GB on disk. Measured end to
+    end: prefill peak over weights fell 20.06 GB -> 3.86 GB when lm_head moved
+    to affine.
+    """
+    from turboquant_mlx.integration.vlm import VLM_SKIP_PATTERNS
+
+    assert "lm_head" in VLM_SKIP_PATTERNS["muse_glimmer"]
+
+
+def test_vlm_skip_predicate_excludes_lm_head_and_vision_tower():
+    pytest.importorskip("mlx_vlm", reason="mlx-vlm not installed")
+    from turboquant_mlx.integration.vlm import vlm_should_quantize
+
+    predicate = vlm_should_quantize("muse_glimmer", lambda p, m: True)
+    assert predicate("language_model.lm_head", None) is False
+    assert predicate("vision_tower.layers.0.attn.q_proj", None) is False
+    # the text stack still goes through TurboQuant
+    assert predicate(f"{_L0}.self_attn.q_proj", None) is True
+    assert predicate(f"{_L0}.self_attn.gate_proj", None) is True
+    assert predicate(f"{_L0}.mlp.down_proj", None) is True
+
+
 def test_normed_embedding_keeps_its_norm_when_quantized():
     """Quantizing `embed_tokens` must preserve the RMS normalization.
 

--- a/tests/test_muse_glimmer.py
+++ b/tests/test_muse_glimmer.py
@@ -1,0 +1,156 @@
+"""Muse Glimmer (Meta, dense 30B VLM) support.
+
+Two things here are easy to get silently wrong, and both produce a model that
+loads and generates fluent-looking garbage rather than raising:
+
+1. The decoder block contains TWO projections named ``gate_proj`` —
+   ``self_attn.gate_proj`` (the sigmoid attention output gate) and
+   ``mlp.gate_proj`` (the SwiGLU gate). They read DIFFERENT norms, and they
+   belong to different bit tiers.
+2. ``embed_tokens`` is a ``NormedEmbedding`` — an ``nn.Embedding`` subclass that
+   RMS-normalizes the row it looks up. The inherited ``to_quantized`` returns a
+   plain ``QuantizedEmbedding`` and drops the normalization.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from turboquant_mlx.config import TurboQuantConfig
+from turboquant_mlx.integration.rotation_configs import (
+    get_rotation_config,
+    should_fuse_rotation,
+)
+
+_L0 = "language_model.model.layers.0"
+
+
+def test_rotation_config_registered():
+    for arch in ("muse_glimmer", "muse_glimmer_text"):
+        assert get_rotation_config(arch) is not None
+
+
+def test_attention_gate_and_mlp_gate_fuse_into_different_norms():
+    """The two `gate_proj`s must not collapse onto one norm."""
+    cfg = get_rotation_config("muse_glimmer")
+
+    attn_fuse, attn_norm = should_fuse_rotation(f"{_L0}.self_attn.gate_proj", cfg)
+    mlp_fuse, mlp_norm = should_fuse_rotation(f"{_L0}.mlp.gate_proj", cfg)
+
+    assert (attn_fuse, attn_norm) == (True, "input_layernorm")
+    assert (mlp_fuse, mlp_norm) == (True, "pre_feedforward_layernorm")
+    assert attn_norm != mlp_norm
+
+
+@pytest.mark.parametrize(
+    "proj,expected",
+    [
+        ("self_attn.q_proj", (True, "input_layernorm")),
+        ("self_attn.k_proj", (True, "input_layernorm")),
+        ("self_attn.v_proj", (True, "input_layernorm")),
+        # o_proj reads attn_out * sigmoid(gate) -> non-linear -> online
+        ("self_attn.o_proj", (False, None)),
+        ("mlp.up_proj", (True, "pre_feedforward_layernorm")),
+        # down_proj reads swiglu(gate, up) -> non-linear -> online
+        ("mlp.down_proj", (False, None)),
+    ],
+)
+def test_rotation_fusion_targets(proj, expected):
+    cfg = get_rotation_config("muse_glimmer")
+    assert should_fuse_rotation(f"{_L0}.{proj}", cfg) == expected
+
+
+def test_post_norms_absorb_nothing():
+    """The sandwich `post_*` norms sit on the residual branch, after the
+    sublayer, so no projection may fuse into them."""
+    cfg = get_rotation_config("muse_glimmer")
+    targets = set(cfg.fuse_norm_to_projs)
+    assert "post_attention_layernorm" not in targets
+    assert "post_feedforward_layernorm" not in targets
+
+
+def test_qualified_entries_do_not_regress_bare_name_archs():
+    """Adding parent-qualified matching must not change LLaMA-style configs."""
+    cfg = get_rotation_config("llama")
+    assert should_fuse_rotation("m.layers.0.self_attn.q_proj", cfg) == (
+        True, "input_layernorm")
+    assert should_fuse_rotation("m.layers.0.mlp.gate_proj", cfg) == (
+        True, "post_attention_layernorm")
+    assert should_fuse_rotation("m.layers.0.mlp.down_proj", cfg) == (False, None)
+    assert should_fuse_rotation("m.layers.0.self_attn.o_proj", cfg) == (False, None)
+
+
+def test_gated_attention_takes_the_attention_bit_tier():
+    """`self_attn.gate_proj` is attention, not MLP — a hybrid build must not
+    quietly drop it into the MLP tier (or vice versa)."""
+    cfg = TurboQuantConfig(bits=3, group_size=64, attn_bits=3, mlp_bits=2)
+    assert cfg.bits_for_path(f"{_L0}.self_attn.gate_proj") == 3
+    assert cfg.bits_for_path(f"{_L0}.self_attn.q_proj") == 3
+    assert cfg.bits_for_path(f"{_L0}.mlp.gate_proj") == 2
+    assert cfg.bits_for_path(f"{_L0}.mlp.down_proj") == 2
+
+
+def test_normed_embedding_keeps_its_norm_when_quantized():
+    """Quantizing `embed_tokens` must preserve the RMS normalization.
+
+    Without the patch, `nn.quantize` swaps in a plain QuantizedEmbedding and the
+    normalization vanishes — no error, just wrong activations everywhere.
+    """
+    mg_language = pytest.importorskip(
+        "mlx_vlm.models.muse_glimmer.language",
+        reason="mlx-vlm build without muse_glimmer",
+    )
+    from turboquant_mlx.integration.vlm import patch_vlm_arch
+
+    patch_vlm_arch("muse_glimmer")
+
+    vocab, dims, eps = 512, 256, 1e-5
+    emb = mg_language.NormedEmbedding(vocab, dims, eps)
+    mx.eval(emb.parameters())
+
+    idx = mx.array([1, 7, 300])
+    ref = emb(idx)
+
+    q = emb.to_quantized(group_size=64, bits=8)
+    mx.eval(q.parameters())
+    got = q(idx)
+
+    # The norm survived: a plain QuantizedEmbedding would return unnormalized
+    # rows, whose RMS is nowhere near 1.
+    rms = mx.sqrt(mx.mean(mx.square(got), axis=-1))
+    assert float(mx.max(mx.abs(rms - 1.0))) < 5e-2
+
+    # And 8-bit quantization alone should stay close to the bf16 reference.
+    assert float(mx.max(mx.abs(got - ref))) < 5e-2
+
+
+def test_normed_embedding_patch_is_idempotent():
+    pytest.importorskip(
+        "mlx_vlm.models.muse_glimmer.language",
+        reason="mlx-vlm build without muse_glimmer",
+    )
+    from mlx_vlm.models.muse_glimmer import language as mg_language
+    from turboquant_mlx.integration.vlm import patch_vlm_arch
+
+    patch_vlm_arch("muse_glimmer")
+    first = mg_language.NormedEmbedding.to_quantized
+    patch_vlm_arch("muse_glimmer")
+    assert mg_language.NormedEmbedding.to_quantized is first
+
+
+def test_quantized_normed_embedding_is_not_a_bare_quantized_embedding():
+    pytest.importorskip(
+        "mlx_vlm.models.muse_glimmer.language",
+        reason="mlx-vlm build without muse_glimmer",
+    )
+    from mlx_vlm.models.muse_glimmer import language as mg_language
+    from turboquant_mlx.integration.vlm import patch_vlm_arch
+
+    patch_vlm_arch("muse_glimmer")
+    emb = mg_language.NormedEmbedding(128, 64, 1e-5)
+    mx.eval(emb.parameters())
+    q = emb.to_quantized(group_size=64, bits=8)
+
+    assert isinstance(q, nn.QuantizedEmbedding)
+    assert type(q) is not nn.QuantizedEmbedding
+    assert hasattr(q, "embed_norm")

--- a/tests/test_polar_qmm.py
+++ b/tests/test_polar_qmm.py
@@ -1,0 +1,109 @@
+"""polar_qmm: dense batched GEMM on packed weights.
+
+Verified against the dequantize + GEMM path it replaces, which is the reference
+by construction: the kernel must produce the same numbers without ever
+materializing the weight.
+"""
+
+import mlx.core as mx
+import pytest
+
+from turboquant_mlx.core.polar_quantize import polar_dequantize_weight
+from turboquant_mlx.core.packing import pack_indices, pack_trits
+from turboquant_mlx.kernels.polar_qmm import polar_qmm
+
+
+def _make(out_dims, in_dims, bits, group_size, seed=0, trit=False):
+    """Build a random packed weight plus its dequantized reference."""
+    mx.random.seed(seed)
+    n_groups = in_dims // group_size
+    n_codes = 3 if trit else (1 << bits)
+    if trit:
+        codebook = mx.array([-0.7, 0.0, 0.7], dtype=mx.float16)
+    else:
+        codebook = mx.array(
+            [(i - (n_codes - 1) / 2) * 0.5 for i in range(n_codes)],
+            dtype=mx.float16,
+        )
+    idx = mx.random.randint(0, n_codes, (out_dims, in_dims)).astype(mx.uint32)
+    scales = (mx.random.uniform(shape=(out_dims, n_groups)) * 0.5
+              + 0.25).astype(mx.float16)
+    packed = pack_trits(idx) if trit else pack_indices(idx, bits)
+    ref_w = polar_dequantize_weight(packed, scales, codebook, bits, group_size,
+                                    in_dims, trit=trit)
+    return packed, scales, codebook, ref_w
+
+
+def _check(out_dims, in_dims, n_tokens, bits, group_size, trit=False, tol=2e-2):
+    packed, scales, codebook, ref_w = _make(out_dims, in_dims, bits,
+                                            group_size, trit=trit)
+    x = mx.random.normal((n_tokens, in_dims)).astype(mx.float16)
+
+    got = polar_qmm(packed, scales, codebook, x, bits, group_size, trit=trit)
+    ref = x @ ref_w.T
+    mx.eval(got, ref)
+
+    assert got.shape == (n_tokens, out_dims)
+    denom = mx.maximum(mx.abs(ref).max(), mx.array(1e-3, dtype=mx.float16))
+    rel = float((mx.abs(got - ref) / denom).max())
+    assert rel < tol, f"max rel err {rel:.4g} (bits={bits} g={group_size} " \
+                      f"O={out_dims} K={in_dims} N={n_tokens})"
+
+
+@pytest.mark.parametrize("bits", [2, 3, 4])
+@pytest.mark.parametrize("group_size", [32, 64, 128])
+def test_matches_dequant_gemm(bits, group_size):
+    _check(128, 256, 8, bits, group_size)
+
+
+@pytest.mark.parametrize("n_tokens", [1, 2, 7, 15, 16, 17, 31, 32, 64, 129])
+def test_token_counts_including_tile_boundaries(n_tokens):
+    """Tokens are processed in tiles of 16 — check the tail handling."""
+    _check(128, 256, n_tokens, 3, 64)
+
+
+@pytest.mark.parametrize("out_dims", [64, 128, 192, 256])
+def test_output_block_multiples(out_dims):
+    _check(out_dims, 256, 8, 3, 64)
+
+
+@pytest.mark.parametrize("out_dims", [65, 100, 130])
+def test_output_dims_not_multiple_of_64(out_dims):
+    """The safe_o clamp must keep partial output blocks in bounds."""
+    _check(out_dims, 256, 8, 3, 64)
+
+
+@pytest.mark.parametrize("in_dims", [256, 320, 512, 640, 1024])
+def test_k_chunk_boundaries(in_dims):
+    _check(128, in_dims, 8, 3, 64)
+
+
+def test_trit_packing():
+    _check(128, 320, 8, 3, 64, trit=True)
+
+
+@pytest.mark.parametrize("n_tokens", [1, 16, 33])
+def test_trit_token_counts(n_tokens):
+    _check(128, 320, n_tokens, 3, 64, trit=True)
+
+
+def test_real_muse_glimmer_shapes():
+    """The shapes that actually matter on a 30B dense model."""
+    for out_dims, in_dims in [(4096, 6656),    # q_proj / attn gate_proj
+                              (256, 6656),     # k_proj / v_proj (GQA 2 heads)
+                              (6656, 4096),    # o_proj
+                              (19968, 6656)]:  # mlp gate/up
+        _check(out_dims, in_dims, 4, 3, 64, tol=3e-2)
+
+
+def test_single_token_matches_qmv():
+    """N=1 must agree with the dedicated decode kernel."""
+    from turboquant_mlx.kernels.polar_qmv import polar_qmv
+
+    packed, scales, codebook, _ = _make(256, 512, 3, 64)
+    x = mx.random.normal((1, 512)).astype(mx.float16)
+    a = polar_qmm(packed, scales, codebook, x, 3, 64)
+    b = polar_qmv(packed, scales, codebook, x, 3, 64)
+    mx.eval(a, b)
+    denom = mx.maximum(mx.abs(b).max(), mx.array(1e-3, dtype=mx.float16))
+    assert float((mx.abs(a - b) / denom).max()) < 2e-2


### PR DESCRIPTION
Adds Meta's **Muse Glimmer** (`muse_glimmer`, dense 29.8B VLM, released 2026-08-10), a fused dense batched Metal kernel that closes a long-standing gap in `kernels/`, and a `turboquant-plan` correctness fix.

## The headline result

**At matched 4-bit, TurboQuant beats MLX's affine quantizer on quality *and* size** — 800-token fixed-passage PPL, greedy, M4 Max:

| build | size | PPL ↓ | decode |
|---|---|---|---|
| `mlx-community/Muse-Glimmer-30B-4bit` | 19.88 GiB | 4.3798 | 26.1 tok/s |
| **TurboQuant `tq4-g64`** | **14.88 GiB** | **4.3315** | 9.4 tok/s |
| TurboQuant `tq3-g64` | 12.53 GiB | 5.0454 | 10.9 tok/s |

It wins while *handicapped*: the affine build leaves `embed_tokens` and the whole vision tower at bf16, which is most of its extra 5 GB. Decode is 2.4–2.8× slower — the usual codebook-vs-affine trade, reconfirmed on a new dense model.

I nearly reported the tq3 row as a quality regression. It isn't — that gap is the 3-bit step, and the matched-4-bit control is what isolates it. Worth keeping as a rule: always run the matched-bit control before concluding anything from a tq3-vs-mlx4 table.

## `polar_qmm` — dense batched GEMM on packed weights

`PolarQuantizedLinear` had a fused kernel only for single-vector decode. Every batch > 1 — that is, **all of prefill** — fell back to `polar_dequantize_weight` + GEMM, materializing the weight at **~14 bytes per parameter**, measured consistently across matrices two orders of magnitude apart in size. `kernels/` had no dense batched kernel; the `gather`/`qmm` variants are all MoE-specific.

The new kernel decodes in registers and writes nothing. Dispatch bounds are set by measurement, not preference — it is **9.3× faster at N=2–8** on wide MLP projections but **0.41× at N=2048**, where MLX's tuned GEMM wins, and 0.5–0.8× when the output is too narrow to fill the GPU. So: `2 <= n_tokens <= 256` and `output_dims >= 512`, with `TURBOQUANT_QMM_MAX_TOKENS` to override.

On Muse-Glimmer tq3, prefill peak over resident weights at 64 tokens drops **3.86 GB → 0.62 GB**, and prefill runs **23.1 → 73.9 tok/s**. This benefits every dense TurboQuant model. PPL is unchanged (5.0454 dequant vs 5.0452 fused — fp32 accumulate vs fp16 GEMM).

## Three architecture traps, all silent rather than loud

- **`lm_head` must not be polar-quantized on a big-vocab model.** At 1.345B params it is 10× the largest MLP matrix, so the dequantize-on-prefill fallback cost **18.84 GB of transient peak by itself**, to save 0.21 GB on disk. Routing it to affine: prefill peak 20.06 → 3.86 GB for +0.16 GiB, prefill slightly *faster*.
- **Two `gate_proj`s in one block** — a sigmoid attention output gate and the SwiGLU gate — reading *different* norms. `should_fuse_rotation` matched leaf names only and would have fused one into the wrong norm. Entries may now be parent-qualified; bare-name configs are unaffected and a test pins that. `bits_for_path` was already correct, now pinned so it can't regress into another nemotron-style silent no-op.
- **`embed_tokens` is a `NormedEmbedding`** whose inherited `to_quantized` returns a plain `QuantizedEmbedding` and **silently drops the RMS normalization**. Now quantized through a norm-preserving subclass on both convert and load.

## `turboquant-plan` fix — please note the blast radius

Plan modelled attention scratch only, missing the lm_head output for the chunk and polar dequantization. On Muse Glimmer at 16K the estimate goes 2.15 → 6.70 GB against a measured 6.39 GB, and a 16 GB mini flips from a false `RESIDENT` to `WILL NOT RUN` (14.77 needed vs 14.40 usable; measured 14.73).

**This changes plan output for existing models** — every model gains the logits term, dense TurboQuant models gain the dequant term — so published cards that embed plan output will need regenerating. MoE expert dequantization is still not modelled.

## Caveats

- The MLX model classes come from **[Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838), which is an unmerged draft and not on PyPI.** `[vlm]` alone will not load this model; the README documents the pinned install, including the `transformers==5.15.0` override against our `<5.13` mlx-lm pin.
- No 16 GB build exists. `tq3` is ~0.4 GB over, and the obvious step down fails: a `tq3a-tq2e-g64` hybrid fits at 9.63 GiB but measures **PPL 7.5547** with visible text corruption — 2-bit on a *dense* MLP is not a usable tier, same as 32-expert GPT-OSS-20B.
- Structural verification: 1436/1436 tensors matched against the real checkpoint, 0 missing / 0 extra / 0 shape mismatches, total params exactly 29,776,626,688.

481 tests pass (53 new).