### PR TITLE
fix(plan): model prefill the way it actually runs — chunked, and MoE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,34 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`turboquant-plan` over-estimated prefill workspace on big-vocab models by
+  charging for an lm_head output that is never computed.** The projection
+  billed `chunk x vocab x 2` for every prefill chunk. Both engines chunk
+  prefill (`mlx_lm.generate_step`, mlx-vlm `generate/ar.py`) and both *discard*
+  the chunk forward's return value, evaluating only the KV cache state — and
+  MLX is lazy, so an lm_head matmul nobody asks for never runs. Measured on an
+  M4 Max at 2048 x 202048, against a floor doing the cache work alone:
+  dropping the output costs **0 MB**, while slicing `[:, -1:]` out of it costs
+  the full **763 MiB**. Both loops also leave exactly one token for the scoring
+  step.
+
+  So the term is real only when the prompt fits in a *single* forward
+  (`context <= step`), where the slice happens after the matmul. On
+  Muse-Glimmer-30B at 5,068 tokens this cut the projected workspace from 5.21
+  GB to 4.39 GB, and it was making `--prefill-step-size` look like it bought
+  headroom it does not buy. The estimate is now the max of the widest chunk
+  pass and the one-token scoring step, rather than a sum of costs that never
+  coexist.
+
+  Also corrected: the chunk can no longer exceed the prompt, so a 900-token
+  prompt is billed as a 900-token forward instead of a 2048-token one.
+
+  MoE expert dequantization remains unmodelled. The field-calibrated mini
+  datapoints are unaffected — they were measured on a config with no
+  `vocab_size`, so they never depended on this term.
+
 ## [0.21.1] - 2026-08-11
 
 Two `turboquant-serve-vlm` fixes found by using it: an agent harness never

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,9 +30,44 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
   Also corrected: the chunk can no longer exceed the prompt, so a 900-token
   prompt is billed as a 900-token forward instead of a 2048-token one.
 
-  MoE expert dequantization remains unmodelled. The field-calibrated mini
-  datapoints are unaffected — they were measured on a config with no
-  `vocab_size`, so they never depended on this term.
+  The field-calibrated mini datapoints are unaffected — they were measured on
+  a config with no `vocab_size`, so they never depended on this term.
+
+### Added
+
+- **`turboquant-plan` now models the MoE prefill term**, the last one it left
+  out. It is not what the old TODO assumed. Expert *dequantization* is
+  essentially never paid during prefill: mlx-lm's SwitchGLU sorts any batch of
+  64+ routings, and sorted batches go to `polar_gather_qmm`, which tiles over
+  packed weights and materializes nothing. Measured on a 256-expert block at
+  chunk 2048: **357.8 MB** peak, against a **933.8 MB** control that does
+  dequantize all experts — the 768 MB tensor never appears.
+
+  What is actually there is routing-expanded activations. SwitchGLU fans every
+  token out to `top_k` rows before the expert matmuls, so the transient scales
+  with `chunk x top_k`, not `chunk`. Measured bytes per routing on one
+  gate/up/down block, against `8 x (hidden + moe_intermediate)`:
+
+  | geometry (experts, hidden, moe_inter) | measured | bound |
+  |---|---|---|
+  | 256, 2048, 768 (Qwen3.6-35B-A3B) | 21,077 | 22,528 |
+  | 128, 1024, 2048 (inverted ratio) | 20,564 | 24,576 |
+  | 64, 4096, 1024 (wide hidden) | 38,984 | 40,960 |
+  | 256, 2048, 512 (narrow expert) | 19,541 | 20,480 |
+  | 256, 3072, 1024 (Laguna-S-2.1) | 30,819 | 32,768 |
+
+  The bound holds on all of them with 3–16% slack, and is what the eight live
+  routing-expanded buffers cost if the allocator reused none. On Laguna-S-2.1
+  at 16K context this adds 0.67 GB to the projection at the default chunk.
+
+  The dequant fallback is still charged where it can genuinely fire: expert
+  output dims that `polar_gather_qmm` cannot tile (not a multiple of 64), and
+  only below the switch layer's 2 GiB cap, above which it reverts to gather
+  kernels that materialize nothing.
+
+  Expert width is read from `moe_intermediate_size`, never `intermediate_size`
+  — on Laguna those are 1024 and 12288, a 12x error. Models whose config does
+  not state `num_experts_per_tok` get no term rather than a guessed one.
 
 ## [0.21.1] - 2026-08-11
 

--- a/plan.py
+++ b/plan.py
@@ -282,6 +282,82 @@ _POLAR_LIVE_PROJECTIONS = 2.0
 _QMM_MAX_TOKENS = 256
 
 
+# MoE prefill. SwitchGLU fans every token out to top_k rows before the expert
+# matmuls (mlx_lm/models/switch_layers.py:_gather_sort), so an expert block's
+# transient scales with chunk x top_k, not chunk. Measured on an M4 Max, one
+# gate/up/down block, sorted prefill, peak over resident packed weights:
+#
+#   geometry (experts, hidden, moe_inter)   measured B/routing   8x(h+m)
+#   256, 2048,  768  (Qwen3.6-35B-A3B)             21077          22528
+#   128, 1024, 2048  (inverted ratio)              20564          24576
+#    64, 4096, 1024  (wide hidden)                 38984          40960
+#   256, 2048,  512  (narrow expert)               19541          20480
+#   128, 6656, 1024  (big hidden, top-4)           59497          61440
+#
+# 8 x (hidden + moe_inter) bounds all five (3-16% slack) and is what the eight
+# live routing-expanded buffers cost if none were reused: the input rows, a
+# rotated copy each for gate and up, both projection outputs, the SwiGLU
+# product, the rotated down input, and the down output. MLX's allocator reuses
+# some, so the true peak lands under the sum. Bound, not a fit.
+_MOE_ROUTING_BYTES_PER_UNIT = 8
+
+# polar_gather_qmm handles sorted prefill by tiling over PACKED weights and
+# materializes nothing, but only for output dims it can tile
+# (kernels/polar_gather_qmm.py:supports -> output_dims % OB). Anything else
+# falls back to dequantizing every expert, capped by the switch layer at
+# _GATHER_MM_MAX_DEQUANT_BYTES (above the cap it uses the gather kernels
+# instead, which again materialize nothing).
+_GATHER_QMM_OUTPUT_MULTIPLE = 64        # kernels/polar_gather_qmm.py:OB
+_GATHER_MM_MAX_DEQUANT_BYTES = 2 << 30  # layers/polar_switch_linear.py
+
+
+def _moe_geometry(cfg: dict) -> tuple:
+    """(n_experts, top_k, hidden, moe_intermediate), 0 for anything unknown.
+
+    Expert counts and top-k are spelled differently per family: num_experts
+    (Qwen), num_local_experts (Mixtral/GPT-OSS), n_routed_experts (DeepSeek),
+    and num_experts_per_token (Kimi K3) beside the usual num_experts_per_tok.
+    """
+    c = _text_config(cfg)
+    n_experts = _pos_int(c.get("num_experts"),
+                         _pos_int(c.get("num_local_experts"),
+                                  _pos_int(c.get("n_routed_experts"), 0)))
+    top_k = _pos_int(c.get("num_experts_per_tok"),
+                     _pos_int(c.get("num_experts_per_token"), 0))
+    hidden = _pos_int(c.get("hidden_size"), 0)
+    moe_inter = _pos_int(c.get("moe_intermediate_size"),
+                         _pos_int(c.get("intermediate_size"), 0))
+    return n_experts, top_k, hidden, moe_inter
+
+
+def _moe_prefill_bytes(cfg: dict, chunk: int, quant: dict | None) -> float:
+    """Transient for ONE MoE expert block during a prefill chunk.
+
+    Two parts, and the weight one is usually zero — see the constants above.
+    Returns 0 when the config does not say how many experts a token routes to,
+    since guessing that would move the verdict on no evidence.
+    """
+    n_experts, top_k, hidden, moe_inter = _moe_geometry(cfg)
+    if not (top_k and hidden and moe_inter):
+        return 0.0
+
+    routings = float(chunk) * float(top_k)
+    activations = (routings * _MOE_ROUTING_BYTES_PER_UNIT
+                   * float(hidden + moe_inter))
+
+    dequant = 0.0
+    if quant and quant.get("mode") == "turboquant" and n_experts:
+        # gate/up project hidden -> moe_inter; down projects back.
+        for out_dims, in_dims in ((moe_inter, hidden), (hidden, moe_inter)):
+            if out_dims % _GATHER_QMM_OUTPUT_MULTIPLE == 0:
+                continue        # fused gather-GEMM: nothing materialized
+            b = float(n_experts) * float(out_dims) * float(in_dims) * 2.0
+            if b <= _GATHER_MM_MAX_DEQUANT_BYTES:
+                dequant = max(dequant, b)
+
+    return activations + dequant
+
+
 def _largest_projection_params(cfg: dict) -> float:
     """Parameter count of the widest dense projection in one decoder layer."""
     c = _text_config(cfg)
@@ -327,8 +403,19 @@ def prefill_workspace_bytes(cfg: dict, context: int, step: int,
     a 202k-vocab model and made `--prefill-step-size` look like it bought
     headroom it does not buy. Do not "restore" the term without re-measuring.
 
-    MoE expert dequantization is still NOT modelled — SwitchLinear has its own
-    dequant-all fallback with different residency.
+    4. For MoE, one expert block's transient (`_moe_prefill_bytes`). Dominated
+       by routing-expanded activations, NOT by weight dequantization: sorted
+       prefill goes to `polar_gather_qmm`, which tiles over packed weights and
+       materializes nothing. Measured on a 256-expert Qwen block at chunk 2048:
+       357.8 MB peak against a 933.8 MB control that does dequantize all
+       experts — the fallback costs the full 768 MB tensor, the prefill path
+       pays none of it.
+
+    Terms 1 and 4 are summed even though attention finishes before the MLP
+    starts, so they do not truly coexist. That is deliberate: both are real and
+    nonzero, and this tool exists to prevent OOMs. It is a different case from
+    the lm_head term above, which is dropped because it measured at exactly
+    zero, not merely at a different moment.
     """
     c = _text_config(cfg)
     heads = _pos_int(c.get("num_attention_heads"), 16)
@@ -347,6 +434,8 @@ def prefill_workspace_bytes(cfg: dict, context: int, step: int,
         dequant = (_largest_projection_params(cfg)
                    * _POLAR_DEQUANT_BYTES_PER_PARAM
                    * _POLAR_LIVE_PROJECTIONS)
+    if is_moe:
+        dequant += _moe_prefill_bytes(cfg, chunk, quant)
 
     if not chunked:
         # One forward: logits[:, -1, :] slices AFTER the matmul has run, so the

--- a/plan.py
+++ b/plan.py
@@ -295,37 +295,69 @@ def _largest_projection_params(cfg: dict) -> float:
 def prefill_workspace_bytes(cfg: dict, context: int, step: int,
                             quant: dict | None = None,
                             is_moe: bool = False) -> float:
-    """Transient memory for one prefill chunk (ESTIMATE). Three terms:
+    """Transient memory for prefill (ESTIMATE), modelling the CHUNKED path.
 
-    1. Attention scratch — scales with chunk size AND context, which is why a
-       long agent turn can OOM at a chunk size that was fine when the
-       conversation was short.
-    2. The lm_head output for the whole chunk. Easy to forget and often the
-       largest term on a big-vocab model: 202048 vocab x 2048 tokens = 0.77 GB.
+    `context` is treated as the prompt length being prefilled — the planner's
+    existing convention, and the case the tool exists to protect (a long agent
+    turn).
+
+    Three terms:
+
+    1. Attention scratch — chunk x context. The only term with a real cliff,
+       and the one `--prefill-step-size` actually buys down. The last chunk
+       sees the full context, so `context` (not the chunk) is the second factor.
+    2. The lm_head output, which is NOT simply chunk-shaped — see below.
     3. Weight dequantization, for TurboQuant DENSE layers only, and only above
-       the fused kernel's token bound. This one is a step function, not a
-       gradient: it appears in full the moment the chunk exceeds
-       _QMM_MAX_TOKENS.
+       the fused kernel's token bound. A step function, not a gradient: it
+       appears in full the moment the chunk exceeds _QMM_MAX_TOKENS.
 
-    MoE expert dequantization is NOT modelled — SwitchLinear has its own
-    dequant-all fallback with different residency, so MoE estimates here remain
-    attention + logits only.
+    On the lm_head term. Both engines chunk prefill (`mlx_lm.generate_step`,
+    mlx-vlm `generate/ar.py`) and both DISCARD the chunk forward's return value,
+    evaluating only the KV cache state. MLX is lazy, so an lm_head matmul whose
+    output nobody asks for is never computed at all. Measured on an M4 Max at
+    2048 x 202048, against a floor that does the cache work alone:
+
+        dropped output (what the chunk loop does)     +0 MB
+        sliced [:, -1:] out of it (unchunked step)  +763 MiB
+
+    Both loops then leave exactly ONE token for the scoring step. So the full
+    `chunk x vocab x 2` cost is real only when the prompt fits in a single
+    forward (context <= step); past that it collapses to one token's worth.
+    Modelling it as always-chunk-shaped over-predicted peak by up to 0.83 GB on
+    a 202k-vocab model and made `--prefill-step-size` look like it bought
+    headroom it does not buy. Do not "restore" the term without re-measuring.
+
+    MoE expert dequantization is still NOT modelled — SwitchLinear has its own
+    dequant-all fallback with different residency.
     """
     c = _text_config(cfg)
     heads = _pos_int(c.get("num_attention_heads"), 16)
-    attn = float(step) * float(context) * float(heads) * 2.0
-
     vocab = _pos_int(c.get("vocab_size"), _pos_int(cfg.get("vocab_size"), 0))
-    logits = float(step) * float(vocab) * 2.0
+
+    # Chunking engages only when the prompt is longer than the chunk; a shorter
+    # prompt goes through in one forward whose width is the prompt itself.
+    chunk = min(step, context) if context else step
+    chunked = context > step
+
+    attn = float(chunk) * float(context) * float(heads) * 2.0
 
     dequant = 0.0
     if (quant and quant.get("mode") == "turboquant" and not is_moe
-            and step > _QMM_MAX_TOKENS):
+            and chunk > _QMM_MAX_TOKENS):
         dequant = (_largest_projection_params(cfg)
                    * _POLAR_DEQUANT_BYTES_PER_PARAM
                    * _POLAR_LIVE_PROJECTIONS)
 
-    return attn + logits + dequant
+    if not chunked:
+        # One forward: logits[:, -1, :] slices AFTER the matmul has run, so the
+        # whole chunk x vocab tensor is materialized first.
+        return attn + float(chunk) * float(vocab) * 2.0 + dequant
+
+    # Chunked: the widest chunk pass (lm_head elided) and the 1-token scoring
+    # step (full vocab, one token) peak at different moments, so take the max
+    # rather than summing costs that never coexist.
+    scoring = float(context) * float(heads) * 2.0 + float(vocab) * 2.0
+    return max(attn + dequant, scoring)
 
 
 # --------------------------------------------------------------------------

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -17,6 +17,7 @@ from turboquant_mlx.plan import (
     machine,
     footprint,
     _attention_layers,
+    _moe_prefill_bytes,
     _resolve,
     is_complete_checkpoint,
     kv_bytes,
@@ -28,7 +29,11 @@ from turboquant_mlx.plan import (
 
 GB = 1e9
 
-# Qwen3.6-35B-A3B geometry (the real one, from the shipped config)
+# Qwen3.6-35B-A3B geometry (the real one, from the shipped config).
+# NOTE: this fixture carries neither `vocab_size` nor `moe_intermediate_size`,
+# so the lm_head and MoE-routing terms of prefill_workspace_bytes are both
+# ZERO here. That is why the field calibration below is unaffected by changes
+# to either — it is not coverage of them. Use MUSE / LAGUNA for those.
 Q35 = {
     "model_type": "qwen3_5_moe",
     "quantization": {"mode": "turboquant", "bits": 3, "group_size": 64},
@@ -61,6 +66,26 @@ MUSE = {
         "vocab_size": 202048,
         "sliding_window": 2048,
         "layer_types": (["sliding_attention"] * 3 + ["full_attention"]) * 8,
+    },
+}
+
+
+# Laguna-S-2.1 geometry, read off the shipped config.json. Unlike Q35 this
+# carries moe_intermediate_size + num_experts_per_tok, so it is the fixture for
+# anything that depends on expert routing.
+LAGUNA = {
+    "model_type": "laguna",
+    "quantization": {"mode": "turboquant", "bits": 3, "group_size": 64},
+    "text_config": {
+        "num_hidden_layers": 48,
+        "hidden_size": 3072,
+        "moe_intermediate_size": 1024,
+        "intermediate_size": 12288,      # the DENSE mlp — must not be used
+        "num_experts": 256,
+        "num_experts_per_tok": 10,
+        "num_attention_heads": 48,
+        "vocab_size": 100352,
+        "layer_types": (["sliding_attention"] * 3 + ["full_attention"]) * 12,
     },
 }
 
@@ -258,6 +283,82 @@ class TestWorkspace:
         assert (prefill_workspace_bytes(MUSE, 900, 2048)
                 == prefill_workspace_bytes(MUSE, 900, 900))
 
+    def test_moe_term_bounds_the_measured_per_routing_cost(self):
+        """SwitchGLU fans each token out to top_k rows, so an expert block's
+        transient scales with chunk x top_k.
+
+        MEASURED on an M4 Max, Laguna-S-2.1's exact geometry (256 experts,
+        hidden 3072, moe_inter 1024, top-10), one gate/up/down block, sorted
+        prefill, peak over resident packed weights: 30,833 B/routing at step
+        256 and 30,819 at step 1024. The model must BOUND that, not match it —
+        this tool exists to prevent OOMs.
+        """
+        step, top_k = 1024, LAGUNA["text_config"]["num_experts_per_tok"]
+        per_routing = (_moe_prefill_bytes(LAGUNA, step, LAGUNA["quantization"])
+                       / (step * top_k))
+        assert per_routing >= 30833, "must not under-predict the measurement"
+        assert per_routing < 30833 * 1.25, "bound has drifted loosely"
+
+    def test_moe_term_scales_with_top_k_not_just_chunk(self):
+        few = dict(LAGUNA, text_config=dict(LAGUNA["text_config"],
+                                            num_experts_per_tok=5))
+        assert (_moe_prefill_bytes(LAGUNA, 512, None)
+                == pytest.approx(_moe_prefill_bytes(few, 512, None) * 2))
+        assert (_moe_prefill_bytes(LAGUNA, 1024, None)
+                == pytest.approx(_moe_prefill_bytes(LAGUNA, 512, None) * 2))
+
+    def test_moe_uses_the_expert_width_not_the_dense_mlp(self):
+        """moe_intermediate_size (1024), never intermediate_size (12288) — a
+        12x error on any model that carries both."""
+        step = 512
+        c = LAGUNA["text_config"]
+        routings = step * c["num_experts_per_tok"]
+        assert _moe_prefill_bytes(LAGUNA, step, None) == pytest.approx(
+            routings * 8 * (c["hidden_size"] + c["moe_intermediate_size"]))
+
+    def test_sorted_prefill_pays_no_expert_dequantization(self):
+        """polar_gather_qmm tiles over PACKED weights when output dims are a
+        multiple of 64, materializing nothing. Measured: a 256-expert block at
+        chunk 2048 peaks at 357.8 MB, against 933.8 MB for a control that does
+        dequantize all experts — the 768 MB tensor never appears.
+
+        So the term is activations only. Break the tiling constraint and the
+        fallback cost shows up.
+        """
+        step = 512
+        c = LAGUNA["text_config"]
+        q = LAGUNA["quantization"]
+        routings = step * c["num_experts_per_tok"]
+
+        # Real geometry: activations only, even with TurboQuant weights.
+        assert _moe_prefill_bytes(LAGUNA, step, q) == pytest.approx(
+            routings * 8 * (c["hidden_size"] + c["moe_intermediate_size"])), \
+            "no dequant term should appear for 64-divisible expert dims"
+
+        # 1000 is not a multiple of 64, so gate/up cannot be tiled and fall
+        # back to dequantizing every expert: 256 x 1000 x 3072 x 2 B = 1.57 GB,
+        # under the switch layer's 2 GiB cap.
+        odd = dict(LAGUNA, text_config=dict(c, moe_intermediate_size=1000))
+        assert (_moe_prefill_bytes(odd, step, q)
+                - routings * 8 * (3072 + 1000)) == pytest.approx(
+            256 * 1000 * 3072 * 2)
+
+        # Past the cap the switch layer uses the gather kernels instead, which
+        # materialize nothing — so a huge expert tensor is NOT charged.
+        huge = dict(LAGUNA, text_config=dict(c, moe_intermediate_size=1000,
+                                             num_experts=4096))
+        assert _moe_prefill_bytes(huge, step, q) == pytest.approx(
+            routings * 8 * (3072 + 1000))
+
+    def test_no_moe_term_for_a_dense_model(self):
+        assert (prefill_workspace_bytes(MUSE, 5068, 512, is_moe=False)
+                == prefill_workspace_bytes(MUSE, 5068, 512))
+
+    def test_moe_term_skipped_when_routing_is_unknown(self):
+        """Q35 has no moe_intermediate_size; guessing it would move a verdict
+        on no evidence, so the term stays out."""
+        assert _moe_prefill_bytes(Q35, 512, Q35["quantization"]) == 0.0
+
     def test_chunking_crossover_is_a_drop_not_a_jump(self):
         """Crossing the chunk size must not make the estimate worse: past the
         bound the lm_head term is elided, which is a saving, not a cost."""
@@ -310,13 +411,17 @@ class TestFieldCalibration:
         The measured fact is only that **2048 OOMed and 128 worked** — 512 and
         256 were never tried, so the field data does not actually contradict
         512. What it does suggest is that two errors were cancelling: the
-        undersized-RAM bug was compensating for MoE expert dequantization,
-        which `prefill_workspace_bytes` still does not model (SwitchLinear has
-        its own dequant-all fallback). This assertion therefore pins the part
-        that was measured and no more.
+        undersized-RAM bug was compensating for an unmodelled MoE term. This
+        assertion therefore pins the part that was measured and no more.
+
+        That MoE term is now modelled (`_moe_prefill_bytes`), and it turned out
+        NOT to be expert dequantization — sorted prefill tiles over packed
+        weights and materializes nothing. It is routing-expanded activations,
+        chunk x top_k wide. This fixture still does not exercise it, because
+        Q35 carries no `moe_intermediate_size`; see the note on the fixture.
 
         TODO: re-measure the real step ceiling for a MoE at 21K on the mini,
-        then model the MoE dequant term and tighten this back up.
+        then tighten this back up.
         """
         pl = self._plan(tmp_path, 12.59, context=21000, kv_bits=8)
         step = pl["projection"]["prefill_step_size"]

--- a/tests/test_plan.py
+++ b/tests/test_plan.py
@@ -46,6 +46,25 @@ Q35 = {
 }
 
 
+# Muse-Glimmer-30B geometry (the real one). Unlike Q35 this carries a
+# vocab_size, and a big one — it is the fixture for anything lm_head-shaped.
+MUSE = {
+    "model_type": "muse_glimmer",
+    "quantization": {"mode": "turboquant", "bits": 3, "group_size": 64},
+    "text_config": {
+        "num_hidden_layers": 32,
+        "hidden_size": 6656,
+        "intermediate_size": 19968,
+        "num_attention_heads": 32,
+        "num_key_value_heads": 8,
+        "head_dim": 128,
+        "vocab_size": 202048,
+        "sliding_window": 2048,
+        "layer_types": (["sliding_attention"] * 3 + ["full_attention"]) * 8,
+    },
+}
+
+
 def _write_model(tmp_path, cfg, tensors):
     """Minimal on-disk model: config.json + one shard whose HEADER is real but
     whose payload is zero-filled (the planner must never read the payload)."""
@@ -209,6 +228,42 @@ class TestWorkspace:
         assert a == pytest.approx(b * 16)          # linear in chunk
         c = prefill_workspace_bytes(Q35, 42000, 128)
         assert c == pytest.approx(b * 2)           # linear in context
+
+    def test_chunked_prefill_does_not_pay_for_the_lm_head(self):
+        """The chunk loop discards the forward's output and evaluates only the
+        cache state; MLX being lazy, the lm_head matmul never runs. Measured on
+        an M4 Max at 2048x202048: dropping the output costs 0 MB, while slicing
+        [:, -1:] out of it costs the full 763 MiB.
+
+        So a big-vocab model prefilled in chunks must be billed attention
+        scratch, NOT chunk x vocab x 2 (0.83 GB at 2048 x 202048 on Muse).
+        """
+        w = prefill_workspace_bytes(MUSE, 5068, 2048)
+        attn = 2048 * 5068 * MUSE["text_config"]["num_attention_heads"] * 2
+        assert w == pytest.approx(attn)
+
+        naive = attn + 2048 * MUSE["text_config"]["vocab_size"] * 2
+        assert naive - w > 0.8 * GB, "the term this test exists to keep out"
+
+    def test_unchunked_prefill_does_pay_for_the_lm_head(self):
+        """A prompt that fits in ONE forward gets no such relief: the engine
+        slices logits[:, -1, :] after the matmul has already run."""
+        w = prefill_workspace_bytes(MUSE, 1500, 2048)
+        heads = MUSE["text_config"]["num_attention_heads"]
+        assert w == pytest.approx(1500 * 1500 * heads * 2
+                                  + 1500 * MUSE["text_config"]["vocab_size"] * 2)
+
+    def test_chunk_never_exceeds_the_prompt(self):
+        """context <= step means the forward is prompt-wide, not step-wide."""
+        assert (prefill_workspace_bytes(MUSE, 900, 2048)
+                == prefill_workspace_bytes(MUSE, 900, 900))
+
+    def test_chunking_crossover_is_a_drop_not_a_jump(self):
+        """Crossing the chunk size must not make the estimate worse: past the
+        bound the lm_head term is elided, which is a saving, not a cost."""
+        just_under = prefill_workspace_bytes(MUSE, 2048, 2048)
+        just_over = prefill_workspace_bytes(MUSE, 2100, 2048)
+        assert just_over < just_under
 
 
 class TestFieldCalibration:


### PR DESCRIPTION
`turboquant-plan`'s prefill projection carried one term that is never paid and was missing another that always is. Both were found by measuring rather than reading, and the measurements are in the code so they can be re-run.

## 1. The lm_head term is free under chunked prefill

The projection billed `chunk x vocab x 2` for every prefill chunk. But both engines chunk prefill (`mlx_lm.generate_step`, mlx-vlm `generate/ar.py`) and both **discard** the chunk forward's return value, evaluating only the KV cache state. MLX is lazy, so an lm_head matmul nobody asks for never runs.

Measured on an M4 Max at `2048 x 202048`, against a floor doing the cache work alone:

| what the graph does | peak over floor |
|---|---|
| output dropped (what the chunk loop does) | **+0 MB** |
| `[:, -1:]` sliced out of it | **+763 MiB** |

Exactly zero, not "small". The sliced case equals a full-eval control, confirming `logits[:, -1, :]` materializes the whole tensor before slicing.

Both loops also leave exactly one token for the scoring step, so the term is real **only** when the prompt fits in a single forward (`context <= step`). The estimate is now the max of the widest chunk pass and the one-token scoring step, rather than a sum of costs that never coexist.

Muse-Glimmer-30B at 5,068 tokens: **5.21 -> 4.39 GB**. The old number made `--prefill-step-size` look like it bought headroom it does not buy.

Also: the chunk can no longer exceed the prompt, so a 900-token prompt is billed as a 900-token forward instead of a 2048-token one.

## 2. The MoE term is activations, not dequantization

This was the standing TODO, and the premise was wrong. Expert dequantization is essentially never paid during prefill: mlx-lm's SwitchGLU sorts any batch of 64+ routings, and sorted batches go to `polar_gather_qmm`, which tiles over **packed** weights.

Measured on a 256-expert block at chunk 2048:

| | peak |
|---|---|
| sorted prefill (the real path) | **357.8 MB** |
| control that dequantizes all experts | **933.8 MB** |

The 768 MB tensor never appears.

What is actually there is routing-expanded activations — SwitchGLU fans every token out to `top_k` rows before the expert matmuls, so the transient scales with `chunk x top_k`, not `chunk`. Measured bytes per routing on one gate/up/down block against the `8 x (hidden + moe_inter)` bound:

| geometry (experts, hidden, moe_inter) | measured | bound |
|---|---|---|
| 256, 2048, 768 (Qwen3.6-35B-A3B) | 21,077 | 22,528 |
| 128, 1024, 2048 (inverted ratio) | 20,564 | 24,576 |
| 64, 4096, 1024 (wide hidden) | 38,984 | 40,960 |
| 256, 2048, 512 (narrow expert) | 19,541 | 20,480 |
| 256, 3072, 1024 (Laguna-S-2.1) | 30,819 | 32,768 |

Never exceeded, 3–16% slack. It is a **bound**, not a fit: it is what the eight live routing-expanded buffers cost if the allocator reused none. Laguna-S-2.1 at 16K context gains 0.67 GB at the default chunk.

The dequant fallback is still charged where it can genuinely fire: expert output dims `polar_gather_qmm` cannot tile (not a multiple of 64), and only below the switch layer's 2 GiB cap, above which it reverts to gather kernels that materialize nothing.

Expert width comes from `moe_intermediate_size`, never `intermediate_size` — on Laguna those are 1024 and 12288, a 12x error. Configs that do not state `num_experts_per_tok` get no term rather than a guessed one.

## Why one is subtracted and the other summed

The MoE term is summed with attention scratch even though attention finishes before the MLP starts, so they do not truly coexist. That is deliberate: both are real and nonzero, and this tool exists to prevent OOMs. It is a different case from the lm_head term, which is dropped because it measured at **exactly zero** — never exists, rather than exists at a different moment. Both rationales are recorded in the docstring.

## On the field calibration

The mini datapoints are unaffected, and I checked rather than assumed. `Q35` carries neither `vocab_size` nor `moe_intermediate_size`, so **both** terms were already zero in every field test — the calibration never depended on either, and its passing is not coverage of them.

That is now stated on the fixture, so it is not mistaken for coverage again. Two new fixtures give real coverage: `MUSE` (202,048 vocab) and `LAGUNA` (read off the shipped `config.json`).

## Verification

**526 passed, 5 skipped** (+6 new tests), including the untouched field-calibration suite.