### PR TITLE
chore: release 0.21.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.21.0] - 2026-08-11
+
+Muse Glimmer becomes usable from a plain `pip install`, and serveable to an
+agent. [Blaizzy/mlx-vlm#1838](https://github.com/Blaizzy/mlx-vlm/pull/1838)
+merged the day after the port shipped, which collapsed the install to one line —
+and, because the released code differs from the PR head the port was written
+against, broke every Muse Glimmer entry point until fixed here.
+
 ### Added
 
 - **`turboquant-serve-vlm`: an OpenAI-compatible server for multimodal

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.20.1"
+__version__ = "0.21.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.20.1"
+version = "0.21.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Cut fresh off `main` after #80 and #81 landed.

## Version
`0.20.1` → **`0.21.0`** in `pyproject.toml` and `__init__.py`; `[Unreleased]` moved to `[0.21.0] - 2026-08-11`.

Minor rather than patch: a new console script, new CLI flags, and raised dependency floors.

## What's in it

**Added**
- `turboquant-serve-vlm` — OpenAI + Anthropic compatible server for multimodal TurboQuant models (#81)
- `--reasoning LEVEL` / `--no-think` for `generate_vlm` (#80)

**Changed**
- Muse Glimmer installs with a plain `pip install "turboquant-mlx-full[vlm]"` — mlx-vlm#1838 merged and shipped in 0.6.12, so the git pin is gone
- `transformers<5.13` → `transformers!=5.13.*`; `[vlm]` now needs `mlx-vlm>=0.6.12`

**Fixed**
- `patch_vlm_arch` crashed on mlx-vlm >= 0.6.12, taking down every Muse Glimmer entry point
- Muse Glimmer leaked its whole reasoning channel into `message.content` on non-tool turns
- `reasoning_effort` was silently dropped, so the model always deliberated at `high`

## Verification

- Full suite: **510 passed, 5 skipped**
- Built sdist + wheel at 0.21.0
- **Clean-venv install of the built wheel with `[vlm]`**:

| | |
|---|---|
| turboquant_mlx | 0.21.0 |
| mlx_vlm | 0.6.12 |
| transformers | 5.15.0 |
| `muse_glimmer` import | OK |
| `turboquant_mlx.serve_vlm` | OK |

All six console scripts present: `turboquant-convert`, `-doctor`, `-generate`, `-plan`, `-serve`, `-serve-vlm`.

After merge: tag `v0.21.0` → `release.yml` → GitHub Release + PyPI (needs the manual `pypi` environment approval), then a clean-venv check against PyPI itself.