### PR TITLE
fix(serve_vlm): stop the reasoning channel suppressing the answer (0.21.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.21.1] - 2026-08-11
+
+Two `turboquant-serve-vlm` fixes found by using it: an agent harness never
+received the assistant's final message, and a documented flag was missing from
+`--help`.
+
+### Fixed
+
+- **Muse Glimmer returned an empty final message to any tools-enabled client.**
+  While streaming, mlx-vlm suppresses content deltas from the moment the tool
+  parser's `tool_call_start` appears in the output, and `in_tool_call` has no
+  release path — once latched, it stays latched for the rest of the generation.
+  ATEM's `tool_call_start` is `to=self<|message|>`, which is exactly the channel
+  router Muse Glimmer emits at the start of *every* turn, tool call or not. So
+  the latch closed on the first reasoning token of every request that declared
+  tools, and nothing the model said afterwards reached the client.
+
+  The asymmetry made it look like a model problem: a plain `curl` with no tools
+  answered correctly, tool calls kept working (those are parsed from the full
+  output, not the stream), and only prose went missing. In OpenCode the model
+  would find and fix the bug, run the tests green, and then say nothing.
+
+  `turboquant-serve-vlm` now maps that trigger to `<atem:function_calls>`, the
+  tag that genuinely opens a call — and the same string mlx-vlm uses to detect
+  the ATEM format in the first place. Tool-call *parsing* is untouched, since
+  `process_tool_calls` reads the marker from the parser itself. Parsers whose
+  `tool_call_start` is not a known collision pass through unchanged.
+
+- **`--reasoning-strength` was missing from `--help`.** `--help` falls through
+  to mlx-vlm's parser, which owns every other flag and exits before ours is
+  mentioned, so a flag the model cards document looked nonexistent.
+
 ## [0.21.0] - 2026-08-11
 
 Muse Glimmer becomes usable from a plain `pip install`, and serveable to an

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.21.0"
+__version__ = "0.21.1"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/docs/RESULTS_MUSE.md
+++ b/docs/RESULTS_MUSE.md
@@ -1,0 +1,195 @@
+# Muse-Glimmer-30B: agentic + vision validation (tq4 vs tq3)
+
+Date: 2026-08-11 · Machine: 64 GB M4 Max · Engine: turboquant-mlx 0.21.0, re-verified on 0.21.1
+Client: opencode 1.17.13 · Server: `turboquant-serve-vlm` (mlx-vlm 0.6.12)
+
+First agentic validation of a **dense** TurboQuant model, and of
+`turboquant-serve-vlm`. Both builds pass 3/3, and quantizing the vision tower
+costs nothing measurable against the build that leaves it in bf16.
+
+## 1. Agentic coding — OpenCode, n=3 per build
+
+```bash
+turboquant-serve-vlm --model <path> --port 8080 --reasoning-strength low
+```
+
+- Task: identical to the 35B runs (`setup_task_repo.sh`) — planted
+  `len(values) + 1` off-by-one in `average()`, failing pytest. The prompt gives
+  the exact venv command and asks to run → find → fix → re-run → explain.
+- Sampling: **temp 1.0 / top_p 0.95** (Meta's recommendation for this model),
+  set via opencode's `agent.build`. Opencode sends no temperature of its own and
+  mlx-vlm's server defaults to 0.0 (greedy), which is the configuration that
+  produced the 35B's 204x perseveration loop — so this is load-bearing.
+- Skills disabled (`"tools": {"skill*": false}`) for a clean 7.3K system prompt.
+- Fresh task repo per run; server restarted per build, one model resident.
+
+| build | run | secs | requests | actions | fix | tests intact |
+|---|---|---|---|---|---|---|
+| `tq4-g64` | 1 | 547 | 7 | 4 | ✅ | ✅ |
+| `tq4-g64` | 2 | 658 | 7 | 4 | ✅ | ✅ |
+| `tq4-g64` | 3 | 658 | 7 | 4 | ✅ | ✅ |
+| `tq3-g64` | 1 | 795 | 8 | 5 | ✅ | ✅ |
+| `tq3-g64` | 2 | 728 | 8 | 5 | ✅ | ✅ |
+| `tq3-g64` | 3 | 640 | 7 | 4 | ✅ | ✅ |
+
+**tq4 3/3 · tq3 3/3.** Trajectories:
+
+```
+tq4:  pytest → Read . → Read stats.py → edit → pytest → 3 passed
+tq3:  ls -la → pytest → Read stats.py → Read test_stats.py → edit → pytest → 3 passed
+```
+
+Every run executed the exact venv command it was given, first try — which the
+35B ternary never did across 4 configs (see RESULTS.md). Action counts stayed in
+a 4–5 band with no run drifting; the perseveration failure mode would show up as
+a run ballooning to 20+ actions.
+
+**A pass requires all three of:** pytest reports `3 passed`, the fix is
+specifically `sum(values) / len(values)`, and `test_stats.py` is byte-identical
+to a freshly generated reference. The last one matters — "3 passed" alone cannot
+distinguish a real fix from a model that edited the tests until they agreed with
+the bug. All 6 runs were byte-identical.
+
+### The missing closing explanation — found and fixed in 0.21.1
+
+The prompt ends with "Tell me what the bug was." **All 8 runs on 0.21.0 end at
+`3 passed` with zero lines of prose after it.** The engineering was right every
+time; the summary was absent, consistently.
+
+It was **our bug, in the server** — see §3 for the root cause and the fix. After
+0.21.1, one run per build:
+
+| build | secs | requests | actions | fix | tests intact | prose lines |
+|---|---|---|---|---|---|---|
+| `tq4-g64` | 589 | 7 | 4 | ✅ | ✅ | **6** |
+| `tq3-g64` | 772 | 8 | 5 | ✅ | ✅ | **6** |
+
+> The bug was in `stats.py:8`. The average function divided by `len(values) + 1`
+> instead of `len(values)`.
+
+Action counts, the fix and the test-file md5 are all unchanged, so tool calling
+is unaffected by the fix.
+
+## 2. Vision — quantized tower vs bf16 control
+
+The size advantage over `mlx-community/Muse-Glimmer-30B-4bit` exists largely
+because TurboQuant quantizes `embed_tokens` **and the entire 50-layer ViT-G/14
+vision tower** (3.3B params) that the affine build leaves in bf16. So vision is
+exactly where our compression could silently break — and it had never been
+tested on the quantized builds.
+
+Four synthetic images with exact ground truth (greedy decode, so re-runnable).
+The mlx-community build is included as a **control**: a case both miss is a model
+limitation, a case only ours misses is our bug.
+
+| case | ground truth | tq4 | tq3 | mlx4 control (bf16 vision) |
+|---|---|---|---|---|
+| OCR | `VOLTAGE 47` | ✅ 13 s | ✅ 12 s | ✅ 547 s ⁽¹⁾ |
+| count red circles (blue-square distractors) | `3` | ✅ 11 s | ✅ 11 s | ✅ 7 s |
+| tallest bar | `C` | ✅ 11 s | ✅ 11 s | ✅ 7 s |
+| top-left shape | `triangle` | ✅ 11 s | ✅ 13 s | ✅ 7 s |
+| | | **4/4** | **4/4** | **4/4** |
+
+⁽¹⁾ cold load of a 19.88 GiB model, not inference — the following three cases at
+7 s confirm it. Our builds were already page-cached from the agentic runs.
+
+**Quantizing the vision tower cost nothing measurable here.** Two limits on that
+claim, stated plainly:
+
+- 4/4 vs 4/4 means **no regression detected**, not identical vision quality.
+  These are clean synthetic images with unambiguous answers; a harder battery
+  (cluttered photos, small text, fine-grained counting) could still separate
+  them. This is a soundness check, not a vision benchmark.
+- The control is **faster per case once warm** (7 s vs 11–13 s), which is the
+  codebook-vs-affine decode gap already documented for this model (2.4–2.8×).
+
+## 3. Reasoning level: `low` vs `medium`
+
+`low` is what the model cards recommend for agents. `medium` was run to ask two
+things: does more deliberation help on a roomier machine (24 GB+, where the
+token budget is not the constraint it is on a 16 GB mini), and does it bring
+back the missing explanation?
+
+| build | level | secs | requests | actions | pass | prose after final test |
+|---|---|---|---|---|---|---|
+| tq4 | low (n=3) | 547 / 658 / 658 | 7 | 4 | 3/3 | 0 |
+| tq4 | medium | 727 | 8 | 5 | ✅ | 0 |
+| tq3 | low (n=3) | 640 / 728 / 795 | 7–8 | 4–5 | 3/3 | 0 |
+| tq3 | medium | 608 | 7 | 4 | ✅ | 0 |
+
+**Medium passes, and buys nothing measurable.** tq4 costs +70 s and one extra
+action for the same correct fix; tq3 lands at 608 s, inside the `low` spread
+(640–795 s), so the wall-clock difference is within run-to-run noise rather than
+a real slowdown. No behavioural difference worth a recommendation change:
+**stay on `low`**. `high` was not run — on this evidence it would only be slower
+for the same outcome.
+
+### The missing explanation was ours, and two hypotheses were wrong
+
+**Hypothesis 1 — the reasoning level trims the summary. Falsified.** `medium`
+produces `prose_lines = 0` on both builds too. The raw transcript was checked
+directly, so it was never a parsing artifact.
+
+**Hypothesis 2 — the model never emits the `to=user` routing header, so the
+thinking splitter never closes. Also wrong.** The header is emitted. The
+content is discarded *after* the splitter, further down the pipe.
+
+**Actual root cause.** ATEM declares
+`tool_call_start = "to=self<|message|>"` — byte-identical to the channel router
+Muse Glimmer emits at the start of every turn. While streaming, mlx-vlm drops
+every content delta from the moment `tool_call_start` appears in the output, and
+`in_tool_call` **has no release path**: once latched, it stays latched for the
+rest of the generation. So on any request that declared tools, the latch closed
+on the first reasoning token and nothing the model said afterwards reached the
+client.
+
+Reproducible with no model loaded:
+
+```python
+from mlx_vlm.server.responses_state import suppress_tool_call_content as S
+R = "to=self<|message|>"
+S(R + "thinking", False, R, "the answer")   # -> (True, None)   the answer, dropped
+S("...", False, None, "the answer")         # -> (False, 'the answer')  no tools: fine
+```
+
+That asymmetry is why it read as a model problem: a plain curl answered
+correctly (no tools declared, so no trigger), tool calls kept working (they are
+parsed from the *full output*, not the stream), and only prose went missing.
+
+**Fix (0.21.1):** `turboquant-serve-vlm` remaps the suppression trigger to
+`<atem:function_calls>`, the tag that genuinely opens a call — and the string
+mlx-vlm itself uses to detect the ATEM format. Tool-call parsing is untouched,
+since `process_tool_calls` reads the marker from the parser. Verified in §1.
+
+**The transferable lesson:** when a model's channel protocol and its tool
+protocol share a marker, every consumer that keys off that marker becomes
+ambiguous. Check what the inferred tool parser declares against what the model
+emits on an *ordinary* turn, not just a tool turn.
+
+## 4. Two serving gotchas specific to `turboquant-serve-vlm`
+
+Neither exists with `turboquant-serve`, and both cost real time here.
+
+1. **The model id must be the exact path the server preloaded.** mlx-vlm's
+   server routes by `request.model` and will fetch+load *any* other id from the
+   Hub. `default_model` (the `turboquant-serve` convention) 404s, and sending the
+   upstream repo id `meta-models/Muse-Glimmer-30B` **started loading the 59.6 GB
+   bf16 original over the top of the quantized one** — caught at 2.3 GB RSS and
+   killed. On a 64 GB box that is a wedge risk.
+2. **`max_tokens` must clear the reasoning budget.** At `max_tokens: 20` the
+   reply came back `content: None` — reasoning consumed the whole allowance
+   before any answer token. Fine at 150; opencode allows 8192. A client with a
+   tight cap sees empty replies and blames the model.
+
+## Reproduce
+
+```bash
+bash scripts/opencode_smoke/setup_task_repo.sh /tmp/task
+turboquant-serve-vlm --model manjunathshiva/Muse-Glimmer-30B-tq4-g64 \
+    --port 8080 --reasoning-strength low
+# opencode.json: provider baseURL http://127.0.0.1:8080/v1, model id = the
+# exact --model path, agent.build.temperature 1.0 / top_p 0.95
+cd /tmp/task && opencode run "<the prompt above>"
+```
+
+Vision battery: `make_vision_tests.py` + `run_vision_tests.py` (scratchpad).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.21.0"
+version = "0.21.1"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"

--- a/serve_vlm.py
+++ b/serve_vlm.py
@@ -4,7 +4,7 @@
 multimodal architectures. mlx-vlm ships its own, considerably richer server
 (OpenAI *and* Anthropic routes, per-model tool parsers, continuous batching,
 speculative decoding), so this module drives that one instead of reimplementing
-it — it only teaches it the three things it cannot know about a TurboQuant VLM:
+it — it only teaches it the four things it cannot know about a TurboQuant VLM:
 
 1. **How to load the checkpoint.** mlx-vlm's server reaches the model through
    exactly one seam: ``mlx_vlm.server.generation.load_model_resources`` calls
@@ -20,6 +20,11 @@ it — it only teaches it the three things it cannot know about a TurboQuant VLM
 3. **What the reasoning knob is called.** The server sends OpenAI's
    ``reasoning_effort``; Muse Glimmer's chat template only reads
    ``reasoning_strength`` and otherwise deliberates at its ``high`` default.
+
+4. **Which marker really opens a tool call.** ATEM's ``tool_call_start`` is the
+   same string Muse Glimmer opens every turn with, so mlx-vlm's streaming
+   content suppressor latches on the first reasoning token and the answer never
+   reaches the client. See ``TOOL_CALL_SUPPRESSION_TRIGGER``.
 
 Usage:
     turboquant-serve-vlm --model <tq-dir-or-repo> --port 8080
@@ -52,6 +57,26 @@ CHANNEL_DELIMITERS: Dict[str, Tuple[str, str]] = {
         "to=self<|message|>",
         "<|start|>assistant to=user<|message|>",
     ),
+}
+
+# Tool-call openers that are unsafe as a *streaming* suppression trigger,
+# mapped to the marker that actually opens a call.
+#
+# While streaming, mlx-vlm drops every content delta from the moment the tool
+# parser's `tool_call_start` appears in the output, and has no release path —
+# `in_tool_call` latches on and stays on. ATEM's `tool_call_start` is
+# `to=self<|message|>`, which is the channel router Muse Glimmer emits at the
+# start of *every* turn, tool call or not. So on any tools-enabled request the
+# latch closes on the first reasoning token and the assistant's answer never
+# reaches the client — an agent harness sees the work happen and then an empty
+# final message.
+#
+# `<atem:function_calls>` is the tag that genuinely opens a call (mlx-vlm uses
+# it to *detect* the ATEM format in the first place), so it is both correct and
+# strictly more specific. Tool-call parsing is untouched: `process_tool_calls`
+# reads `tool_call_start` from the parser itself, not from here.
+TOOL_CALL_SUPPRESSION_TRIGGER: Dict[str, str] = {
+    "to=self<|message|>": "<atem:function_calls>",
 }
 
 # OpenAI's reasoning_effort vocabulary -> Muse Glimmer's reasoning_strength.
@@ -160,6 +185,40 @@ def install_reasoning_strength_mapping(default_strength: Optional[str] = None) -
     GenerationArguments.to_template_kwargs = to_template_kwargs
 
 
+def install_tool_call_suppression_fix() -> None:
+    """Stop a reasoning-channel opener from suppressing the streamed answer.
+
+    Rebinds the name inside each route module rather than in `responses_state`,
+    because both import it directly and would otherwise keep the original.
+    Idempotent, and a no-op for every parser whose `tool_call_start` is not a
+    known collision — those pass straight through unchanged.
+    """
+    modules = []
+    for name in ("openai", "anthropic"):
+        try:
+            modules.append(__import__(f"mlx_vlm.server.{name}", fromlist=[name]))
+        except ImportError:  # pragma: no cover - route set varies by version
+            continue
+
+    for module in modules:
+        original = getattr(module, "suppress_tool_call_content", None)
+        if original is None or getattr(original, "_turboquant_wrapper", False):
+            continue
+
+        def suppress_tool_call_content(
+            full_output, in_tool_call, tc_start, delta_content, _original=original
+        ):
+            return _original(
+                full_output,
+                in_tool_call,
+                TOOL_CALL_SUPPRESSION_TRIGGER.get(tc_start, tc_start),
+                delta_content,
+            )
+
+        suppress_tool_call_content._turboquant_wrapper = True
+        module.suppress_tool_call_content = suppress_tool_call_content
+
+
 def channel_delimiters_for(model_path) -> Optional[Tuple[str, str]]:
     """The thinking delimiters this model needs, if we know of any."""
     return CHANNEL_DELIMITERS.get(model_architecture(model_path) or "")
@@ -239,6 +298,7 @@ def main(argv=None):
     logging.basicConfig(level=logging.INFO, format="%(levelname)s - %(message)s")
 
     install_turboquant_loader()
+    install_tool_call_suppression_fix()
 
     model_path = _extract_option(server_argv, "--model")
     resolved = None

--- a/tests/test_serve_vlm.py
+++ b/tests/test_serve_vlm.py
@@ -222,9 +222,18 @@ class TestToolCallSuppressionFix:
         assert "<tool_call>" not in serve_vlm.TOOL_CALL_SUPPRESSION_TRIGGER
 
     def _patched_module(self):
-        """A stand-in route module carrying mlx-vlm's real suppressor."""
+        """A stand-in route module carrying mlx-vlm's real suppressor.
+
+        Deliberately the *real* upstream function rather than a fake: these
+        tests assert what mlx-vlm actually does, so a hand-written stand-in
+        would only prove the stand-in matches itself. That makes them require
+        the optional `[vlm]` extra, which CI does not install.
+        """
         import types
 
+        pytest.importorskip(
+            "mlx_vlm", reason="needs the [vlm] extra for the real suppressor"
+        )
         from mlx_vlm.server.responses_state import suppress_tool_call_content
 
         module = types.ModuleType("fake_routes")

--- a/tests/test_serve_vlm.py
+++ b/tests/test_serve_vlm.py
@@ -1,6 +1,6 @@
 """Serving TurboQuant VLMs through mlx-vlm's server.
 
-Three things go silently wrong without this module, and none of them raise:
+Four things go silently wrong without this module, and none of them raise:
 
 1. mlx-vlm's server cannot load a polar checkpoint at all.
 2. Muse Glimmer's reasoning channel lands in `message.content`, because
@@ -8,6 +8,9 @@ Three things go silently wrong without this module, and none of them raise:
    An agent harness then reads the model's private deliberation as its answer.
 3. `reasoning_effort` never reaches the template, which reads
    `reasoning_strength` — so the model always deliberates at `high`.
+4. While streaming, ATEM's `tool_call_start` is the same string Muse Glimmer
+   opens every turn with, so mlx-vlm suppresses every content delta and the
+   client receives an empty answer.
 """
 
 import json
@@ -15,6 +18,7 @@ import sys
 
 import pytest
 
+from turboquant_mlx import serve_vlm
 from turboquant_mlx.serve_vlm import (
     CHANNEL_DELIMITERS,
     build_server_argv,
@@ -197,3 +201,72 @@ class TestChatTemplateDiscovery:
     def test_missing_template_is_empty_not_an_error(self, tmp_path):
         _write_model(tmp_path, {})
         assert chat_template_text(tmp_path) == ""
+
+
+class TestToolCallSuppressionFix:
+    """The reasoning-channel opener must not suppress the streamed answer.
+
+    ATEM declares `tool_call_start = "to=self<|message|>"`, which is exactly
+    what Muse Glimmer emits at the start of every turn. mlx-vlm's streaming
+    suppressor latches `in_tool_call` on that string and never releases it, so
+    without this fix a tools-enabled request streams no content at all.
+    """
+
+    ROUTER = "to=self<|message|>"
+    CALL_TAG = "<atem:function_calls>"
+
+    def test_the_router_is_remapped_to_the_real_call_tag(self):
+        assert serve_vlm.TOOL_CALL_SUPPRESSION_TRIGGER[self.ROUTER] == self.CALL_TAG
+
+    def test_unknown_parsers_pass_through_untouched(self):
+        assert "<tool_call>" not in serve_vlm.TOOL_CALL_SUPPRESSION_TRIGGER
+
+    def _patched_module(self):
+        """A stand-in route module carrying mlx-vlm's real suppressor."""
+        import types
+
+        from mlx_vlm.server.responses_state import suppress_tool_call_content
+
+        module = types.ModuleType("fake_routes")
+        module.suppress_tool_call_content = suppress_tool_call_content
+        return module
+
+    def _install_on(self, module, monkeypatch):
+        import sys
+
+        monkeypatch.setitem(sys.modules, "mlx_vlm.server.openai", module)
+        monkeypatch.setitem(sys.modules, "mlx_vlm.server.anthropic", module)
+        serve_vlm.install_tool_call_suppression_fix()
+
+    def test_reasoning_no_longer_swallows_the_answer(self, monkeypatch):
+        module = self._patched_module()
+        before = module.suppress_tool_call_content(
+            self.ROUTER + "thinking", False, self.ROUTER, "the answer"
+        )
+        assert before == (True, None), "precondition: upstream drops the answer"
+
+        self._install_on(module, monkeypatch)
+
+        latched, delta = module.suppress_tool_call_content(
+            self.ROUTER + "thinking", False, self.ROUTER, "the answer"
+        )
+        assert (latched, delta) == (False, "the answer")
+
+    def test_a_real_tool_call_is_still_suppressed(self, monkeypatch):
+        module = self._patched_module()
+        self._install_on(module, monkeypatch)
+
+        latched, delta = module.suppress_tool_call_content(
+            self.ROUTER + "thinking" + self.CALL_TAG,
+            False,
+            self.ROUTER,
+            "<atem:invoke name=",
+        )
+        assert (latched, delta) == (True, None), "tool markup must not reach the user"
+
+    def test_installing_twice_does_not_double_wrap(self, monkeypatch):
+        module = self._patched_module()
+        self._install_on(module, monkeypatch)
+        once = module.suppress_tool_call_content
+        serve_vlm.install_tool_call_suppression_fix()
+        assert module.suppress_tool_call_content is once


### PR DESCRIPTION
Closes #167.

`turboquant-serve-vlm` 0.21.0 returns an **empty final message to any client that declares tools**. This is ours, not the model's.

## Root cause

```
atem.tool_call_start           == "to=self<|message|>"
Muse's reasoning-channel open  == "to=self<|message|>"   <- byte-identical
```

While streaming, mlx-vlm drops every content delta from the moment the tool parser's `tool_call_start` appears in the output, and `in_tool_call` has no release path — once latched it stays latched for the rest of the generation. Since that string is the channel router Muse Glimmer emits at the start of *every* turn, the latch closes on the first reasoning token of any tools-enabled request.

Reproduced with no model loaded:

```
after reasoning opens : True None
final answer delta    : True None      <- the answer, dropped
no-tools control      : (False, 'The bug was an off-by-one.')
```

The asymmetry is why this looked like a model problem: plain `curl` answered correctly (no tools declared, so no trigger), tool calls kept working (they are parsed from the full output, not the stream), and only prose went missing.

**This corrects the hypothesis recorded in RESULTS_MUSE.md**, which blamed a missing `to=user` routing header. The header is emitted; the content is discarded downstream.

## Fix

Remap the suppression trigger to `<atem:function_calls>` — the tag that genuinely opens a call, and the same string mlx-vlm uses to *detect* the ATEM format. Strictly more specific than the channel router.

- Tool-call **parsing** is untouched: `process_tool_calls` reads the marker from the parser itself.
- Rebound inside each route module (`openai`, `anthropic`), because both import the name directly.
- Parsers whose `tool_call_start` is not a known collision pass through unchanged.

## Verification

Unit: 516 passed, 5 skipped (+5 new). One test asserts the upstream precondition, so it fails loudly if this is ever fixed upstream and the shim becomes redundant.

End-to-end, OpenCode, one run per build:

| build | secs | reqs | tests | fix | tests intact | actions | prose lines |
|---|---|---|---|---|---|---|---|
| tq4 | 589 | 7 | 3 passed | yes | yes | 4 | **6** (was 0) |
| tq3 | 772 | 8 | 3 passed | yes | yes | 5 | **6** (was 0) |

> The bug was in `stats.py:8`. The average function divided by `len(values) + 1` instead of `len(values)`.

Tool calling unaffected: same action counts, correct minimal fix, `test_stats.py` byte-identical to a fresh reference.

## Also in this release

`--reasoning-strength` now appears in `--help` (#83, merged after 0.21.0 was published).

Fix and version bump are in one PR rather than the usual two: a single squash-merge avoids the release-branch-off-feature-branch conflict, and this is a patch with one fix.