### PR TITLE
fix(tests): close the index file flagged by CodeQL

### DIFF
--- a/tests/test_convert_streaming.py
+++ b/tests/test_convert_streaming.py
@@ -31,7 +31,8 @@ def test_streaming_shard_writer_multishard():
         n = w.finalize()
         assert n >= 2, f"expected multiple shards, got {n}"
 
-        idx = json.load(open(Path(d) / "model.safetensors.index.json"))
+        with open(Path(d) / "model.safetensors.index.json") as fh:
+            idx = json.load(fh)
         assert set(idx["weight_map"]) == set(tensors)
         assert idx["metadata"]["total_size"] == sum(v.nbytes for v in tensors.values())
         # every referenced shard file actually exists


### PR DESCRIPTION
Clears the two open `py/file-not-closed` alerts — one by fixing it, one by dismissing it, because only one is real.

## Real: `tests/test_convert_streaming.py:34` (alert #41)

```python
-idx = json.load(open(Path(d) / "model.safetensors.index.json"))
+with open(Path(d) / "model.safetensors.index.json") as fh:
+    idx = json.load(fh)
```

The handle stayed open until GC. Harmless inside a `TemporaryDirectory`, but real, and this was the last instance of the pattern anywhere in the tree.

## Not real: `stream/safetensors_reader.py:80` (alert #51) — dismissed

`SafetensorsExpertReader` opens one fd per shard and **keeps them**, because reads are plain `os.pread` against persistent descriptors — that is the design, not an oversight. They are released in `close()` (L165), with `__del__` as a backstop (L173), and the one call site owning a short-lived reader (`stream/calibrate_experts.py:98`) calls `close()` explicitly. The other (`stream/loader.py:319`) holds the reader for the model's lifetime by intent.

CodeQL's `py/file-not-closed` does not follow that class-level lifecycle, so it is dismissed as a false positive rather than papered over with a `with` block that would break streaming.

## Note on C++ scanning

While here: the CodeQL workflow scans **Python only**, and should stay that way. The repo tracks zero C/C++/ObjC/Metal sources and has no `CMakeLists.txt` or `setup.py` — the Metal kernels are Python f-strings built at runtime. Adding `cpp` to the matrix would fail the job with "No source code was seen during the build" on every PR.

**526 passed, 5 skipped.**