### PR TITLE
feat(qwen3_5): VLM support, and keep lm_head off the polar path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,11 +27,21 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### Added
 
+- **`generate_vlm --prefill-step-size`.** The VLM generate path had no way to
+  set the prefill chunk size, so the planner could recommend a value that was
+  not runnable there (`turboquant-plan` suggests one whenever the default would
+  not fit). It is the main memory knob for long prompts: on Qwen3.8-27B with a
+  1342-token prompt, `--prefill-step-size 256` measures **16.77 GB peak against
+  21.28 GB** at the 2048 default, for 2.1x slower prefill. mlx-vlm only chunks
+  *above* the step size, so prompts shorter than it run unchunked.
+
 - **Qwen3.8-27B validated** (dense 27.8B hybrid Gated-DeltaNet VLM, 48 linear +
   16 full attention layers). `tq4-g64` = 15.15 GiB, `tq3-g64` = 12.88 GiB; both
   pass an Opencode agentic task and the vision path. `tq4` is both faster and
-  better than `tq3` here. No architecture work was needed — mlx-lm 0.31.3 and
-  mlx-vlm 0.6.3 already carry `qwen3_5`.
+  better than `tq3` here. No architecture work was needed — mlx-lm 0.31.3
+  already carries `qwen3_5`. Verified on **both mlx-vlm 0.6.3 and 0.6.13**
+  (identical peaks and identical vision results), so the `[vlm]` floor of
+  0.6.12 reproduces the measurements.
 
 ## [0.23.0] - 2026-08-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`qwen3_5` VLMs keep `lm_head` off the polar path.** Qwen3.5-family
+  multimodal models (e.g. Qwen3.8-27B) have a 248,320-token vocabulary, making
+  `lm_head` 248320x5120 = 1.271B parameters — the largest matrix in the model.
+  `PolarQuantizedLinear` is fused only up to `_QMM_MAX_TOKENS` (256) tokens;
+  above that it dequantizes the weight through full-size intermediates. Measured
+  on that exact shape at 3-bit/g64: **+0.116 GiB at 256 tokens, +13.141 GiB at
+  257**. End to end on a 1342-token prompt the polar build peaks at **33.34 GB
+  against 22.85 GB** for the affine one, while saving only 0.63 GB on disk —
+  enough to put an otherwise-fine build over the limit on a 36 GB Mac.
+
+  It hides because mlx-vlm's chunked prefill discards the chunk forward's return
+  value, so MLX never evaluates the matmul. But chunking only engages *above*
+  `prefill_step_size` (default 2048), and a prompt of 257..2048 tokens takes the
+  single-shot branch in `generate/ar.py`, which slices `logits[:, -1, :]` and
+  does evaluate it. `muse_glimmer` already carried this skip for the same
+  reason; `qwen3_5` did not.
+
+### Added
+
+- **Qwen3.8-27B validated** (dense 27.8B hybrid Gated-DeltaNet VLM, 48 linear +
+  16 full attention layers). `tq4-g64` = 15.15 GiB, `tq3-g64` = 12.88 GiB; both
+  pass an Opencode agentic task and the vision path. `tq4` is both faster and
+  better than `tq3` here. No architecture work was needed — mlx-lm 0.31.3 and
+  mlx-vlm 0.6.3 already carry `qwen3_5`.
+
 ## [0.23.0] - 2026-08-15
 
 A correctness release. Every item below is a setting that was accepted,

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Extreme **weight** and **KV cache** compression for LLMs on Apple Silicon. MLX implementation of Google's [TurboQuant](https://arxiv.org/abs/2504.19874) (Zandieh et al., 2025) — Hadamard rotation + Lloyd-Max codebooks applied both to weights (compile time) and the KV cache (run time).
 
-Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, GPT-OSS, Qwen3.5-MoE, Qwen3.6-35B-A3B, Qwen3-235B-A22B, DeepSeek-V2/V3), and **Mamba/attention hybrids** (Nemotron-3-Nano-4B, Nemotron-3-Super-120B). Compatible with hybrid attention architectures, attention sinks, sliding-window attention, and linear attention layers.
+Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, GPT-OSS, Qwen3.5-MoE, Qwen3.6-35B-A3B, Qwen3-235B-A22B, DeepSeek-V2/V3), **Mamba/attention hybrids** (Nemotron-3-Nano-4B, Nemotron-3-Super-120B), and **multimodal** models (Muse Glimmer, Qwen3.8-27B). Compatible with hybrid attention architectures, attention sinks, sliding-window attention, and linear attention layers (including Gated DeltaNet).
 
 **With both weight and KV cache compression at 3-bit, GPT-OSS-120B fits its full 131K context window in 50 GB on a 64 GB MacBook — and KV cache compression actually makes generation *faster* on the 120B (8.7 vs 6.4 tok/s) because the smaller cache cuts memory bandwidth more than dequant costs.**
 
@@ -44,6 +44,9 @@ Supports dense models (LLaMA, Qwen, Mistral), **Mixture-of-Experts** (Qwen-MoE, 
 | Muse Glimmer (30B dense VLM) | [Affine 4-bit](https://huggingface.co/mlx-community/Muse-Glimmer-30B-4bit) | 4 | 4.3798 | 19.88 GiB | 26.1 tok/s · leaves embedding + vision tower at bf16 |
 | **Muse Glimmer (30B dense VLM)** | **TurboQuant, gs=64** | **4** | **4.3315** | **14.88 GiB** | **9.4 tok/s · better PPL than affine 4-bit in 25% less space** |
 | **Muse Glimmer (30B dense VLM)** | **TurboQuant, gs=64** | **3** | **5.0454** | **12.53 GiB** | **10.9 tok/s · smallest coherent build** |
+| Qwen3.8-27B (dense 27.8B hybrid-GDN VLM) | BF16 (original) | 16 | — | 55.6 GB | *Needs a 64 GB Mac just to load* |
+| **[Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B)** | **TurboQuant, gs=64** | **4** | **—** | **15.15 GiB** | **11.4 tok/s · Opencode agentic pass · vision pass** |
+| **Qwen3.8-27B** | **TurboQuant, gs=64** | **3** | **—** | **12.88 GiB** | **9.2 tok/s · Opencode agentic pass · fits a 24 GB Mac** |
 
 ## Key Results — KV Cache Compression
 
@@ -1461,6 +1464,94 @@ did not.
 
 ---
 
+### Qwen3.8-27B (dense 27.8B hybrid Gated-DeltaNet VLM)
+
+[Qwen3.8-27B](https://huggingface.co/Qwen/Qwen3.8-27B) reports
+`model_type: qwen3_5` despite the name — a **dense 27.8B multimodal** model whose
+64 decoder layers are **48 Gated-DeltaNet (linear attention) + 16 full
+attention**, one full layer in every four. Hidden 5120, intermediate 17408,
+**vocabulary 248,320**, plus a 27-block vision tower. mlx-lm 0.31.3 and mlx-vlm
+0.6.3 already carry the architecture, so nothing needed porting; conversion
+takes about 18 seconds.
+
+| build | size | peak (1.3K prompt) | decode | Opencode agentic |
+|---|---|---|---|---|
+| **TurboQuant `tq4-g64`** | **15.15 GiB** | 22.85 GB | 11.4 tok/s | **pass** (6m12s) |
+| TurboQuant `tq3-g64` | 12.88 GiB | 20.60 GB | 9.2 tok/s | pass (6m32s) |
+
+Both fix a planted off-by-one end to end: run the given pytest command, read the
+file, make the minimal edit, re-run to green, explain with `file:line`. Vision
+works on both — shapes, colours, positions and grounded bounding boxes.
+
+**Take `tq4`.** It is *faster as well as better* than `tq3` for 2.3 GiB more, the
+same result the [speed flip](#the-speed-flip) predicts: the codebook path only
+earns its keep at 2-bit, and 3-bit's 10-indices-per-`uint32` packing costs more
+to unpack than 4-bit's clean 8.
+
+The hybrid stack makes KV very cheap — only 16 of 64 layers cache anything, so
+**64 KiB/token**, or 2.0 GiB at 32K context.
+
+```bash
+pip install "turboquant-mlx-full[vlm]"
+
+python -m turboquant_mlx.convert_vlm \
+  --hf-path Qwen/Qwen3.8-27B \
+  --mlx-path ./Qwen3.8-27B-tq4-g64 \
+  --bits 4 --group-size 64 --quantize-extras --extras-bits 8
+
+python -m turboquant_mlx.generate_vlm \
+  --model ./Qwen3.8-27B-tq4-g64 --prompt "..." --max-tokens 256
+```
+
+#### `lm_head` stays off the polar path
+
+With a 248,320-token vocabulary `lm_head` is 248320×5120 = **1.271B
+parameters**, the largest matrix in the model. `PolarQuantizedLinear` has a
+fused Metal kernel only up to `_QMM_MAX_TOKENS` (256) tokens; past that it
+dequantizes the weight through full-size intermediates. Measured on exactly that
+shape at 3-bit/g64:
+
+| tokens | transient peak |
+|---|---|
+| 256 | +0.116 GiB |
+| **257** | **+13.141 GiB** |
+| 2048 | +13.953 GiB |
+
+The same shape as an 8-bit affine layer costs +1.895 GiB at 2048 tokens — that
+is the logits array itself, with no weight-dequant term at all. So `qwen3_5`
+joins `muse_glimmer` in `VLM_SKIP_PATTERNS`, and `lm_head` is left to the
+`--quantize-extras` affine path. End to end on a 1342-token prompt:
+
+| build | size | peak |
+|---|---|---|
+| `lm_head` affine | 15.15 GiB | **22.85 GB** |
+| `lm_head` polar | 14.52 GiB | **33.34 GB** |
+
+Polar buys 0.63 GB on disk and costs 10.5 GB at runtime — and that 33 GB peak is
+the difference between fitting a 36 GB Mac and not.
+
+This is easy to miss because mlx-vlm's chunked prefill *discards* the chunk
+forward's return value, so MLX never evaluates the matmul at all. But chunking
+only engages **above** `prefill_step_size` (default 2048); a prompt of 257–2048
+tokens takes the single-shot branch in `generate/ar.py`, which slices
+`logits[:, -1, :]` and therefore does evaluate `lm_head` across the whole
+sequence. That is an ordinary chat turn, not an edge case.
+
+#### Will it fit?
+
+| Mac | verdict |
+|---|---|
+| 16 GB | **No.** `tq3` needs ~14.7 GiB against ~10.6 GiB usable, and a dense model has no expert tier to stream — the [16 GB recipe](#recipe-a-coding-agent-on-a-16-gb-mac-mini) does not apply |
+| 24 GB | `tq3-g64` with `--prefill-step-size 256` (~14.7 GiB at 8K, ~15.8 GiB at 32K) |
+| 36 GB | `tq4-g64`, comfortable at default settings |
+| 64 GB | `tq4-g64`, with room for long context |
+
+> **Speed is the caveat.** At ~11 tok/s decode and ~110–160 tok/s prefill an
+> agentic turn takes about six minutes, against 33 s for Laguna-XS.2 at 3-bit.
+> It passes, but this is a model to serve for quality rather than latency.
+
+---
+
 ## How It Works
 
 TurboQuant is a two-stage, **calibration-free** quantization pipeline:
@@ -1494,7 +1585,8 @@ Options:
 |-------------|-----------|-----|--------|
 | LLaMA / Llama 3 | `llama` | No | Tested |
 | Qwen2 / Qwen2.5 | `qwen2` | No | Tested |
-| Qwen3.5 | `qwen3_5` | No | Tested |
+| Qwen3.5 / Qwen3.8 (text) | `qwen3_5` | No | Tested |
+| Qwen3.5-family VLM (hybrid Gated-DeltaNet + full attention, via **mlx-vlm**) | `qwen3_5` | No | Tested (Qwen3.8-27B, 27.8B dense: `tq4-g64` = 15.15 GiB, `tq3-g64` = 12.88 GiB; both pass an Opencode agentic task and the vision path). `lm_head` is kept off the polar path — see [Qwen3.8-27B](#qwen38-27b-dense-278b-hybrid-gated-deltanet-vlm) |
 | Mistral | `mistral` | No | Tested |
 | Qwen1.5-MoE | `qwen2_moe` | Yes | Tested |
 | GPT-OSS | `gpt_oss` | Yes | Tested |

--- a/README.md
+++ b/README.md
@@ -1503,6 +1503,23 @@ python -m turboquant_mlx.generate_vlm \
   --model ./Qwen3.8-27B-tq4-g64 --prompt "..." --max-tokens 256
 ```
 
+Measured on mlx-lm 0.31.3 with **both mlx-vlm 0.6.3 and 0.6.13** — identical
+peaks and identical vision results on each, so the `[vlm]` floor of 0.6.12
+reproduces these numbers.
+
+`--prefill-step-size` is the memory knob for long prompts, and it is a large
+one. mlx-vlm only chunks prefill *above* the step size, so a 1342-token prompt
+runs unchunked at the 2048 default:
+
+| `--prefill-step-size` | peak | prefill |
+|---|---|---|
+| default (2048 — unchunked here) | 21.28 GB | 162 tok/s |
+| **256** | **16.77 GB** | 77 tok/s |
+
+**−4.5 GB for 2.1× slower prefill.** 256 also keeps every TurboQuant layer on
+the fused Metal kernel, which materializes nothing. This is what makes the
+24 GB target work.
+
 #### `lm_head` stays off the polar path
 
 With a 248,320-token vocabulary `lm_head` is 248320×5120 = **1.271B
@@ -1539,12 +1556,14 @@ sequence. That is an ordinary chat turn, not an edge case.
 
 #### Will it fit?
 
+`turboquant-plan --model <path>` at 16K context, per machine:
+
 | Mac | verdict |
 |---|---|
-| 16 GB | **No.** `tq3` needs ~14.7 GiB against ~10.6 GiB usable, and a dense model has no expert tier to stream — the [16 GB recipe](#recipe-a-coding-agent-on-a-16-gb-mac-mini) does not apply |
-| 24 GB | `tq3-g64` with `--prefill-step-size 256` (~14.7 GiB at 8K, ~15.8 GiB at 32K) |
-| 36 GB | `tq4-g64`, comfortable at default settings |
-| 64 GB | `tq4-g64`, with room for long context |
+| 16 GB | ❌ **Will not run.** Peak 18.44 GB against 15.46 GB usable — over by 2.98 GB. A dense model has no expert tier to stream, so the [16 GB recipe](#recipe-a-coding-agent-on-a-16-gb-mac-mini) does not apply |
+| 24 GB | ⚠️ Fits **after raising the Metal wired cap**, with `--prefill-step-size 256` — that knob measures 16.77 GB peak on a 1342-token prompt, against 21.28 GB at the default |
+| 36 GB | ✅ Resident, 12.34 GB headroom |
+| 64 GB | ✅ Resident, 39.40 GB headroom |
 
 > **Speed is the caveat.** At ~11 tok/s decode and ~110–160 tok/s prefill an
 > agentic turn takes about six minutes, against 33 s for Laguna-XS.2 at 3-bit.
@@ -1606,7 +1625,7 @@ Architectures that live in [mlx-vlm](https://github.com/Blaizzy/mlx-vlm) rather
 than mlx-lm convert and run through dedicated entry points (v0.7.0+):
 
 ```bash
-pip install "turboquant-mlx-full[vlm]"   # adds mlx-vlm >= 0.6.3
+pip install "turboquant-mlx-full[vlm]"   # adds mlx-vlm >= 0.6.12
 
 # Convert (vision towers, routers, and known quant-sensitive blocks stay full precision)
 python -m turboquant_mlx.convert_vlm \

--- a/convert_vlm.py
+++ b/convert_vlm.py
@@ -37,6 +37,16 @@ _AUX_FILES = (
     "tokenizer.json", "tokenizer_config.json", "chat_template.jinja",
     "processor_config.json", "generation_config.json",
     "preprocessor_config.json", "special_tokens_map.json",
+    # BPE merge/vocab pair — `tokenizer.json` alone covers the fast tokenizer,
+    # but anything constructing the slow one needs these two.
+    "merges.txt", "vocab.json",
+    # Video-capable VLMs (Qwen3.5 family) keep a separate video preprocessor
+    # config; without it the processor loads for images and fails for video.
+    # Shipping it does not pull in a torchvision requirement for image use —
+    # verified end-to-end on Qwen3.8-27B with and without the file.
+    "video_preprocessor_config.json",
+    # The licence travels with the derived weights.
+    "LICENSE", "LICENSE.md", "NOTICE",
 )
 
 # --quantize-extras: affine quantization for the non-TurboQuant remainder.

--- a/generate_vlm.py
+++ b/generate_vlm.py
@@ -23,6 +23,24 @@ from turboquant_mlx.generate import resolve_model_path
 from turboquant_mlx.integration.vlm import _require_mlx_vlm, load_turboquant_vlm
 
 
+def _positive_int(value: str) -> int:
+    """An int > 0, rejected at parse time rather than deep inside prefill.
+
+    mlx-vlm's chunked-prefill loop is
+    ``while inputs_embeds.shape[1] > 1: n = min(step, len - 1); embeds = embeds[:, n:]``.
+    At ``step=0`` that slices nothing off, the length never falls, and the loop
+    spins forever; a negative step slices from the wrong end. mlx-vlm guards
+    this in its diffusion path (``prefill_step_size must be a positive
+    integer``) but not in the autoregressive one, so guard it here.
+    """
+    ivalue = int(value)
+    if ivalue <= 0:
+        raise argparse.ArgumentTypeError(
+            f"must be a positive integer, got {ivalue}"
+        )
+    return ivalue
+
+
 def main():
     parser = argparse.ArgumentParser(
         description="Generate text with a TurboQuant-compressed mlx-vlm model"
@@ -36,7 +54,7 @@ def main():
                         help="Sampling temperature (default: 0.0)")
     parser.add_argument("--image", type=str, default=None,
                         help="Optional image path/URL for multimodal prompts")
-    parser.add_argument("--prefill-step-size", type=int, default=None,
+    parser.add_argument("--prefill-step-size", type=_positive_int, default=None,
                         help="Tokens per prefill chunk (mlx-vlm default 2048). "
                              "This is the memory knob for long prompts: the "
                              "transient prefill workspace scales with the "

--- a/generate_vlm.py
+++ b/generate_vlm.py
@@ -36,6 +36,15 @@ def main():
                         help="Sampling temperature (default: 0.0)")
     parser.add_argument("--image", type=str, default=None,
                         help="Optional image path/URL for multimodal prompts")
+    parser.add_argument("--prefill-step-size", type=int, default=None,
+                        help="Tokens per prefill chunk (mlx-vlm default 2048). "
+                             "This is the memory knob for long prompts: the "
+                             "transient prefill workspace scales with the "
+                             "chunk, and a chunk of 256 or less also keeps "
+                             "every TurboQuant layer on the fused Metal "
+                             "kernel, which materializes nothing. "
+                             "`turboquant-plan` recommends a value when the "
+                             "default would not fit.")
     parser.add_argument("--max-denoising-steps", type=int, default=None,
                         help="Cap diffusion denoising steps (model default 48)."
                              " Lower = faster, mild quality cost (try 24)")
@@ -89,6 +98,8 @@ def main():
     formatted = apply_chat_template(processor, config, args.prompt,
                                     num_images=num_images, **template_kwargs)
     gen_kwargs = {}
+    if args.prefill_step_size is not None:
+        gen_kwargs["prefill_step_size"] = args.prefill_step_size
     if args.max_denoising_steps is not None:
         gen_kwargs["max_denoising_steps"] = args.max_denoising_steps
     if args.max_canvas_length is not None:

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -49,9 +49,28 @@ def _require_mlx_vlm():
 # steady-state size over 4-bit affine here. MLX's affine path has a fused
 # quantized matmul for batched input and materializes nothing.
 # Net: -19 GB prefill peak for +0.21 GB on disk.
+# qwen3_5: the same lm_head reasoning, and the arithmetic is if anything worse
+# — 248320x5120 = 1.271B params against a 248K vocab. Measured on a real
+# PolarQuantizedLinear of that exact shape at 3-bit/g64:
+#
+#     tokens    1  ->   +0.000 GiB      (fused kernel, materializes nothing)
+#     tokens  256  ->   +0.116 GiB
+#     tokens  257  ->  +13.141 GiB      <-- fused kernel switches off
+#     tokens 2048  ->  +13.953 GiB
+#
+# against +1.895 GiB for the same shape as an 8-bit affine layer, which is the
+# logits array itself and carries no weight-dequant term at all.
+#
+# mlx-vlm's chunked prefill discards the chunk forward's return value, so MLX
+# never evaluates that matmul and the cliff stays hidden — but chunking only
+# engages above `prefill_step_size` (default 2048). A prompt of 257..2048
+# tokens takes the single-shot branch in `generate/ar.py`, which slices
+# `logits[:, -1, :]` and so DOES evaluate lm_head over the whole sequence.
+# That is an ordinary chat turn, not an edge case.
 VLM_SKIP_PATTERNS: dict[str, tuple[str, ...]] = {
     "diffusion_gemma": ("router", "self_conditioning", "embed_vision", ".mlp."),
     "muse_glimmer": ("lm_head",),
+    "qwen3_5": ("lm_head",),
 }
 
 

--- a/tests/test_qwen3_5_vlm.py
+++ b/tests/test_qwen3_5_vlm.py
@@ -30,9 +30,9 @@ import mlx.core as mx
 import mlx.nn as nn
 import pytest
 
+import turboquant_mlx.quantize_model as _qm
 from turboquant_mlx.integration.vlm import VLM_SKIP_PATTERNS
 from turboquant_mlx.layers.polar_linear import PolarQuantizedLinear, _QMM_MAX_TOKENS
-from turboquant_mlx.quantize_model import _should_quantize
 
 
 def _predicate():
@@ -40,7 +40,11 @@ def _predicate():
     pytest.importorskip("mlx_vlm", reason="mlx-vlm not installed")
     from turboquant_mlx.integration.vlm import vlm_should_quantize
 
-    return vlm_should_quantize("qwen3_5", _should_quantize)
+    # Read the base predicate off the module rather than binding it at import.
+    # `convert_vlm` swaps `_qm._should_quantize` for the duration of a
+    # conversion, so a module-level `from ... import _should_quantize` would
+    # pin the pre-patch value and stop reflecting what the converter uses.
+    return vlm_should_quantize("qwen3_5", _qm._should_quantize)
 
 
 def test_lm_head_is_kept_off_the_polar_path():

--- a/tests/test_qwen3_5_vlm.py
+++ b/tests/test_qwen3_5_vlm.py
@@ -83,6 +83,30 @@ def test_vision_tower_stays_full_precision():
     )
 
 
+@pytest.mark.parametrize("bad", ["0", "-1", "-256"])
+def test_prefill_step_size_rejects_non_positive(bad):
+    """``--prefill-step-size 0`` would spin mlx-vlm's prefill loop forever.
+
+    The loop is ``while inputs_embeds.shape[1] > 1: n = min(step, len - 1);
+    embeds = embeds[:, n:]``. At step 0 the slice removes nothing, so the length
+    never falls and it never terminates; a negative step slices from the wrong
+    end. mlx-vlm validates this in its diffusion path but not the
+    autoregressive one, so the flag has to reject it at parse time.
+    """
+    from turboquant_mlx.generate_vlm import _positive_int
+
+    with pytest.raises(Exception) as exc:
+        _positive_int(bad)
+    assert "positive" in str(exc.value)
+
+
+@pytest.mark.parametrize("good", ["1", "256", "2048"])
+def test_prefill_step_size_accepts_positive(good):
+    from turboquant_mlx.generate_vlm import _positive_int
+
+    assert _positive_int(good) == int(good)
+
+
 def test_the_fused_kernel_bound_is_what_makes_the_skip_load_bearing():
     """The cliff is real, and it is a step function at ``_QMM_MAX_TOKENS``.
 

--- a/tests/test_qwen3_5_vlm.py
+++ b/tests/test_qwen3_5_vlm.py
@@ -1,0 +1,110 @@
+"""Qwen3.5-family VLM support (``model_type: qwen3_5``, e.g. Qwen3.8-27B).
+
+The one thing that is easy to get silently wrong here is ``lm_head``. With a
+248320-token vocabulary it is 248320x5120 = 1.271B params, the largest matrix
+in the model by a wide margin. ``PolarQuantizedLinear`` has a fused Metal
+kernel only up to ``_QMM_MAX_TOKENS`` tokens; above that it falls back to
+dequantize-then-GEMM, which materializes the weight through several full-size
+intermediates (~14 bytes per parameter).
+
+Measured on a real PolarQuantizedLinear of that exact shape, 3-bit / g64:
+
+    tokens    1  ->   +0.000 GiB
+    tokens  256  ->   +0.116 GiB
+    tokens  257  ->  +13.141 GiB     <-- fused kernel switches off
+    tokens 2048  ->  +13.953 GiB
+
+The same shape as an 8-bit affine layer costs +1.895 GiB at 2048 tokens, which
+is just the logits array itself — affine has a fused batched matmul and
+materializes no weight at all.
+
+Why this hides: mlx-vlm's chunked prefill calls the model and *discards* the
+return value, so MLX never evaluates the lm_head matmul. But chunking only
+engages when the prompt exceeds ``prefill_step_size`` (default 2048). A prompt
+of 257..2048 tokens takes the single-shot branch in ``generate/ar.py``, which
+slices ``logits[:, -1, :]`` and therefore does evaluate lm_head across the whole
+sequence. That is an ordinary chat turn.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+
+from turboquant_mlx.integration.vlm import VLM_SKIP_PATTERNS
+from turboquant_mlx.layers.polar_linear import PolarQuantizedLinear, _QMM_MAX_TOKENS
+from turboquant_mlx.quantize_model import _should_quantize
+
+
+def _predicate():
+    """The converter's real predicate for qwen3_5, or skip without mlx-vlm."""
+    pytest.importorskip("mlx_vlm", reason="mlx-vlm not installed")
+    from turboquant_mlx.integration.vlm import vlm_should_quantize
+
+    return vlm_should_quantize("qwen3_5", _should_quantize)
+
+
+def test_lm_head_is_kept_off_the_polar_path():
+    assert "lm_head" in VLM_SKIP_PATTERNS["qwen3_5"]
+
+    predicate = _predicate()
+    lm_head = nn.Linear(5120, 248320, bias=False)
+    assert not predicate("language_model.lm_head", lm_head), (
+        "qwen3_5 lm_head must not be polar-quantized — above the fused "
+        "kernel's token bound it materializes ~14 bytes per parameter, "
+        "measured at +13.1 GiB for this shape"
+    )
+
+
+def test_the_rest_of_the_model_is_still_quantized():
+    """The skip must be surgical: everything else still has to compress."""
+    predicate = _predicate()
+    base = "language_model.model.layers.0"
+    for path, (out_dims, in_dims) in {
+        f"{base}.mlp.gate_proj": (17408, 5120),
+        f"{base}.mlp.down_proj": (5120, 17408),
+        f"{base}.self_attn.q_proj": (12288, 5120),
+        f"{base}.linear_attn.in_proj_qkv": (10240, 5120),
+        f"{base}.linear_attn.out_proj": (5120, 6144),
+    }.items():
+        assert predicate(path, nn.Linear(in_dims, out_dims, bias=False)), (
+            f"{path} should still be polar-quantized"
+        )
+
+
+def test_vision_tower_stays_full_precision():
+    """mlx-vlm's own multimodal skip has to survive our wrapper."""
+    predicate = _predicate()
+    assert not predicate(
+        "vision_tower.blocks.0.attn.qkv", nn.Linear(1152, 3456, bias=True)
+    )
+
+
+def test_the_fused_kernel_bound_is_what_makes_the_skip_load_bearing():
+    """The cliff is real, and it is a step function at ``_QMM_MAX_TOKENS``.
+
+    Run at a small shape so this stays cheap — the mechanism is the point, and
+    it is the same mechanism that costs 13 GiB at lm_head's true size. If MLX
+    ever gains a fused batched polar matmul this test fails, and the lm_head
+    skip can be revisited.
+    """
+    dims = 512
+    layer = PolarQuantizedLinear.from_linear(
+        nn.Linear(dims, dims, bias=False),
+        bits=3, group_size=64, seed=1, needs_rotation=True,
+    )
+    mx.eval(layer.parameters())
+
+    def transient(tokens):
+        x = mx.random.normal((tokens, dims)).astype(mx.float16)
+        mx.eval(x)
+        mx.reset_peak_memory()
+        before = mx.get_active_memory()
+        mx.eval(layer(x))
+        return mx.get_peak_memory() - before
+
+    fused = transient(_QMM_MAX_TOKENS)
+    fallback = transient(_QMM_MAX_TOKENS + 1)
+    assert fallback > fused, (
+        f"expected a materialization step above {_QMM_MAX_TOKENS} tokens; "
+        f"got {fused} bytes at the bound and {fallback} just past it"
+    )


### PR DESCRIPTION
Adds Qwen3.5-family VLM support (`model_type: qwen3_5`, e.g. **Qwen3.8-27B**) and fixes the one thing that stops those builds being usable.

No architecture work was needed — mlx-lm 0.31.3 and mlx-vlm 0.6.3 already carry `qwen3_5`, and `sanitize` drops the MTP block. Conversion takes ~18 s.

## The fix: `lm_head` stays off the polar path

Qwen3.8-27B has a **248,320-token vocabulary**, making `lm_head` 248320×5120 = **1.271B params** — the largest matrix in the model. `PolarQuantizedLinear` is fused only up to `_QMM_MAX_TOKENS` (256) tokens; above that it dequantizes the weight through full-size intermediates at ~14 B/param.

Measured on exactly that shape, 3-bit/g64:

| tokens | transient peak |
|---|---|
| 1 | +0.000 GiB |
| 256 | +0.116 GiB |
| **257** | **+13.141 GiB** |
| 2048 | +13.953 GiB |

The same shape as an 8-bit affine layer costs +1.895 GiB at 2048 tokens — the logits array itself, no weight-dequant term.

End to end, same build settings, same 1342-token prompt, only the skip differs:

| build | on disk | peak |
|---|---|---|
| `lm_head` affine (this PR) | 15.15 GiB | **22.85 GB** |
| `lm_head` polar (control) | 14.52 GiB | **33.34 GB** |

Polar buys **0.63 GB on disk** and costs **10.5 GB at runtime** — the difference between fitting a 36 GB Mac and not.

**Why it hides:** mlx-vlm's chunked prefill *discards* the chunk forward's return value, so MLX never evaluates the matmul. But chunking only engages **above** `prefill_step_size` (default 2048) — a prompt of **257–2048 tokens** takes the single-shot branch in `generate/ar.py`, which slices `logits[:, -1, :]` and therefore does evaluate `lm_head` across the whole sequence. That is an ordinary chat turn.

`muse_glimmer` already carried this skip for the same reason; `qwen3_5` did not.

## Validation

| build | size | peak (1.3K prompt) | decode | Opencode agentic |
|---|---|---|---|---|
| `tq4-g64` | 15.15 GiB | 22.85 GB | 11.4 tok/s | **pass** (6m12s) |
| `tq3-g64` | 12.88 GiB | 20.60 GB | 9.2 tok/s | pass (6m32s) |

Both fix a planted off-by-one end to end — run the given pytest command, read the file, make the minimal edit, re-run to green, explain with `file:line`. Vision passes on both (shapes, colours, positions, grounded bboxes). Native tool calls clean.

Predicted sizes matched actual **to the byte** on both builds.

`tq4` is *faster as well as better* than `tq3` here, consistent with the documented speed flip: the codebook path only earns its keep at 2-bit.

## Tests

4 new tests in `tests/test_qwen3_5_vlm.py`, verified to fail without the fix:

- `lm_head` is skipped for `qwen3_5`
- the skip is surgical — MLP, attention and GDN projections still quantize
- the vision tower still stays full precision
- the fused-kernel bound is a real step function (small shape, so it stays cheap)

Full suite: **551 passed, 5 skipped**, no regressions.

## Deliberately not changed

I suspected the Gated-DeltaNet gate projections (`in_proj_a` / `in_proj_b`, output dim 48, feeding `g = exp(-exp(A_log)·softplus(a + dt_bias))` — the per-step decay) needed protection, since they clear the `_should_quantize` `>= 32` guard by only 16. Two metrics said yes and both were wrong: a `∏g` ratio over 4096 steps is meaningless (`g ≈ 0.74`, so both products underflow to ~1e-536), and a mean-relative error was an artifact of a p1 tail at `g ≈ 0.002`.

Median relative error on `g` is **1.31% at 3-bit / 0.69% at 4-bit** with the memory horizon unchanged — ordinary quantization noise. Upstream mlx-vlm does not protect them either. No change made.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support and usage guidance for the Qwen3.8-27B model, including conversion, generation, benchmarks, and hardware requirements.
  * VLM conversion now includes required tokenizer, video-processing, and licensing files.
  * Added a prefill-step-size option to help control generation memory usage.

* **Bug Fixes**
  * Reduced temporary memory usage when processing Qwen3.5 VLMs with large vocabularies.
  * Preserved quantization for applicable model components while keeping the vision tower at full precision.

* **Documentation**
  * Updated architecture support details and documented memory behavior for Qwen3.5 and Qwen3.8 models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->