### PR TITLE
chore: release 0.20.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.20.0] - 2026-08-10
+
+Meta's **Muse Glimmer** (dense 30B VLM) lands, and with it the first case where
+TurboQuant beats MLX's affine quantizer on quality *and* size at matched bit
+width — PPL 4.3315 in 14.88 GiB against 4.3798 in 19.88 GiB. Alongside it,
+**`polar_qmm`** closes a long-standing hole in the kernel set: dense prefill no
+longer materializes dequantized weights, which cuts prefill peak memory for
+*every* dense TurboQuant model. `turboquant-plan` gains two prefill terms it was
+missing, which changes its output for existing models.
+
 ### Added
 
 - **Muse Glimmer (Meta, dense 30B VLM) support** — `muse_glimmer`, a

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.19.0"
+__version__ = "0.20.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.19.0"
+version = "0.20.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump + CHANGELOG for **0.20.0**. Rebased onto `main` after #76 was squash-merged, so this is now just the bump.

- `pyproject.toml` and `__init__.py`: 0.19.0 → 0.20.0
- CHANGELOG `[Unreleased]` → `[0.20.0] - 2026-08-10`

Minor bump: new architecture (`muse_glimmer`), new kernel (`polar_qmm`), and a behaviour change in `turboquant-plan` output.

After merge: push `v0.20.0` to trigger `release.yml` (GitHub Release + PyPI via OIDC, gated on the manual `pypi` environment approval).

**Verify before announcing** — a green publish is not proof the package works; 0.17.0 and 0.18.0 both published successfully and were unusable. Install from PyPI into a clean venv and check the version, `models/*` imports, architecture registration in `sys.modules`, and all four console scripts.

One caveat specific to this release: `muse_glimmer` still needs [mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838), which is unmerged and not on PyPI, so `pip install "turboquant-mlx-full[vlm]"` alone will **not** load Muse Glimmer. The README documents the pinned install.

Published builds using this release:
- [manjunathshiva/Muse-Glimmer-30B-tq4-g64](https://huggingface.co/manjunathshiva/Muse-Glimmer-30B-tq4-g64) — 14.88 GiB, PPL 4.3315 (beats affine 4-bit's 4.3798 at 19.88 GiB)
- [manjunathshiva/Muse-Glimmer-30B-tq3-g64](https://huggingface.co/manjunathshiva/Muse-Glimmer-30B-tq3-g64) — 12.53 GiB, PPL 5.0454