### PR TITLE
chore(deps): only open GitHub Actions PRs for major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,7 +14,19 @@ updates:
         patterns:
           - "mlx*"
 
-  # GitHub Actions versions in workflow files
+  # GitHub Actions versions in workflow files.
+  #
+  # Every action here tracks a floating MAJOR tag (actions/checkout@v7,
+  # github/codeql-action@v4, ...), which is what GitHub recommends: patches and
+  # security fixes to the action arrive automatically, including to the security
+  # scanner itself. Patch/minor PRs would therefore only ever propose replacing
+  # a working floating tag with an exact pin that goes stale immediately —
+  # codeql-action alone patches often enough to consume the whole PR budget
+  # below (see #72).
+  #
+  # Note an exact version tag is NOT immutable; genuine supply-chain pinning
+  # needs a full commit SHA. So pinning to a patch buys the churn without the
+  # security property. Majors still open a PR, because those need a human.
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
@@ -23,3 +35,8 @@ updates:
     labels:
       - "dependencies"
       - "github-actions"
+    ignore:
+      - dependency-name: "*"
+        update-types:
+          - "version-update:semver-patch"
+          - "version-update:semver-minor"


### PR DESCRIPTION
Follow-up to closing #72.

Every action in this repo tracks a floating **major** tag — `actions/checkout@v7`, `actions/setup-python@v7`, `actions/upload-artifact@v7`, `github/codeql-action@v4`, `pypa/gh-action-pypi-publish@release/v1`. That is GitHub's recommended usage, and it means patches and security fixes to the action arrive automatically — including to the security scanner itself.

Given that, a patch/minor Dependabot PR can only ever propose replacing a working floating tag with an exact pin. That trade loses in both directions:

- **Churn.** `codeql-action` patches frequently enough to consume the entire `open-pull-requests-limit: 3` on its own, crowding out updates that matter. #72 sat open for two weeks and was already superseded by the time it was read.
- **No actual hardening.** An exact version tag is mutable — it can be repointed. Genuine supply-chain pinning requires a full commit SHA. `@v4.37.3` therefore costs the noise of pinning without the immutability people pin for.

So: ignore patch and minor for actions. **Majors still open a PR**, because a v4 → v5 jump changes behaviour and needs a human.

## Not changed

The `pip` block is untouched. Python dependency patches genuinely matter here, and the `mlx-stack` grouping stays as is. This only narrows the `github-actions` ecosystem.

If the goal ever becomes real supply-chain hardening, the move is SHA-pinning every action across all five workflows and letting Dependabot maintain the SHAs — a different, larger change, and arguably not worth it for a repo whose sensitive surface is OIDC publishing rather than CodeQL.