### PR TITLE
chore: release 0.23.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-08-15
+
+A correctness release. Every item below is a setting that was accepted,
+validated, stored in `config.json` and printed at conversion time — and then
+did not reach the quantizer. Two produced word salad when used; one made a
+layer 10.6x worse than not using it at all.
+
+**No shipped model is affected and no default output changes.** Verified by
+converting Llama-3.2-1B before and after under a fixed `PYTHONHASHSEED`: the
+`model.safetensors` are byte-identical (SHA256 `99def7a6…`). Additionally
+validated on Laguna-S-2.1 tqTe (256-expert MoE + ternary), Muse Glimmer 30B
+tq4 (VLM), and Laguna under expert streaming.
+
+The last entry is what keeps this from recurring: a mechanical audit of the
+flag surface, which is what found the `--mlp-group-size` bug.
+
 ### Fixed
 
 - **The dense group-size compatibility check validated the wrong value.** It

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.22.0"
+__version__ = "0.23.0"
 
 from turboquant_mlx.config import TurboQuantConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.22.0"
+version = "0.23.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump + CHANGELOG cut for **0.23.0**. Merging this, then pushing a `v0.23.0` tag, triggers `release.yml` (OIDC publish, gated on the manual `pypi` environment approval).

## What's in it

A correctness release. Five settings that were accepted, validated, stored in `config.json` and printed at conversion time — and then never reached the quantizer:

| Setting | Was |
|---|---|
| `--fuse-rotations` | Mathematically impossible; word salad when enabled (**removed**) |
| `--rotation` | Completely ignored — all three values byte-identical |
| `--mlp-group-size` | Inert on dense models |
| QJL residual | Measured in the wrong domain — **10.6× worse** than no correction |
| Fused Metal kernels | Could not compile against bfloat16 activations |

Plus a legacy guard so pre-0.23 checkpoints carrying `rotation: "none"` (which have *rotated* weights, since the flag did nothing) still load correctly.

## Nothing shipped changes

Llama-3.2-1B converts **byte-identically** before and after under a fixed `PYTHONHASHSEED` — SHA256 `99def7a6…`.

## Validation

- **547 passed**, 5 skipped, on Python 3.10 / 3.11 / 3.12
- Real models: Llama-3.2-1B (dense), Qwen3-0.6B (dense), Laguna-S-2.1 tqTe (256-expert MoE + ternary), Muse Glimmer 30B tq4 (VLM), Laguna under expert streaming
- **Clean-venv check**: sdist builds, installs into a fresh venv with no repo on the path, exposes the public API, carries all four fixes, and `turboquant-plan` runs end-to-end on a real 118B MoE

## Still Beta

The `Development Status :: 4 - Beta` classifier is unchanged. `Production/Stable` should land with **1.0.0** — a Stable classifier on a `0.x` version contradicts semver.