### PR TITLE
fix(serve_vlm): document --reasoning-strength in --help

### DIFF
--- a/serve_vlm.py
+++ b/serve_vlm.py
@@ -217,6 +217,25 @@ def main(argv=None):
     )
     args, server_argv = parser.parse_known_args(argv)
 
+    # `--help` falls through to mlx-vlm's parser, which owns every other flag
+    # and exits. Print ours first, or a documented flag looks nonexistent.
+    if any(a in ("-h", "--help") for a in server_argv):
+        print(
+            "turboquant-serve-vlm: mlx-vlm's server, taught to load TurboQuant "
+            "checkpoints.\n\nAdded by turboquant-mlx:\n"
+            "  --reasoning-strength LEVEL\n"
+            "                        Default reasoning effort for models whose "
+            "chat template\n"
+            "                        takes one (Muse Glimmer: "
+            "low/medium/high/xhigh, default\n"
+            "                        high). Used when a request does not ask "
+            "for one.\n\n"
+            "Muse Glimmer also gets its reasoning channel split out of "
+            "`content`\nautomatically; pass --thinking-start-token / "
+            "--thinking-end-token to override.\n\n"
+            "Everything below is mlx-vlm's own:\n"
+        )
+
     logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 
     install_turboquant_loader()

--- a/tests/test_serve_vlm.py
+++ b/tests/test_serve_vlm.py
@@ -11,6 +11,7 @@ Three things go silently wrong without this module, and none of them raise:
 """
 
 import json
+import sys
 
 import pytest
 
@@ -151,6 +152,35 @@ class TestServerArgv:
         _write_model(tmp_path, {"model_type": "qwen3_vl"})
         argv = ["--model", str(tmp_path)]
         assert build_server_argv(argv, tmp_path) == argv
+
+
+class TestHelp:
+    def test_help_documents_our_own_flag(self, capsys, monkeypatch):
+        """`--help` is handled by mlx-vlm's parser, which never sees our flag.
+
+        Without this, `--reasoning-strength` is documented on the model cards
+        but absent from `--help`, which reads as "the flag does not exist".
+        """
+        import turboquant_mlx.serve_vlm as serve_vlm
+
+        monkeypatch.setattr(serve_vlm, "install_turboquant_loader", lambda: None)
+
+        def fake_server_main():
+            raise SystemExit(0)
+
+        import types
+
+        fake_cli = types.ModuleType("mlx_vlm.server.cli")
+        fake_cli.main = fake_server_main
+        monkeypatch.setitem(sys.modules, "mlx_vlm.server.cli", fake_cli)
+
+        with pytest.raises(SystemExit):
+            serve_vlm.main(["--help"])
+
+        out = capsys.readouterr().out
+        assert "--reasoning-strength" in out
+        # and it must not swallow mlx-vlm's own help
+        assert "mlx-vlm" in out
 
 
 class TestChatTemplateDiscovery:


### PR DESCRIPTION
Caught while verifying that the commands on the updated model cards work verbatim.

`turboquant-serve-vlm --help` falls through to mlx-vlm's parser — which owns every other flag and exits — so our own `--reasoning-strength` never appeared. The flag **works**; it was just invisible.

That matters now because the [tq4](https://huggingface.co/manjunathshiva/Muse-Glimmer-30B-tq4-g64) and [tq3](https://huggingface.co/manjunathshiva/Muse-Glimmer-30B-tq3-g64) model cards document it. A user checking `--help` would reasonably conclude the flag doesn't exist.

Now prints our flags first, then lets mlx-vlm print its own — both are visible.

New test asserts `--reasoning-strength` appears in `--help` output *and* that we don't swallow mlx-vlm's help.

**511 passed, 5 skipped.**

Not urgent to release on its own — happy to fold it into the next version alongside the OpenCode results.