### PR TITLE
chore: release 0.22.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.22.0] - 2026-08-14
+
+`turboquant-plan` now models prefill the way it actually runs. Two
+corrections, both measured rather than reasoned about: a term it charged for
+that is never paid, and a term it never charged for that always is. Nothing
+outside the planner changes — no conversion, kernel, or serving behaviour is
+touched.
+
 ### Fixed
 
 - **`turboquant-plan` over-estimated prefill workspace on big-vocab models by

--- a/__init__.py
+++ b/__init__.py
@@ -4,6 +4,6 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.21.1"
+__version__ = "0.22.0"
 
 from turboquant_mlx.config import TurboQuantConfig

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.21.1"
+version = "0.22.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Ships the planner corrections from #87. **Planner-only** — no conversion, kernel, or serving behaviour changes, so nothing about existing quantized builds or their outputs moves.

Minor bump rather than a patch: the MoE term is new behaviour (an `### Added`), and projected peaks change for big-vocab and MoE models, which is user-visible in `turboquant-plan` output and in the "Will it fit my Mac?" section of every model card.

## What changed

**A term that was charged but never paid.** `chunk x vocab x 2` for the lm_head output. Both engines discard the prefill chunk's return value and MLX is lazy, so that matmul never runs. Measured at `2048 x 202048`: dropping the output costs **0 MB**, slicing `[:, -1:]` costs **763 MiB**. Muse-Glimmer-30B at 5,068 tokens: 5.21 -> 4.39 GB.

**A term that was never charged but always paid.** MoE routing-expanded activations. Expert *dequantization* turns out to be essentially free during prefill (sorted batches tile over packed weights — 357.8 MB measured against a 933.8 MB dequant-all control), but SwitchGLU fans every token to `top_k` rows, and that was unmodelled. Bounded by `8 x (hidden + moe_inter)` bytes per routing across five geometries, 3–16% slack, never exceeded. Laguna-S-2.1 at 16K: +0.67 GB.

Full rationale and measurement tables in #87 and the CHANGELOG.

## Verification

- **526 passed, 5 skipped**, including the untouched field-calibration suite.
- Built the sdist and installed it into a **clean venv**: `import turboquant_mlx` -> `0.22.0`, and `turboquant-plan` runs end to end on a real Laguna-S-2.1 checkpoint with the new MoE term visible in the projection.

That last step is deliberate. A green publish is not the same as a usable one — this repo has shipped a release that built fine and was broken on install, so the clean-venv check is now part of cutting one.

## After merge

Tag `v0.22.0` -> `release.yml` builds the sdist and publishes `turboquant-mlx-full` to PyPI via OIDC, gated on the manual `pypi` environment approval.