### PR TITLE
feat(serve): turboquant-serve-vlm — serve multimodal TurboQuant models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,51 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`turboquant-serve-vlm`: an OpenAI-compatible server for multimodal
+  TurboQuant models.** `turboquant-serve` wraps `mlx_lm.server`, which has no
+  notion of VLM architectures, so Muse Glimmer and DiffusionGemma could not be
+  served at all. Rather than reimplement a server, this drives *mlx-vlm's* —
+  OpenAI and Anthropic routes, per-model tool parsers, continuous batching — and
+  teaches it the three things it cannot infer about a polar checkpoint:
+
+  1. **How to load it.** mlx-vlm's server reaches the model through exactly one
+     seam (`mlx_vlm.server.generation.load`), so binding that name to a
+     TurboQuant-aware wrapper covers the whole stack. Non-TurboQuant models keep
+     mlx-vlm's own loader, so one server can still serve either.
+  2. **Where the reasoning channel ends** (see Fixed).
+  3. **What the reasoning knob is called** (see Fixed).
+
+  Verified end-to-end on `Muse-Glimmer-30B-tq4-g64`: tool calls return
+  `finish_reason: tool_calls` with correct name and arguments, tool-result round
+  trips answer correctly, and the streaming path emits no protocol markup.
+
+### Fixed
+
+- **Muse Glimmer leaked its entire reasoning channel into `message.content`.**
+  It answers in a harmony-style channel format
+  (`to=self<|message|>…<|eom|><|start|>assistant to=user<|message|>…`), and
+  mlx-vlm's ATEM parser only strips that envelope when a tool call was parsed —
+  so tool turns looked fine while ordinary turns handed the caller the model's
+  private deliberation as its reply, with `reasoning_content` left `None`. An
+  agent harness would ingest it as the answer.
+
+  mlx-vlm's generic thinking splitter handles this correctly once pointed at the
+  right delimiters, so `turboquant-serve-vlm` supplies them per architecture.
+  The span deliberately ends at the routing header rather than at `<|eom|>`, so
+  content starts at the first real answer token instead of carrying
+  `<|start|>assistant to=user<|message|>` on every reply. An explicit
+  `--thinking-start-token`/`--thinking-end-token` always wins.
+
+- **`reasoning_effort` was a silent no-op on Muse Glimmer.** The server passes
+  OpenAI's `reasoning_effort` to the chat template; Muse Glimmer's template only
+  reads `reasoning_strength` (`reasoning_effort` and `enable_thinking` appear
+  zero times in it), so the request was dropped without a warning and the model
+  always deliberated at its `high` default. Requests are now translated
+  (`minimal`/`none` → `low`, since Muse has no "off" level), and
+  `--reasoning-strength` sets the default for clients that ask for nothing —
+  which is most agent harnesses. Measured on `tq4-g64`: a tool-result turn cost
+  **54 completion tokens at `low` versus 106 at `high`**, same answer.
+
 - **`--reasoning LEVEL` and `--no-think` for `generate_vlm`.** Muse Glimmer's
   chat template defaults to `reasoning_strength: high`, which spends hundreds of
   tokens deliberating before a short answer — on a 16 GB mini at ~3.5 tok/s that

--- a/README.md
+++ b/README.md
@@ -377,6 +377,34 @@ for chunk in resp:
 All `mlx_lm.server` flags forward unchanged — see `turboquant-serve --help`
 for `--host`, `--temp`, `--top-p`, `--prompt-cache-size`, etc.
 
+#### Serve a multimodal model (`turboquant-serve-vlm`)
+
+`turboquant-serve` wraps `mlx_lm.server`, which knows nothing about multimodal
+architectures. For a VLM — Muse Glimmer, DiffusionGemma — use
+**`turboquant-serve-vlm`**, which drives *mlx-vlm's* server instead (OpenAI
+**and** Anthropic routes, per-model tool parsers, continuous batching):
+
+```bash
+turboquant-serve-vlm \
+    --model manjunathshiva/Muse-Glimmer-30B-tq4-g64 \
+    --reasoning-strength low --port 8080
+```
+
+All `mlx_vlm.server` flags forward unchanged. Two things are handled for you:
+
+- **The reasoning channel is split out of `content`.** Muse Glimmer answers in a
+  harmony-style channel format, and mlx-vlm's ATEM parser only strips that
+  envelope when a tool call was parsed — so an ordinary turn would hand your
+  agent the model's private deliberation as its reply. The right delimiters are
+  supplied per architecture; the thinking lands in `reasoning_content` where it
+  belongs. An explicit `--thinking-start-token`/`--thinking-end-token` still wins.
+- **`--reasoning-strength` actually reaches the template.** OpenAI clients send
+  `reasoning_effort`, but Muse Glimmer's template reads `reasoning_strength` and
+  otherwise deliberates at its `high` default. Requests are translated, and this
+  flag sets the default for clients that ask for nothing — which is most agent
+  harnesses. Measured on `tq4-g64`: a tool-result turn cost **54 completion
+  tokens at `low` versus 106 at the default `high`**, for the same answer.
+
 #### Serve a model bigger than RAM (expert streaming)
 
 Passing `--cache-budget-gb` routes the loader through the streaming path, so a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ Issues = "https://github.com/manjunathshiva/turboquant-mlx/issues"
 turboquant-convert = "turboquant_mlx.convert:main"
 turboquant-generate = "turboquant_mlx.generate:main"
 turboquant-serve = "turboquant_mlx.serve:main"
+turboquant-serve-vlm = "turboquant_mlx.serve_vlm:main"
 turboquant-plan = "turboquant_mlx.plan:main"
 turboquant-doctor = "turboquant_mlx.plan:doctor_main"
 

--- a/serve_vlm.py
+++ b/serve_vlm.py
@@ -1,0 +1,251 @@
+"""OpenAI-compatible server for TurboQuant-compressed mlx-vlm models.
+
+``turboquant-serve`` wraps ``mlx_lm.server``, which knows nothing about
+multimodal architectures. mlx-vlm ships its own, considerably richer server
+(OpenAI *and* Anthropic routes, per-model tool parsers, continuous batching,
+speculative decoding), so this module drives that one instead of reimplementing
+it — it only teaches it the three things it cannot know about a TurboQuant VLM:
+
+1. **How to load the checkpoint.** mlx-vlm's server reaches the model through
+   exactly one seam: ``mlx_vlm.server.generation.load_model_resources`` calls
+   ``load(...)``, which ``generation`` imported into its own namespace. Binding
+   that name to a TurboQuant-aware wrapper is enough for the whole stack.
+
+2. **Where the reasoning channel ends.** Muse Glimmer answers in a harmony-style
+   channel format, and mlx-vlm's ATEM parser only strips that envelope when a
+   tool call was parsed — so ordinary turns leak the entire thinking channel
+   into ``message.content``. mlx-vlm's generic thinking splitter handles it
+   correctly once pointed at the right delimiters, so we supply them.
+
+3. **What the reasoning knob is called.** The server sends OpenAI's
+   ``reasoning_effort``; Muse Glimmer's chat template only reads
+   ``reasoning_strength`` and otherwise deliberates at its ``high`` default.
+
+Usage:
+    turboquant-serve-vlm --model <tq-dir-or-repo> --port 8080
+    turboquant-serve-vlm --model <tq-dir> --reasoning-strength low
+
+Requires:  pip install "turboquant-mlx-full[vlm]"
+"""
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger("turboquant.serve_vlm")
+
+# Per-architecture (thinking_start, thinking_end) delimiters.
+#
+# Muse Glimmer emits:
+#     to=self<|message|> …reasoning… <|eom|><|start|>assistant to=user<|message|> …answer…
+#
+# Ending the span at the *routing header* rather than at `<|eom|>` is deliberate:
+# it consumes the `<|start|>assistant to=user<|message|>` preamble too, so
+# content begins at the first real answer token. Stopping at `<|eom|>` would
+# leave that header at the front of every reply.
+CHANNEL_DELIMITERS: Dict[str, Tuple[str, str]] = {
+    "muse_glimmer": ("to=self<|message|>", "<|start|>assistant to=user<|message|>"),
+    "muse_glimmer_text": (
+        "to=self<|message|>",
+        "<|start|>assistant to=user<|message|>",
+    ),
+}
+
+# OpenAI's reasoning_effort vocabulary -> Muse Glimmer's reasoning_strength.
+# Muse has no "off" level, so the floor is "low"; anything already valid for the
+# template passes through untouched.
+_EFFORT_TO_STRENGTH = {
+    "none": "low",
+    "minimal": "low",
+    "low": "low",
+    "medium": "medium",
+    "high": "high",
+    "xhigh": "xhigh",
+}
+
+
+def map_reasoning_effort(effort: Optional[str]) -> Optional[str]:
+    """Translate an OpenAI reasoning_effort into a reasoning_strength."""
+    if not effort:
+        return None
+    return _EFFORT_TO_STRENGTH.get(str(effort).lower(), str(effort).lower())
+
+
+def _read_json(path: Path) -> dict:
+    try:
+        return json.loads(path.read_text())
+    except (OSError, ValueError):
+        return {}
+
+
+def is_turboquant_checkpoint(model_path) -> bool:
+    """True if `model_path` is a TurboQuant (polar) checkpoint directory."""
+    config = _read_json(Path(model_path) / "config.json")
+    return (config.get("quantization") or {}).get("mode") == "turboquant"
+
+
+def model_architecture(model_path) -> Optional[str]:
+    return _read_json(Path(model_path) / "config.json").get("model_type")
+
+
+def chat_template_text(model_path) -> str:
+    """The model's chat template, from either place it may be stored."""
+    model_path = Path(model_path)
+    jinja = model_path / "chat_template.jinja"
+    if jinja.exists():
+        try:
+            return jinja.read_text()
+        except OSError:
+            return ""
+    template = _read_json(model_path / "tokenizer_config.json").get("chat_template")
+    return template if isinstance(template, str) else ""
+
+
+def install_turboquant_loader() -> None:
+    """Teach mlx-vlm's server to load TurboQuant checkpoints.
+
+    Idempotent. Non-TurboQuant models keep taking mlx-vlm's own loader, so one
+    server can still serve an ordinary mlx-vlm model.
+    """
+    import mlx_vlm.server.generation as generation
+
+    if getattr(generation.load, "_turboquant_wrapper", False):
+        return
+
+    original_load = generation.load
+
+    def load(model_path, adapter_path=None, **kwargs):
+        from turboquant_mlx.generate import resolve_model_path
+        from turboquant_mlx.integration.vlm import load_turboquant_vlm
+
+        resolved = resolve_model_path(str(model_path))
+        if is_turboquant_checkpoint(resolved):
+            logger.info("loading TurboQuant checkpoint: %s", resolved)
+            model, processor, _config = load_turboquant_vlm(resolved)
+            return model, processor
+        return original_load(model_path, adapter_path, **kwargs)
+
+    load._turboquant_wrapper = True
+    generation.load = load
+
+
+def install_reasoning_strength_mapping(default_strength: Optional[str] = None) -> None:
+    """Feed the chat template `reasoning_strength` instead of `reasoning_effort`.
+
+    Only the name differs, so a request that already says
+    ``reasoning_effort: "low"`` starts working rather than being silently
+    dropped. `default_strength` applies when a request says nothing at all —
+    which is the common case for agent harnesses, and the difference between a
+    short answer and several hundred tokens of deliberation first.
+    """
+    from mlx_vlm.server.generation import GenerationArguments
+
+    original = GenerationArguments.to_template_kwargs
+    if getattr(original, "_turboquant_wrapper", False):
+        return
+
+    def to_template_kwargs(self):
+        kwargs = original(self)
+        strength = map_reasoning_effort(kwargs.get("reasoning_effort"))
+        if strength is None:
+            strength = default_strength
+        if strength is not None:
+            kwargs["reasoning_strength"] = strength
+        return kwargs
+
+    to_template_kwargs._turboquant_wrapper = True
+    GenerationArguments.to_template_kwargs = to_template_kwargs
+
+
+def channel_delimiters_for(model_path) -> Optional[Tuple[str, str]]:
+    """The thinking delimiters this model needs, if we know of any."""
+    return CHANNEL_DELIMITERS.get(model_architecture(model_path) or "")
+
+
+def _extract_option(argv, name: str) -> Optional[str]:
+    """Read `--name value` or `--name=value` out of an argv list."""
+    for i, arg in enumerate(argv):
+        if arg == name and i + 1 < len(argv):
+            return argv[i + 1]
+        if arg.startswith(name + "="):
+            return arg.split("=", 1)[1]
+    return None
+
+
+def _has_option(argv, name: str) -> bool:
+    return any(a == name or a.startswith(name + "=") for a in argv)
+
+
+def build_server_argv(argv, model_path) -> list:
+    """Add the channel delimiters this architecture needs, if not already set.
+
+    An explicit `--thinking-start-token` / `--thinking-end-token` always wins.
+    """
+    delimiters = channel_delimiters_for(model_path) if model_path else None
+    if delimiters is None:
+        return argv
+    if _has_option(argv, "--thinking-start-token") or _has_option(
+        argv, "--thinking-end-token"
+    ):
+        return argv
+
+    start, end = delimiters
+    logger.info(
+        "%s: splitting the reasoning channel on %r -> %r",
+        model_architecture(model_path),
+        start,
+        end,
+    )
+    return argv + ["--thinking-start-token", start, "--thinking-end-token", end]
+
+
+def main(argv=None):
+    argv = list(sys.argv[1:] if argv is None else argv)
+
+    parser = argparse.ArgumentParser(add_help=False)
+    parser.add_argument(
+        "--reasoning-strength",
+        type=str,
+        default=None,
+        help="Default reasoning effort for models whose template takes one "
+        "(Muse Glimmer: low/medium/high/xhigh, default high). Applies when a "
+        "request does not ask for one. Every other flag is mlx-vlm's; see "
+        "`python -m mlx_vlm.server --help`.",
+    )
+    args, server_argv = parser.parse_known_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
+
+    install_turboquant_loader()
+
+    model_path = _extract_option(server_argv, "--model")
+    resolved = None
+    if model_path:
+        try:
+            from turboquant_mlx.generate import resolve_model_path
+
+            resolved = resolve_model_path(model_path)
+        except Exception:  # a repo id we cannot resolve offline, or a typo
+            resolved = model_path
+
+    default_strength = args.reasoning_strength
+    if resolved and (
+        default_strength is not None
+        or "reasoning_strength" in chat_template_text(resolved)
+    ):
+        install_reasoning_strength_mapping(default_strength)
+
+    if resolved:
+        server_argv = build_server_argv(server_argv, resolved)
+
+    from mlx_vlm.server.cli import main as server_main
+
+    sys.argv = [sys.argv[0]] + server_argv
+    return server_main()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_serve_vlm.py
+++ b/tests/test_serve_vlm.py
@@ -1,0 +1,169 @@
+"""Serving TurboQuant VLMs through mlx-vlm's server.
+
+Three things go silently wrong without this module, and none of them raise:
+
+1. mlx-vlm's server cannot load a polar checkpoint at all.
+2. Muse Glimmer's reasoning channel lands in `message.content`, because
+   mlx-vlm's ATEM parser only strips the envelope when a tool call was parsed.
+   An agent harness then reads the model's private deliberation as its answer.
+3. `reasoning_effort` never reaches the template, which reads
+   `reasoning_strength` — so the model always deliberates at `high`.
+"""
+
+import json
+
+import pytest
+
+from turboquant_mlx.serve_vlm import (
+    CHANNEL_DELIMITERS,
+    build_server_argv,
+    channel_delimiters_for,
+    chat_template_text,
+    is_turboquant_checkpoint,
+    map_reasoning_effort,
+    model_architecture,
+)
+
+
+def _write_model(tmp_path, config=None, template=None, template_in_config=False):
+    (tmp_path / "config.json").write_text(json.dumps(config or {}))
+    if template is not None:
+        if template_in_config:
+            (tmp_path / "tokenizer_config.json").write_text(
+                json.dumps({"chat_template": template})
+            )
+        else:
+            (tmp_path / "chat_template.jinja").write_text(template)
+    return tmp_path
+
+
+class TestCheckpointDetection:
+    def test_turboquant_checkpoint_is_detected(self, tmp_path):
+        _write_model(tmp_path, {"quantization": {"mode": "turboquant"}})
+        assert is_turboquant_checkpoint(tmp_path) is True
+
+    def test_affine_mlx_checkpoint_is_not_hijacked(self, tmp_path):
+        """An ordinary mlx-vlm model must keep mlx-vlm's own loader."""
+        _write_model(tmp_path, {"quantization": {"group_size": 64, "bits": 4}})
+        assert is_turboquant_checkpoint(tmp_path) is False
+
+    def test_unquantized_model_is_not_a_turboquant_checkpoint(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "muse_glimmer"})
+        assert is_turboquant_checkpoint(tmp_path) is False
+
+    def test_missing_or_unreadable_config_is_false_not_an_exception(self, tmp_path):
+        assert is_turboquant_checkpoint(tmp_path) is False
+        (tmp_path / "config.json").write_text("{not json")
+        assert is_turboquant_checkpoint(tmp_path) is False
+
+
+class TestReasoningEffortMapping:
+    @pytest.mark.parametrize(
+        "effort,expected",
+        [
+            ("low", "low"),
+            ("medium", "medium"),
+            ("high", "high"),
+            ("xhigh", "xhigh"),
+            ("HIGH", "high"),
+            # Muse has no "off" level; the floor is "low".
+            ("minimal", "low"),
+            ("none", "low"),
+        ],
+    )
+    def test_openai_vocabulary_maps_onto_muse_levels(self, effort, expected):
+        assert map_reasoning_effort(effort) == expected
+
+    def test_absent_effort_stays_absent(self):
+        assert map_reasoning_effort(None) is None
+        assert map_reasoning_effort("") is None
+
+    def test_unknown_value_passes_through_rather_than_being_dropped(self):
+        """Better to hand the template something it may know than nothing."""
+        assert map_reasoning_effort("ludicrous") == "ludicrous"
+
+
+class TestChannelDelimiters:
+    def test_muse_glimmer_gets_delimiters(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "muse_glimmer"})
+        assert channel_delimiters_for(tmp_path) == CHANNEL_DELIMITERS["muse_glimmer"]
+
+    def test_the_span_ends_at_the_routing_header_not_at_eom(self):
+        """Ending at `<|eom|>` would leave the routing header on every reply.
+
+        Muse emits `…<|eom|><|start|>assistant to=user<|message|>answer`, so the
+        end delimiter has to swallow the header for content to start at the
+        first real answer token.
+        """
+        start, end = CHANNEL_DELIMITERS["muse_glimmer"]
+        assert start == "to=self<|message|>"
+        assert end == "<|start|>assistant to=user<|message|>"
+        assert end != "<|eom|>"
+
+    def test_delimiters_split_a_real_generation(self):
+        """Replays the exact shape measured from the served model."""
+        start, end = CHANNEL_DELIMITERS["muse_glimmer"]
+        raw = (
+            " to=self<|message|>We have tool output: temp_c 17.\n\nJust respond."
+            "<|eom|><|start|>assistant to=user<|message|>"
+            "Paris is currently 17°C with light rain."
+        )
+        assert start in raw and end in raw
+        reasoning, _, content = raw.partition(end)
+        assert content == "Paris is currently 17°C with light rain."
+        assert "to=user" not in content
+        assert "<|message|>" not in content
+        assert "We have tool output" in reasoning
+
+    def test_unknown_architecture_gets_nothing(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "qwen3_vl"})
+        assert channel_delimiters_for(tmp_path) is None
+
+    def test_architecture_is_read_from_config(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "muse_glimmer"})
+        assert model_architecture(tmp_path) == "muse_glimmer"
+
+
+class TestServerArgv:
+    def test_delimiters_are_injected_for_muse_glimmer(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "muse_glimmer"})
+        argv = build_server_argv(["--model", str(tmp_path)], tmp_path)
+        start, end = CHANNEL_DELIMITERS["muse_glimmer"]
+        assert argv[-4:] == [
+            "--thinking-start-token",
+            start,
+            "--thinking-end-token",
+            end,
+        ]
+
+    def test_an_explicit_delimiter_is_never_overridden(self, tmp_path):
+        """The user asked for something specific; do not argue."""
+        _write_model(tmp_path, {"model_type": "muse_glimmer"})
+        argv = ["--model", str(tmp_path), "--thinking-start-token", "<think>"]
+        assert build_server_argv(argv, tmp_path) == argv
+
+    def test_an_explicit_end_delimiter_alone_also_wins(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "muse_glimmer"})
+        argv = ["--model", str(tmp_path), "--thinking-end-token=</think>"]
+        assert build_server_argv(argv, tmp_path) == argv
+
+    def test_other_architectures_are_left_alone(self, tmp_path):
+        _write_model(tmp_path, {"model_type": "qwen3_vl"})
+        argv = ["--model", str(tmp_path)]
+        assert build_server_argv(argv, tmp_path) == argv
+
+
+class TestChatTemplateDiscovery:
+    def test_template_read_from_jinja_file(self, tmp_path):
+        _write_model(tmp_path, {}, template="{{ reasoning_strength }}")
+        assert "reasoning_strength" in chat_template_text(tmp_path)
+
+    def test_template_read_from_tokenizer_config(self, tmp_path):
+        _write_model(
+            tmp_path, {}, template="{{ reasoning_strength }}", template_in_config=True
+        )
+        assert "reasoning_strength" in chat_template_text(tmp_path)
+
+    def test_missing_template_is_empty_not_an_error(self, tmp_path):
+        _write_model(tmp_path, {})
+        assert chat_template_text(tmp_path) == ""


### PR DESCRIPTION
Closes the last three blockers between a TurboQuant VLM and an agent harness. All measured on `Muse-Glimmer-30B-tq4-g64`.

## Why a new entry point

`turboquant-serve` wraps `mlx_lm.server`, which has no notion of multimodal architectures — Muse Glimmer and DiffusionGemma could not be served at all.

Rather than reimplement a server, this drives **mlx-vlm's**, which is far richer than anything worth rebuilding (OpenAI *and* Anthropic routes, 13 per-model tool parsers, continuous batching, speculative decoding). It only teaches it the three things it cannot infer about a polar checkpoint.

## 1. How to load it

mlx-vlm's server reaches the model through exactly one seam — `mlx_vlm.server.generation.load_model_resources` calls `load(...)`, which `generation` imported into its own namespace. Binding that name to a TurboQuant-aware wrapper covers the whole stack.

Non-TurboQuant models keep mlx-vlm's own loader, so one server can still serve either kind.

## 2. Where the reasoning channel ends

**This one was silently corrupting every non-tool turn.** Muse Glimmer answers in a harmony-style channel format:

```
to=self<|message|>…reasoning…<|eom|><|start|>assistant to=user<|message|>…answer…
```

mlx-vlm's ATEM parser declares `tool_call_start = "to=self<|message|>"` / `tool_call_end = "</atem:function_calls>"`, and the server strips that span **only when a tool call was parsed**. So tool turns looked fine while ordinary turns handed the caller this as `message.content`, with `reasoning_content` left `None`:

> `to=self<|message|>We have tool output... <|eom|><|start|>assistant to=user<|message|>Paris is currently 17°`

An agent harness ingests the model's private deliberation as its reply — and the answer is truncated, because thinking ate the token budget.

mlx-vlm's generic `ThinkingStreamState` handles this correctly once pointed at the right delimiters, so we supply them per architecture. **The span deliberately ends at the routing header rather than at `<|eom|>`** — otherwise every reply starts with `<|start|>assistant to=user<|message|>`. An explicit `--thinking-start-token`/`--thinking-end-token` always wins.

After:

| | before | after |
|---|---|---|
| `content` | whole channel transcript | `Paris is currently 17°C with light rain.` |
| `reasoning_content` | `None` | the deliberation |

Streaming was checked separately — deltas contain none of `to=self`, `to=user`, `<\|message\|>`, `<\|start\|>`, `<\|eom\|>`.

## 3. What the reasoning knob is called

The server passes OpenAI's `reasoning_effort` to the chat template. Muse Glimmer's template only reads **`reasoning_strength`** — `reasoning_effort` and `enable_thinking` appear **zero** times in its 7167 characters. So the request was dropped without a warning and the model always deliberated at its `high` default.

Requests are now translated (`minimal`/`none` → `low`, since Muse has no "off" level), and `--reasoning-strength` sets the default for clients that ask for nothing — which is most agent harnesses.

Measured, same answer, same prompt:

| reasoning | completion tokens |
|---|---|
| default (`high`) | 106 |
| `low` | **54** |

## Testing

- Full suite: **510 passed, 5 skipped**
- 25 new tests in `tests/test_serve_vlm.py`, including that the delimiter span ends at the routing header and not at `<|eom|>`, that an explicit delimiter is never overridden, and that an affine mlx-vlm checkpoint is not hijacked by the TurboQuant loader
- End-to-end against the real model: tool call → `finish_reason: tool_calls` with correct name/args; tool-result round trip → correct answer; streaming → no markup leak

## Notes

Items 2 and 3 are arguably upstream bugs in mlx-vlm (the ATEM parser only handles the tool path, and nothing maps `reasoning_effort` for templates that use another name). Both fixes here are configuration of mlx-vlm's own generic machinery rather than forks of it, so they should keep working — and can be dropped if upstream adopts them.