### PR TITLE
test: audit every converter flag for actually doing something

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **The dense group-size compatibility check validated the wrong value.** It
+  tested `input_dims % tq_config.group_size` while the layer is quantized at
+  `group_size_for_path(path)`, so with e.g. `--group-size 64
+  --mlp-group-size 128` an MLP whose `input_dims` divides 64 but not 128
+  passed the check and then raised inside `polar_quantize_weight`. The MoE
+  branch already checked the per-path value; the dense branch now does too.
+
 - **`--mlp-group-size` silently did nothing on dense models.** Found by a
   systematic audit of every converter flag (see below). `bits_for_path`
   applies `--mlp-bits` to dense MLP linears, but the dense branch of the
@@ -48,9 +55,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
   15 effect cases across dense and MoE, covering `bits`, `group_size`,
   `rotation`, `rotation_seed`, `attn_bits`, `mlp_bits`, `mlp_group_size`,
-  `use_qjl`, `ternary_experts` and `expert_down_bits`. All pass.
+  `use_qjl`, `ternary_experts` and `expert_down_bits`, plus a save/load
+  round-trip pinning the per-layer group-size derivation. All pass.
 
-### Fixed
+  The fingerprint hashes each parameter in its **own** dtype rather than
+  widening to float32. Packed weights are `uint32` and reach ~1.07e9 in
+  practice, 64x past float32's exact-integer limit of 2^24, so widening would
+  round distinct packings onto the same value and report "unchanged" for
+  genuinely different weights — a false pass in exactly the direction that
+  hides the bug being hunted.
 
 - **`--rotation` was accepted, stored, printed — and ignored.** All three
   values produced identical output. `polar_quantize_weight` had no rotation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,50 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Fixed
 
+- **`--mlp-group-size` silently did nothing on dense models.** Found by a
+  systematic audit of every converter flag (see below). `bits_for_path`
+  applies `--mlp-bits` to dense MLP linears, but the dense branch of the
+  quantizer asked for `tq_config.group_size` directly instead of
+  `group_size_for_path`, so its documented sibling `--mlp-group-size` reached
+  MoE experts only. The two are documented as a matched pair; they now behave
+  like one. No shipped model is affected — the loader read the base group
+  size too, so convert and load agreed and no checkpoint was mis-scaled, and
+  no local or published model sets the flag. Default conversions remain
+  byte-identical (Llama-3.2-1B, SHA256 `99def7a6…`).
+
+- **The loader now recovers each layer's group size from the saved scales
+  rather than re-deriving it from the config rules.** `scales` are
+  `(..., output_dims, n_groups)` with `n_groups = input_dims // group_size`,
+  so the on-disk tensor states the group size exactly. Re-deriving it meant
+  any change to the path rules would silently mis-scale every older
+  checkpoint — the failure mode `CLAUDE.md` records as having already caused
+  one real bug, and the reason the fix above would otherwise have been unsafe
+  to ship. This also makes per-layer group sizes work end to end: a model
+  converted with `--group-size 64 --mlp-group-size 32` now loads with
+  attention at 64 and MLP at 32 and generates correctly.
+
+### Added
+
+- **`tests/test_flag_effects.py` — a mechanical audit of the whole flag
+  surface**, in two independent layers, because a flag can break at either.
+  A *static* pass asserts every `--flag` declared by an entry point is read
+  somewhere in that module (catches "declared and forgotten"), and a
+  *behavioural* pass asserts each config field actually changes the quantized
+  bytes (catches "plumbed all the way through, then ignored" — exactly how
+  `--rotation` passed every review for the project's entire history).
+  Documented no-ops are asserted to stay no-ops, so a flag leaking into
+  layers it should not touch fails too.
+
+  The fingerprint hashes parameter **bytes**, not just shapes. Shapes stay
+  correct no matter which domain the numbers live in, which is precisely why
+  the existing suite missed the rotation bugs.
+
+  15 effect cases across dense and MoE, covering `bits`, `group_size`,
+  `rotation`, `rotation_seed`, `attn_bits`, `mlp_bits`, `mlp_group_size`,
+  `use_qjl`, `ternary_experts` and `expert_down_bits`. All pass.
+
+### Fixed
+
 - **`--rotation` was accepted, stored, printed — and ignored.** All three
   values produced identical output. `polar_quantize_weight` had no rotation
   parameter at all, so the randomized Hadamard was applied unconditionally;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,8 +41,9 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 - **`tests/test_flag_effects.py` — a mechanical audit of the whole flag
   surface**, in two independent layers, because a flag can break at either.
-  A *static* pass asserts every `--flag` declared by an entry point is read
-  somewhere in that module (catches "declared and forgotten"), and a
+  A *static* pass asserts every `--flag` declared by an entry point is
+  actually read off the `parse_args()` namespace (catches "declared and
+  forgotten"), and a
   *behavioural* pass asserts each config field actually changes the quantized
   bytes (catches "plumbed all the way through, then ignored" — exactly how
   `--rotation` passed every review for the project's entire history).

--- a/generate.py
+++ b/generate.py
@@ -106,6 +106,24 @@ def _prepare_polar_layers(model, weights, tq_config):
             if (1 << layer_bits) != cb_size:  # non-power-of-two: fall back
                 layer_bits = tq_config.bits_for_path(path)
 
+        def _group_size_for(input_dims: int) -> int:
+            """Recover the group size from the saved scales, not the config.
+
+            scales are (..., output_dims, n_groups) with
+            n_groups = input_dims // group_size, so the on-disk tensor states
+            the group size exactly. Re-deriving it from the config rules
+            instead means any change to those rules silently misreads every
+            older checkpoint — the failure mode CLAUDE.md records as having
+            already caused one real bug. Falls back to the config rule only
+            when scales are absent.
+            """
+            sc = weights.get(f"{path}.scales")
+            if sc is not None and sc.shape[-1] > 0:
+                derived, rem = divmod(input_dims, int(sc.shape[-1]))
+                if rem == 0 and derived > 0:
+                    return derived
+            return tq_config.group_size_for_path(path)
+
         if has_switch and isinstance(module, SwitchLinear):
             num_experts, output_dims, input_dims = module.weight.shape
             pq = PolarQuantizedSwitchLinear(
@@ -117,7 +135,7 @@ def _prepare_polar_layers(model, weights, tq_config):
                 # Match the convert side, which quantizes experts at
                 # group_size_for_path — so a model built with a finer
                 # --mlp-group-size loads with the correct scale shape.
-                group_size=tq_config.group_size_for_path(path),
+                group_size=_group_size_for(input_dims),
                 trit=is_trit,
                 needs_rotation=needs_rotation,
             )
@@ -129,7 +147,7 @@ def _prepare_polar_layers(model, weights, tq_config):
                 output_dims=output_dims,
                 bias=has_bias,
                 bits=layer_bits,
-                group_size=tq_config.group_size,
+                group_size=_group_size_for(input_dims),
                 use_qjl=has_qjl,
                 needs_rotation=needs_rotation,
             )

--- a/quantize_model.py
+++ b/quantize_model.py
@@ -256,10 +256,14 @@ def turboquant_quantize(
             del module
             continue
 
-        # Check group_size compatibility
+        # Check group_size compatibility against the group size this layer
+        # will ACTUALLY be quantized at — --mlp-group-size can differ from the
+        # base, and validating the base would let a layer past the check and
+        # then fail inside polar_quantize_weight.
         _, input_dims = module.weight.shape
-        if input_dims % tq_config.group_size != 0:
-            print(f"[WARNING] Skipping {path}: input_dims={input_dims} not divisible by group_size={tq_config.group_size}")
+        layer_group_size = tq_config.group_size_for_path(path)
+        if input_dims % layer_group_size != 0:
+            print(f"[WARNING] Skipping {path}: input_dims={input_dims} not divisible by group_size={layer_group_size}")
             n_skipped += 1
             del module
             continue
@@ -277,11 +281,11 @@ def turboquant_quantize(
         pq_layer = PolarQuantizedLinear.from_linear(
             module,
             bits=layer_bits,
-            # group_size_for_path, not the base group_size: --mlp-group-size
-            # must reach dense MLP linears exactly as --mlp-bits already does.
-            # (The loader recovers the real value from the saved scales, so
-            # this rule changing cannot desync convert from load.)
-            group_size=tq_config.group_size_for_path(path),
+            # Per-path, not the base group_size: --mlp-group-size must reach
+            # dense MLP linears exactly as --mlp-bits already does. (The loader
+            # recovers the real value from the saved scales, so this rule
+            # changing cannot desync convert from load.)
+            group_size=layer_group_size,
             seed=seed,
             needs_rotation=needs_rotation,
             use_qjl=tq_config.use_qjl,

--- a/quantize_model.py
+++ b/quantize_model.py
@@ -277,7 +277,11 @@ def turboquant_quantize(
         pq_layer = PolarQuantizedLinear.from_linear(
             module,
             bits=layer_bits,
-            group_size=tq_config.group_size,
+            # group_size_for_path, not the base group_size: --mlp-group-size
+            # must reach dense MLP linears exactly as --mlp-bits already does.
+            # (The loader recovers the real value from the saved scales, so
+            # this rule changing cannot desync convert from load.)
+            group_size=tq_config.group_size_for_path(path),
             seed=seed,
             needs_rotation=needs_rotation,
             use_qjl=tq_config.use_qjl,

--- a/tests/test_flag_effects.py
+++ b/tests/test_flag_effects.py
@@ -26,6 +26,7 @@ import pathlib
 
 import mlx.core as mx
 import mlx.nn as nn
+import numpy as np
 import pytest
 
 from turboquant_mlx.config import TurboQuantConfig
@@ -96,19 +97,26 @@ def _flatten(prefix, obj, out):
 
 
 def _fingerprint(model):
-    """Hash every quantized parameter: name, shape, dtype and bytes.
+    """Hash every quantized parameter: name, shape, dtype and native bytes.
 
     Shape alone is not enough — that is precisely what let a rotated-vs-
     unrotated mixup through. The bytes are the part that has to move.
+
+    Hashed in the parameter's OWN dtype, never widened to float32. Packed
+    weights are uint32, and float32 has a 24-bit mantissa, so casting would
+    round distinct packings onto the same value and make this audit report
+    "unchanged" for genuinely different weights — a false pass in the exact
+    direction that hides the bug being hunted.
     """
     items = []
     _flatten("", model.parameters(), items)
     h = hashlib.sha256()
     for name, arr in sorted(items):
+        mx.eval(arr)
         h.update(name.encode())
         h.update(str(arr.shape).encode())
         h.update(str(arr.dtype).encode())
-        h.update(bytes(memoryview(mx.array(arr).astype(mx.float32))))
+        h.update(np.ascontiguousarray(np.array(arr, copy=False)).tobytes())
     return h.hexdigest()
 
 
@@ -164,6 +172,59 @@ def test_flag_changes_output(label, moe, override, should_change):
         )
 
 
+def test_mixed_group_sizes_survive_a_save_load_round_trip():
+    """A checkpoint whose layers use DIFFERENT group sizes must reload right.
+
+    ``--group-size 64 --mlp-group-size 32`` produces attention and MLP tiers
+    with different scale shapes in one file. The loader must take each layer's
+    group size from its saved scales rather than re-deriving it from the
+    config rules — so the reload here is deliberately given a config whose
+    rules would answer 64 for the MLP. If the derivation regresses to reading
+    the config, the MLP scales are misread and the outputs diverge.
+    """
+    from turboquant_mlx.generate import _prepare_polar_layers
+
+    mx.random.seed(0)
+    cfg = {"model_type": "llama", "hidden_size": _DIM,
+           "num_hidden_layers": 2, "num_attention_heads": 4}
+    quantized, _ = turboquant_quantize(
+        _Tiny(e=0), cfg,
+        TurboQuantConfig(bits=3, group_size=64, mlp_group_size=32),
+    )
+    mx.eval(quantized.parameters())
+
+    items = []
+    _flatten("", quantized.parameters(), items)
+    weights = dict(items)
+
+    # The two tiers really are stored at different granularities.
+    assert weights["layers.0.self_attn.q_proj.scales"].shape[-1] == _DIM // 64
+    assert weights["layers.0.mlp.gate_proj.scales"].shape[-1] == _DIM // 32
+
+    # Reload with a config that does NOT mention mlp_group_size: its rules say
+    # 64 everywhere, so only the saved scales can give the MLP its true 32.
+    reloaded = _Tiny(e=0)
+    _prepare_polar_layers(reloaded, weights,
+                          TurboQuantConfig(bits=3, group_size=64))
+    reloaded.load_weights(list(weights.items()), strict=False)
+    mx.eval(reloaded.parameters())
+
+    assert reloaded.layers[0].self_attn.q_proj.group_size == 64
+    assert reloaded.layers[0].mlp.gate_proj.group_size == 32
+
+    x = mx.random.normal((2, _DIM)).astype(mx.float16)
+    for getter in (lambda m: m.layers[0].self_attn.q_proj,
+                   lambda m: m.layers[0].mlp.gate_proj):
+        want = getter(quantized)(x)
+        got = getter(reloaded)(x)
+        assert mx.allclose(want, got, atol=1e-4).item(), (
+            "mixed-group-size checkpoint did not reload identically — the "
+            "loader is not taking the group size from the saved scales"
+        )
+
+    print("test_mixed_group_sizes_survive_a_save_load_round_trip: PASSED")
+
+
 _ENTRY_POINTS = ["convert.py", "convert_vlm.py"]
 
 
@@ -179,26 +240,26 @@ def test_every_cli_flag_is_referenced(module):
 
     declared = set()
     for node in ast.walk(tree):
-        if (isinstance(node, ast.Call)
+        if not (isinstance(node, ast.Call)
                 and isinstance(node.func, ast.Attribute)
                 and node.func.attr == "add_argument"):
-            for arg in node.args:
-                if isinstance(arg, ast.Constant) and str(arg.value).startswith("--"):
-                    declared.add(str(arg.value)[2:].replace("-", "_"))
+            continue
+        explicit = next(
+            (str(kw.value.value) for kw in node.keywords
+             if kw.arg == "dest" and isinstance(kw.value, ast.Constant)),
+            None,
+        )
+        for arg in node.args:
+            if isinstance(arg, ast.Constant) and str(arg.value).startswith("--"):
+                # argparse derives the attribute from the option name unless
+                # dest= overrides it; check whichever one actually gets read.
+                declared.add(explicit or str(arg.value)[2:].replace("-", "_"))
 
+    # Reads only. Deliberately NOT seeded with the dest= values themselves:
+    # declaring `dest="x"` is not evidence that anything ever reads `args.x`,
+    # and counting it as such would make every dest-renamed flag pass for free.
     used = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
     used |= {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
-    used |= {kw.arg for n in ast.walk(tree)
-             if isinstance(n, ast.Call) for kw in n.keywords if kw.arg}
-
-    # `dest=` renames the attribute, so honour it before declaring a miss.
-    for node in ast.walk(tree):
-        if (isinstance(node, ast.Call)
-                and isinstance(node.func, ast.Attribute)
-                and node.func.attr == "add_argument"):
-            for kw in node.keywords:
-                if kw.arg == "dest" and isinstance(kw.value, ast.Constant):
-                    used.add(str(kw.value.value))
 
     orphans = sorted(f for f in declared if f not in used)
     assert not orphans, (

--- a/tests/test_flag_effects.py
+++ b/tests/test_flag_effects.py
@@ -1,0 +1,206 @@
+"""Every knob must actually do something.
+
+The failure mode this file exists to catch is the one that hid three separate
+bugs: a flag that is accepted, validated, stored into ``config.json``, printed
+at conversion time — and never reaches the quantizer. ``--rotation`` shipped
+that way for the project's entire history; ``--fuse-rotations`` shipped a
+variant of it that produced word salad; ``--mlp-group-size`` silently did
+nothing on dense models.
+
+None of those were exotic code paths. They were documented CLI flags, and the
+reason none of the existing tests caught them is that every test asserted on
+*shapes*, which stay correct no matter which domain the numbers live in.
+
+Two independent layers here, because a flag can break at either:
+
+1. :func:`test_every_cli_flag_is_referenced` — static. Does the argparse flag
+   reach anything at all? Catches "defined and forgotten".
+2. ``test_flag_changes_output`` — behavioural. Does the config field change
+   the quantized bytes? Catches "plumbed all the way through and then
+   ignored", which is exactly how ``--rotation`` passed every review.
+"""
+
+import ast
+import hashlib
+import pathlib
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from turboquant_mlx.config import TurboQuantConfig
+from turboquant_mlx.quantize_model import turboquant_quantize
+
+try:
+    from mlx_lm.models.switch_layers import SwitchLinear
+    HAVE_SWITCH = True
+except ImportError:  # pragma: no cover - mlx_lm is a hard dep in practice
+    HAVE_SWITCH = False
+
+_DIM, _HIDDEN, _EXPERTS = 128, 256, 4
+
+
+class _Attn(nn.Module):
+    def __init__(self, d):
+        super().__init__()
+        self.q_proj = nn.Linear(d, d, bias=False)
+        self.k_proj = nn.Linear(d, d, bias=False)
+        self.v_proj = nn.Linear(d, d, bias=False)
+        self.o_proj = nn.Linear(d, d, bias=False)
+
+
+class _DenseMLP(nn.Module):
+    def __init__(self, d, h):
+        super().__init__()
+        self.gate_proj = nn.Linear(d, h, bias=False)
+        self.up_proj = nn.Linear(d, h, bias=False)
+        self.down_proj = nn.Linear(h, d, bias=False)
+
+
+class _Experts(nn.Module):
+    def __init__(self, d, h, e):
+        super().__init__()
+        self.gate_proj = SwitchLinear(d, h, e, bias=False)
+        self.up_proj = SwitchLinear(d, h, e, bias=False)
+        self.down_proj = SwitchLinear(h, d, e, bias=False)
+
+
+class _MoEMLP(nn.Module):
+    def __init__(self, d, h, e):
+        super().__init__()
+        self.switch_mlp = _Experts(d, h, e)
+
+
+class _Block(nn.Module):
+    def __init__(self, d, h, e):
+        super().__init__()
+        self.self_attn = _Attn(d)
+        self.mlp = _MoEMLP(d, h, e) if e else _DenseMLP(d, h)
+
+
+class _Tiny(nn.Module):
+    def __init__(self, e=0, n=2):
+        super().__init__()
+        self.layers = [_Block(_DIM, _HIDDEN, e) for _ in range(n)]
+
+
+def _flatten(prefix, obj, out):
+    if isinstance(obj, mx.array):
+        out.append((prefix, obj))
+    elif isinstance(obj, dict):
+        for k, v in obj.items():
+            _flatten(f"{prefix}.{k}" if prefix else k, v, out)
+    elif isinstance(obj, (list, tuple)):
+        for i, v in enumerate(obj):
+            _flatten(f"{prefix}.{i}", v, out)
+
+
+def _fingerprint(model):
+    """Hash every quantized parameter: name, shape, dtype and bytes.
+
+    Shape alone is not enough — that is precisely what let a rotated-vs-
+    unrotated mixup through. The bytes are the part that has to move.
+    """
+    items = []
+    _flatten("", model.parameters(), items)
+    h = hashlib.sha256()
+    for name, arr in sorted(items):
+        h.update(name.encode())
+        h.update(str(arr.shape).encode())
+        h.update(str(arr.dtype).encode())
+        h.update(bytes(memoryview(mx.array(arr).astype(mx.float32))))
+    return h.hexdigest()
+
+
+def _quantize(moe, **overrides):
+    mx.random.seed(0)
+    model = _Tiny(e=_EXPERTS if moe else 0)
+    cfg = {"model_type": "llama", "hidden_size": _DIM,
+           "num_hidden_layers": 2, "num_attention_heads": 4}
+    tq = TurboQuantConfig(**{"bits": 3, "group_size": 64, **overrides})
+    model, _ = turboquant_quantize(model, cfg, tq)
+    mx.eval(model.parameters())
+    return _fingerprint(model)
+
+
+# (id, moe?, config override, must the output change?)
+_CASES = [
+    ("bits=4",                 False, dict(bits=4),                        True),
+    ("bits=2",                 False, dict(bits=2),                        True),
+    ("group_size=32",          False, dict(group_size=32),                 True),
+    ("rotation=none",          False, dict(rotation="none"),               True),
+    ("rotation_seed=7",        False, dict(rotation_seed=7),               True),
+    ("attn_bits=2",            False, dict(attn_bits=2),                   True),
+    ("mlp_bits=2",             False, dict(mlp_bits=2),                    True),
+    ("mlp_group_size=32",      False, dict(mlp_group_size=32),             True),
+    ("use_qjl",                False, dict(use_qjl=True),                  True),
+    ("mlp_bits=2 (moe)",       True,  dict(mlp_bits=2),                    True),
+    ("ternary_experts (moe)",  True,  dict(ternary_experts=True),          True),
+    ("expert_down_bits (moe)", True,  dict(expert_down_bits=4),            True),
+    # Documented no-ops. These must NOT change anything, or the flag is
+    # leaking into layers it was never meant to touch.
+    ("blockwise is an alias",  False, dict(rotation="blockwise_hadamard"), False),
+    ("ternary_experts (dense)", False, dict(ternary_experts=True),         False),
+    ("expert_down_bits (dense)", False, dict(expert_down_bits=4),          False),
+]
+
+
+@pytest.mark.parametrize("label,moe,override,should_change",
+                         _CASES, ids=[c[0] for c in _CASES])
+def test_flag_changes_output(label, moe, override, should_change):
+    if moe and not HAVE_SWITCH:
+        pytest.skip("mlx_lm SwitchLinear unavailable")
+    base = _quantize(moe)
+    varied = _quantize(moe, **override)
+    if should_change:
+        assert base != varied, (
+            f"{label} did not change the quantized output — the setting is "
+            f"being accepted and then ignored"
+        )
+    else:
+        assert base == varied, (
+            f"{label} changed the quantized output but is documented as a "
+            f"no-op — it is leaking into layers it should not touch"
+        )
+
+
+_ENTRY_POINTS = ["convert.py", "convert_vlm.py"]
+
+
+@pytest.mark.parametrize("module", _ENTRY_POINTS)
+def test_every_cli_flag_is_referenced(module):
+    """Each ``--flag`` must be read somewhere in its own module.
+
+    Static half of the audit: catches a flag that is declared and then never
+    consulted. Cheap, and it runs without touching MLX at all.
+    """
+    src = (pathlib.Path(__file__).resolve().parents[1] / module).read_text()
+    tree = ast.parse(src)
+
+    declared = set()
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add_argument"):
+            for arg in node.args:
+                if isinstance(arg, ast.Constant) and str(arg.value).startswith("--"):
+                    declared.add(str(arg.value)[2:].replace("-", "_"))
+
+    used = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
+    used |= {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    used |= {kw.arg for n in ast.walk(tree)
+             if isinstance(n, ast.Call) for kw in n.keywords if kw.arg}
+
+    # `dest=` renames the attribute, so honour it before declaring a miss.
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Attribute)
+                and node.func.attr == "add_argument"):
+            for kw in node.keywords:
+                if kw.arg == "dest" and isinstance(kw.value, ast.Constant):
+                    used.add(str(kw.value.value))
+
+    orphans = sorted(f for f in declared if f not in used)
+    assert not orphans, (
+        f"{module}: CLI flags declared but never read: {orphans}"
+    )

--- a/tests/test_flag_effects.py
+++ b/tests/test_flag_effects.py
@@ -249,17 +249,59 @@ def test_every_cli_flag_is_referenced(module):
              if kw.arg == "dest" and isinstance(kw.value, ast.Constant)),
             None,
         )
-        for arg in node.args:
-            if isinstance(arg, ast.Constant) and str(arg.value).startswith("--"):
-                # argparse derives the attribute from the option name unless
-                # dest= overrides it; check whichever one actually gets read.
-                declared.add(explicit or str(arg.value)[2:].replace("-", "_"))
+        # argparse derives the dest from the FIRST long option only; any
+        # further strings are aliases sharing that same dest (convert.py
+        # declares "--hf-path", "--model" on one call, and there is no
+        # args.model). An explicit dest= overrides all of them.
+        first_long = next(
+            (str(a.value) for a in node.args
+             if isinstance(a, ast.Constant) and str(a.value).startswith("--")),
+            None,
+        )
+        if first_long is not None:
+            declared.add(explicit or first_long[2:].replace("-", "_"))
 
-    # Reads only. Deliberately NOT seeded with the dest= values themselves:
-    # declaring `dest="x"` is not evidence that anything ever reads `args.x`,
-    # and counting it as such would make every dest-renamed flag pass for free.
-    used = {n.attr for n in ast.walk(tree) if isinstance(n, ast.Attribute)}
-    used |= {n.id for n in ast.walk(tree) if isinstance(n, ast.Name)}
+    # Only reads off the parsed namespace count. Matching bare attribute or
+    # variable names anywhere in the module makes this check near-vacuous:
+    # `--bits` would look "read" because `config.bits` or a local `bits`
+    # exists, and an orphaned flag sails through. Verified: with that looser
+    # rule, deleting every `args.bits` read still passed.
+    namespaces = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Assign):
+            continue
+        call = node.value
+        if (isinstance(call, ast.Call)
+                and isinstance(call.func, ast.Attribute)
+                and call.func.attr in ("parse_args", "parse_known_args")):
+            for tgt in node.targets:
+                if isinstance(tgt, ast.Name):
+                    namespaces.add(tgt.id)
+                elif isinstance(tgt, ast.Tuple):  # parse_known_args() -> (ns, rest)
+                    for el in tgt.elts:
+                        if isinstance(el, ast.Name):
+                            namespaces.add(el.id)
+                            break
+
+    assert namespaces, f"{module}: found no parse_args() result to check against"
+
+    used = {
+        n.attr for n in ast.walk(tree)
+        if isinstance(n, ast.Attribute)
+        and isinstance(n.value, ast.Name)
+        and n.value.id in namespaces
+        and isinstance(n.ctx, ast.Load)
+    }
+    # getattr(args, "x") / vars(args)["x"] style reads
+    for node in ast.walk(tree):
+        if (isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "getattr"
+                and len(node.args) >= 2
+                and isinstance(node.args[0], ast.Name)
+                and node.args[0].id in namespaces
+                and isinstance(node.args[1], ast.Constant)):
+            used.add(str(node.args[1].value))
 
     orphans = sorted(f for f in declared if f not in used)
     assert not orphans, (


### PR DESCRIPTION
Follow-up to #92, which found three bugs sharing one shape: a flag accepted, validated, stored in `config.json`, printed at conversion time — and never reaching the quantizer.

This adds the mechanical guard for that class, and fixes the one remaining instance it found.

## The audit

`tests/test_flag_effects.py`, in two independent layers because a flag can break at either:

1. **Static** — every `--flag` an entry point declares must be read somewhere in that module. Catches "declared and forgotten".
2. **Behavioural** — each config field must change the quantized **bytes**. Catches "plumbed all the way through, then ignored", which is how `--rotation` passed every review for the project's entire history.

Hashing bytes rather than shapes is the load-bearing choice: shapes stay correct no matter which domain the numbers live in, which is exactly why the existing suite missed the rotation bugs. Documented no-ops are asserted to *stay* no-ops, so a flag leaking into layers it shouldn't touch fails too.

15 effect cases across dense and MoE: `bits`, `group_size`, `rotation`, `rotation_seed`, `attn_bits`, `mlp_bits`, `mlp_group_size`, `use_qjl`, `ternary_experts`, `expert_down_bits`.

## What it found

**`--mlp-group-size` did nothing on dense models.** The dense branch asked for `tq_config.group_size` instead of `group_size_for_path`, so the flag reached MoE experts only — while its documented sibling `--mlp-bits` reached both.

Fixing that alone would have been unsafe: the loader re-derived group size from the same config rules, so changing the rule would silently mis-scale every older checkpoint. So **the loader now recovers each layer's group size from the saved scales**, which state it exactly (`n_groups = input_dims // group_size`). That removes the whole class of convert/load group-size disagreement — the failure mode `CLAUDE.md` records as having already caused one real bug — and makes per-layer group sizes work end to end.

## Verification

- Default conversions byte-identical: Llama-3.2-1B `SHA256 99def7a6…`
- Mixed group sizes work: `--group-size 64 --mlp-group-size 32` → attention 32 groups, MLP 64 groups, loads and generates correctly
- Audit catches its own regression: reverting the fix fails with *"mlp_group_size=32 did not change the quantized output — the setting is being accepted and then ignored"*
- Revalidated on Laguna-S-2.1 tqTe (256-expert MoE + ternary) and Muse Glimmer tq4 (VLM)
- **546 passed, 5 skipped**

No shipped model affected — no local or published model sets `mlp_group_size`, and convert/load previously agreed on the base value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantized model loading by recovering per-layer group sizes from saved scale data.
  * Fixed dense-model handling of path-specific MLP group sizes.
  * Standardized group-size selection for linear-layer quantization.
  * Improved support for distinct attention and MLP group sizes.

* **Tests**
  * Added coverage verifying supported configuration flags affect quantized outputs as documented.
  * Added checks for no-op flags, save/load behavior, and undeclared flag usage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->