### PR TITLE
feat(vlm): reasoning-effort flags + mlx-vlm 0.6.12 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,49 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Added
+
+- **`--reasoning LEVEL` and `--no-think` for `generate_vlm`.** Muse Glimmer's
+  chat template defaults to `reasoning_strength: high`, which spends hundreds of
+  tokens deliberating before a short answer — on a 16 GB mini at ~3.5 tok/s that
+  is most of the wall clock. `--reasoning low|medium|high|xhigh` sets it, and
+  `--no-think` asks for the least reasoning a template supports (it also passes
+  `enable_thinking=False` for Qwen-style templates). Templates that do not
+  reference these keys ignore them. Note that Muse Glimmer has no "off" level,
+  so `--no-think` reduces but does not eliminate the thinking channel.
+
+### Changed
+
+- **Muse Glimmer installs with a plain `pip install "turboquant-mlx-full[vlm]"`.**
+  [Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838) merged on
+  2026-08-10 and shipped in **mlx-vlm 0.6.12**, so the git pin previously
+  documented in the README is obsolete and has been removed. `[vlm]` now
+  requires `mlx-vlm>=0.6.12`.
+
+- **The `transformers<5.13` cap is now a `!=5.13.*` exclusion.** The
+  `AutoTokenizer.register` breakage is confined to the 5.13 series — verified
+  against mlx-lm 0.31.3, where 5.12, 5.14 and 5.15 all import cleanly and only
+  5.13 raises. The old cap was incompatible with mlx-vlm 0.6.12
+  (`transformers>=5.14`), so a resolver honouring it would silently downgrade
+  mlx-vlm to a build with no `muse_glimmer` — the same failure mode that broke
+  the documented install order in 0.20.1.
+
+### Fixed
+
+- **`patch_vlm_arch` crashed on mlx-vlm >= 0.6.12**, taking `convert_vlm` and
+  `load_turboquant_vlm` — every Muse Glimmer entry point — down with it. The
+  released #1838 differs from the PR head this support was written against:
+  `NormedEmbedding` is gone, and `TextModel` now owns a paramless `embed_norm`
+  that it applies in `__call__`. The patch reached straight for
+  `_mg.NormedEmbedding` and raised `AttributeError`. It is now a no-op on the
+  merged layout, where a plain `QuantizedEmbedding` is already correct because
+  the norm is applied outside it.
+
+  **Checkpoints are unaffected in both directions**: `RMSNormNoScale` has no
+  parameters, so neither layout contributes an `embed_norm` key, and models
+  converted against either one load against both. Verified end-to-end by
+  generating with the published `tq4-g64` build on mlx-vlm 0.6.12.
+
 ## [0.20.1] - 2026-08-10
 
 A planner correctness fix and the field data behind it. `turboquant-plan`

--- a/README.md
+++ b/README.md
@@ -144,10 +144,10 @@ pip install "turboquant-mlx-full[vlm]"    # multimodal / diffusion models via ml
 pip install "turboquant-mlx-full[kimi]"   # Kimi K3's tiktoken-based tokenizer
 ```
 
-> **Muse Glimmer needs an unreleased mlx-vlm.** Its MLX model classes live in
-> [Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838), which is
-> not merged and not on PyPI, so `[vlm]` alone will not load it. See
-> [Muse Glimmer](#muse-glimmer-30b-dense-vlm) for the pinned install.
+> **Muse Glimmer needs mlx-vlm >= 0.6.12**, the first release carrying its MLX
+> model classes ([Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838),
+> merged 2026-08-10). `[vlm]` pins that floor, so the one-liner above is all you
+> need — the git pin previously documented here is obsolete.
 
 ## Quick Start
 
@@ -1389,13 +1389,8 @@ inherited `to_quantized` would silently drop its RMS normalization; TurboQuant
 quantizes it through a norm-preserving subclass instead.
 
 ```bash
-# The MLX model classes are not released yet — pin the PR.
-uv venv --python 3.12 .venv-mg
-VIRTUAL_ENV=$PWD/.venv-mg uv pip install \
-    "mlx-vlm @ git+https://github.com/Blaizzy/mlx-vlm.git@c7416a4bcb"
-VIRTUAL_ENV=$PWD/.venv-mg uv pip install "turboquant-mlx-full[vlm]"
-# mlx-vlm's Muse Glimmer needs transformers 5.15, above our mlx-lm pin:
-VIRTUAL_ENV=$PWD/.venv-mg uv pip install --no-deps "transformers==5.15.0"
+# mlx-vlm 0.6.12 shipped the Muse Glimmer classes, so this is a plain install.
+pip install "turboquant-mlx-full[vlm]"
 
 python -m turboquant_mlx.convert_vlm \
   --hf-path meta-models/Muse-Glimmer-30B \
@@ -1482,7 +1477,7 @@ Options:
 | DeepSeek-V2 / V3 (MLA + MoE) | `deepseek_v2` / `deepseek_v3` / `deepseek_v32` | Yes (SwitchGLU experts) | Tested (V2-Lite: convert + resident + streaming, coherent at 3-bit); V3/V3.2 share the MLA+MoE layout and reuse the config (untested — need ~250 GB disk) |
 | Kimi K3 (KDA linear-attn + gated-NoPE MLA, Stable LatentMoE) | `kimi_k3` | Yes (896 experts, top-16 + 2 shared) | Tested (2.8T: mxfp4 source → 931 GB `tq3a-tqTe-down4-g64`, streams from disk on a 512 GB Mac Studio; does **not** fit resident on any Mac). Custom arch — MLX port shipped here (mlx-lm has no native `kimi_k3`); fp32 forward parity ≤ 2.7e-6 vs transformers. Needs `[kimi]` extra |
 | Sarvam MoE (Megatron-style fused QKV, DeepSeek-V3 routing) | `sarvam_moe` | Yes | Port tested against fp32 (7122/7122 tensors, layer-1 parity 5.4e-7). Custom arch — MLX port shipped here. **No quantized build published**: 4-bit degenerates on long generations (53% of trials; mlx-lm affine 4-bit 100%) |
-| Muse Glimmer (dense VLM: gated attention, sandwich norms, sliding/NoPE mix, ViT-G/14) | `muse_glimmer` | No | Tested (29.8B: `tq4-g64` beats affine 4-bit on PPL — 4.3315 vs 4.3798 — in 25% less space; `tq3-g64` = 12.53 GiB). Structural match verified against the checkpoint, 1436/1436 tensors. Model classes come from the **unmerged** [mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838) — see [Muse Glimmer](#muse-glimmer-30b-dense-vlm) for the pinned install |
+| Muse Glimmer (dense VLM: gated attention, sandwich norms, sliding/NoPE mix, ViT-G/14) | `muse_glimmer` | No | Tested (29.8B: `tq4-g64` beats affine 4-bit on PPL — 4.3315 vs 4.3798 — in 25% less space; `tq3-g64` = 12.53 GiB). Structural match verified against the checkpoint, 1436/1436 tensors. Needs **mlx-vlm >= 0.6.12** ([#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838), merged) — see [Muse Glimmer](#muse-glimmer-30b-dense-vlm) |
 | DiffusionGemma (block-diffusion MoE, via **mlx-vlm**) | `diffusion_gemma` | Yes (128 experts, top-8) | Tested (26B-A4B: convert + block-diffusion sampler, coherent at 3-bit — [HF](https://huggingface.co/manjunathshiva/diffusiongemma-26B-A4B-it-tq3-g32)). **Experimental**: decode is much slower than native 4-bit until a batched codebook gather-GEMM kernel lands |
 
 ### mlx-vlm architectures (multimodal / diffusion)

--- a/generate_vlm.py
+++ b/generate_vlm.py
@@ -43,6 +43,20 @@ def main():
                         help="Cap the diffusion canvas length (model default "
                              "256). Lower = smaller activation memory, useful "
                              "on 16 GB machines (try 128)")
+    parser.add_argument("--reasoning", type=str, default=None,
+                        metavar="LEVEL",
+                        help="Reasoning effort for models whose chat template "
+                             "takes one (Muse Glimmer: low/medium/high/xhigh, "
+                             "default high). Lower spends far fewer tokens "
+                             "thinking before answering — worth a lot on slow "
+                             "machines. Ignored by templates without it.")
+    parser.add_argument("--no-think", action="store_true",
+                        help="Minimise reasoning: shorthand for the lowest "
+                             "effort the template supports, plus "
+                             "`enable_thinking=False` for Qwen-style "
+                             "templates. NOTE this does not guarantee zero "
+                             "reasoning — Muse Glimmer has no 'off' level and "
+                             "may still emit a short thinking channel.")
     args = parser.parse_args()
 
     _require_mlx_vlm()
@@ -56,8 +70,24 @@ def main():
     print(f"[INFO] Loaded in {time.time() - t0:.1f}s")
 
     num_images = 1 if args.image else 0
+
+    # Chat-template knobs for reasoning effort. Templates differ: Qwen-style
+    # ones take `enable_thinking`, Muse Glimmer takes `reasoning_strength`
+    # (low/medium/high/xhigh, defaulting to **high** — which spends hundreds of
+    # tokens deliberating before a short answer, and at a few tok/s that is most
+    # of the wall clock). Unknown keys are ignored by a template that does not
+    # reference them, so passing both is safe.
+    template_kwargs = {}
+    if args.reasoning:
+        template_kwargs["reasoning_strength"] = args.reasoning
+    if args.no_think:
+        template_kwargs.setdefault("reasoning_strength", "low")
+        template_kwargs["enable_thinking"] = False
+    if template_kwargs:
+        print(f"[INFO] chat template: {template_kwargs}")
+
     formatted = apply_chat_template(processor, config, args.prompt,
-                                    num_images=num_images)
+                                    num_images=num_images, **template_kwargs)
     gen_kwargs = {}
     if args.max_denoising_steps is not None:
         gen_kwargs["max_denoising_steps"] = args.max_denoising_steps

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -71,11 +71,23 @@ def _patch_muse_glimmer_normed_embedding() -> None:
     ``load_turboquant_vlm`` reach the embedding through ``nn.quantize``, so
     patching ``to_quantized`` fixes the write and read sides at once.
 
-    Idempotent, and a no-op if mlx-vlm has no muse_glimmer module.
+    Only needed for the pre-merge layout. mlx-vlm 0.6.12 shipped
+    [#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838) with the norm hoisted
+    out of the embedding — ``TextModel`` holds a paramless ``embed_norm`` and
+    applies it in ``__call__``, so a plain ``QuantizedEmbedding`` already keeps
+    the maths right and there is nothing to patch. The on-disk key set is the
+    same either way (``RMSNormNoScale`` has no parameters), so models converted
+    against either layout load against both.
+
+    Idempotent, and a no-op if mlx-vlm has no muse_glimmer module or already
+    applies the norm itself.
     """
     try:
         from mlx_vlm.models.muse_glimmer import language as _mg
     except ImportError:
+        return
+    # >=0.6.12: no NormedEmbedding to patch — the norm lives in TextModel.
+    if not hasattr(_mg, "NormedEmbedding"):
         return
     if getattr(_mg.NormedEmbedding, "_tq_patched", False):
         return

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,16 +41,21 @@ dependencies = [
     "mlx>=0.20.0",
     "mlx-lm>=0.31.3",
     # transformers 5.13 dropped string keys in AutoTokenizer.register, which
-    # mlx-lm <= 0.31.3 still uses (NewlineTokenizer) — import breaks. Lift the
-    # cap once an mlx-lm release is compatible.
-    "transformers<5.13",
+    # mlx-lm <= 0.31.3 still uses (NewlineTokenizer) at module scope — importing
+    # mlx_lm.tokenizer_utils raises AttributeError. 5.14 restored string keys,
+    # so the break is confined to the 5.13 series (verified against mlx-lm
+    # 0.31.3: 5.12 OK, 5.13 FAIL, 5.14 OK, 5.15 OK). A `<5.13` cap would now
+    # force the resolver to downgrade mlx-vlm, which needs >=5.14.
+    "transformers!=5.13.*",
     "numpy",
 ]
 
 [project.optional-dependencies]
 eval = ["datasets", "transformers"]
 dev = ["pytest", "build", "twine"]
-vlm = ["mlx-vlm>=0.6.3"]
+# 0.6.12 is the first release carrying the Muse Glimmer model classes
+# (Blaizzy/mlx-vlm#1838). Below that, `[vlm]` cannot load muse_glimmer.
+vlm = ["mlx-vlm>=0.6.12"]
 # Kimi K3 ships a tiktoken-based tokenizer that needs blobfile to load.
 kimi = ["tiktoken", "blobfile"]
 

--- a/tests/test_muse_glimmer.py
+++ b/tests/test_muse_glimmer.py
@@ -10,6 +10,12 @@ loads and generates fluent-looking garbage rather than raising:
 2. ``embed_tokens`` is a ``NormedEmbedding`` — an ``nn.Embedding`` subclass that
    RMS-normalizes the row it looks up. The inherited ``to_quantized`` returns a
    plain ``QuantizedEmbedding`` and drops the normalization.
+
+Point 2 describes the **pre-merge** mlx-vlm layout. mlx-vlm 0.6.12 released
+Blaizzy/mlx-vlm#1838 with the norm hoisted out of the embedding: ``embed_tokens``
+is a plain ``nn.Embedding`` and ``TextModel`` owns a paramless ``embed_norm``
+that it applies in ``__call__``. Both layouts are supported, so the tests below
+skip the ones that do not apply to the installed build.
 """
 
 import mlx.core as mx
@@ -23,6 +29,25 @@ from turboquant_mlx.integration.rotation_configs import (
 )
 
 _L0 = "language_model.model.layers.0"
+
+
+def _muse_language_module():
+    """The installed build's muse_glimmer language module, or skip."""
+    return pytest.importorskip(
+        "mlx_vlm.models.muse_glimmer.language",
+        reason="mlx-vlm build without muse_glimmer",
+    )
+
+
+def _require_normed_embedding():
+    """Skip on mlx-vlm >= 0.6.12, where there is no NormedEmbedding to patch."""
+    mg_language = _muse_language_module()
+    if not hasattr(mg_language, "NormedEmbedding"):
+        pytest.skip(
+            "mlx-vlm >= 0.6.12 applies the embedding norm in TextModel, so "
+            "there is no NormedEmbedding to patch"
+        )
+    return mg_language
 
 
 def test_rotation_config_registered():
@@ -124,10 +149,7 @@ def test_normed_embedding_keeps_its_norm_when_quantized():
     Without the patch, `nn.quantize` swaps in a plain QuantizedEmbedding and the
     normalization vanishes — no error, just wrong activations everywhere.
     """
-    mg_language = pytest.importorskip(
-        "mlx_vlm.models.muse_glimmer.language",
-        reason="mlx-vlm build without muse_glimmer",
-    )
+    mg_language = _require_normed_embedding()
     from turboquant_mlx.integration.vlm import patch_vlm_arch
 
     patch_vlm_arch("muse_glimmer")
@@ -153,11 +175,7 @@ def test_normed_embedding_keeps_its_norm_when_quantized():
 
 
 def test_normed_embedding_patch_is_idempotent():
-    pytest.importorskip(
-        "mlx_vlm.models.muse_glimmer.language",
-        reason="mlx-vlm build without muse_glimmer",
-    )
-    from mlx_vlm.models.muse_glimmer import language as mg_language
+    mg_language = _require_normed_embedding()
     from turboquant_mlx.integration.vlm import patch_vlm_arch
 
     patch_vlm_arch("muse_glimmer")
@@ -167,11 +185,7 @@ def test_normed_embedding_patch_is_idempotent():
 
 
 def test_quantized_normed_embedding_is_not_a_bare_quantized_embedding():
-    pytest.importorskip(
-        "mlx_vlm.models.muse_glimmer.language",
-        reason="mlx-vlm build without muse_glimmer",
-    )
-    from mlx_vlm.models.muse_glimmer import language as mg_language
+    mg_language = _require_normed_embedding()
     from turboquant_mlx.integration.vlm import patch_vlm_arch
 
     patch_vlm_arch("muse_glimmer")
@@ -182,3 +196,47 @@ def test_quantized_normed_embedding_is_not_a_bare_quantized_embedding():
     assert isinstance(q, nn.QuantizedEmbedding)
     assert type(q) is not nn.QuantizedEmbedding
     assert hasattr(q, "embed_norm")
+
+
+def test_patch_vlm_arch_survives_the_merged_mlx_vlm_layout():
+    """`patch_vlm_arch` must be a no-op, not a crash, on mlx-vlm >= 0.6.12.
+
+    The released #1838 dropped `NormedEmbedding` and applies the norm inside
+    `TextModel.__call__` instead. An earlier version of the patch reached
+    straight for `_mg.NormedEmbedding` and raised AttributeError, which broke
+    BOTH `convert_vlm` and `load_turboquant_vlm` — every Muse Glimmer entry
+    point — the moment a user installed a current mlx-vlm.
+    """
+    mg_language = _muse_language_module()
+    from turboquant_mlx.integration.vlm import patch_vlm_arch
+
+    had = hasattr(mg_language, "NormedEmbedding")
+    saved = getattr(mg_language, "NormedEmbedding", None)
+    if had:  # simulate the merged layout on a pre-merge build
+        delattr(mg_language, "NormedEmbedding")
+    try:
+        patch_vlm_arch("muse_glimmer")  # must not raise
+        patch_vlm_arch("muse_glimmer_text")
+    finally:
+        if had:
+            mg_language.NormedEmbedding = saved
+
+
+def test_merged_layout_applies_the_embedding_norm_outside_the_embedding():
+    """On >= 0.6.12 the norm must live in TextModel, or quantizing drops it.
+
+    This is the invariant that makes the no-op above safe: a plain
+    `QuantizedEmbedding` is only correct because something else normalizes.
+    """
+    mg_language = _muse_language_module()
+    if hasattr(mg_language, "NormedEmbedding"):
+        pytest.skip("pre-merge mlx-vlm: the norm lives inside the embedding")
+
+    import inspect
+
+    src = inspect.getsource(mg_language.TextModel)
+    assert "self.embed_norm" in src
+    assert "self.embed_norm(self.embed_tokens(" in src
+    # and it must be paramless, or it would add on-disk keys our converted
+    # checkpoints do not carry
+    assert mg_language.RMSNormNoScale(1e-6).parameters() == {}


### PR DESCRIPTION
Two Muse-Glimmer-scoped changes that belong together, since both are about making the model usable from a plain install.

## 1. `--reasoning` / `--no-think` for `generate_vlm`

Muse Glimmer's chat template defaults to `reasoning_strength: high`. On the 16 GB mini at ~3.5 tok/s, that deliberation is most of the wall clock before a short answer appears.

- `--reasoning low|medium|high|xhigh` sets it directly
- `--no-think` asks for the least reasoning the template supports, and also passes `enable_thinking=False` for Qwen-style templates

Templates that don't reference these keys ignore them. Muse Glimmer has no "off" level, so `--no-think` reduces but does not eliminate the thinking channel — the help text says so rather than implying otherwise.

## 2. mlx-vlm 0.6.12 compatibility — this one was a live break

[#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838) merged 2026-08-10 and shipped in mlx-vlm **0.6.12**. The released code differs from the PR head this support was written against:

| | pre-merge (pinned PR head) | released 0.6.12 |
|---|---|---|
| `embed_tokens` | `NormedEmbedding` (norm inside) | plain `nn.Embedding` |
| the norm | inside the embedding | `TextModel.embed_norm`, applied in `__call__` |

`patch_vlm_arch` reached straight for `_mg.NormedEmbedding` and raised `AttributeError` — taking down **both** `convert_vlm` and `load_turboquant_vlm`, i.e. every Muse Glimmer entry point, for anyone on a current mlx-vlm.

It is now a no-op on the merged layout, where a plain `QuantizedEmbedding` is already correct because the norm is applied outside it.

**Checkpoints are unaffected in both directions.** `RMSNormNoScale` has no parameters, so neither layout contributes an `embed_norm` key; models converted against either one load against both. Verified end-to-end by generating with the published `tq4-g64` build on mlx-vlm 0.6.12 — coherent output, 11.7 tok/s.

## 3. The install collapses to one line

```bash
pip install "turboquant-mlx-full[vlm]"
```

- `[vlm]` now requires `mlx-vlm>=0.6.12` (first release carrying the model classes)
- `transformers<5.13` becomes `transformers!=5.13.*`

The cap mattered: mlx-vlm 0.6.12 requires `transformers>=5.14`, so a resolver honouring `<5.13` would **silently downgrade mlx-vlm** to a build with no `muse_glimmer` — the same failure mode that broke the documented install order in 0.20.1. The breakage is confined to the 5.13 series, verified against mlx-lm 0.31.3:

| transformers | `import mlx_lm.tokenizer_utils` |
|---|---|
| 5.12.0 | OK |
| 5.13.0 | **FAIL** — `'str' object has no attribute '__module__'` |
| 5.14.0 | OK |
| 5.15.0 | OK |

## Testing

- Full suite: **485 passed, 3 skipped**
- `test_muse_glimmer.py` on **both** layouts: 13p/5s on mlx-vlm 0.6.3, 15p/3s on 0.6.12
- Two new tests: `patch_vlm_arch` must not raise on the merged layout, and the merged layout must apply the norm in `TextModel` with a paramless `RMSNormNoScale` (the invariant that makes the no-op safe)
- Clean-venv verified: `pip install "<wheel>[vlm]"` resolves mlx-vlm 0.6.12 + transformers 5.15.0 in one step, and `muse_glimmer` imports

No version bump here — the release PR gets cut fresh off `main` after this merges.