### PR TITLE
chore: release 0.24.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [0.24.0] - 2026-08-15
+
+Qwen3.5-family VLM support (`model_type: qwen3_5`, e.g. Qwen3.8-27B), and the
+one thing that stopped those builds being usable.
+
+No architecture work was needed — mlx-lm 0.31.3 and mlx-vlm already carry
+`qwen3_5`. The substance is that a 248K-vocabulary `lm_head` must not go through
+the polar path, which costs 10.5 GB of runtime peak to save 0.63 GB on disk.
+
 ### Fixed
 
 - **`qwen3_5` VLMs keep `lm_head` off the polar path.** Qwen3.5-family

--- a/__init__.py
+++ b/__init__.py
@@ -4,7 +4,7 @@ Adapts Google's TurboQuant (PolarQuant + QJL) technique for weight quantization,
 achieving 3-bit quality matching 4-bit affine with no calibration data needed.
 """
 
-__version__ = "0.23.0"
+__version__ = "0.24.0"
 
 from turboquant_mlx.config import TurboQuantConfig
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "turboquant-mlx-full"
-version = "0.23.0"
+version = "0.24.0"
 description = "Extreme weight and KV cache compression for LLMs on Apple Silicon (MLX implementation of Google's TurboQuant)"
 readme = "README.md"
 requires-python = ">=3.10"


### PR DESCRIPTION
Version bump for 0.24.0.

Contents are #95: Qwen3.5-family VLM support (`model_type: qwen3_5`, e.g. Qwen3.8-27B).

**Fixed**
- `qwen3_5` VLMs keep `lm_head` off the polar path. A 248,320-token vocabulary makes `lm_head` 1.271B params; above the fused kernel's 256-token bound it dequantizes at ~14 B/param — **+13.1 GiB transient at 257 tokens**. End to end on a 1342-token prompt: **33.34 GB peak vs 22.85 GB**, for 0.63 GB more on disk. Hidden because chunked prefill discards the forward's return value, but chunking only engages above `prefill_step_size` (default 2048).
- `convert_vlm` now copies `merges.txt`, `vocab.json`, `video_preprocessor_config.json` and the licence alongside converted weights.
- `--prefill-step-size` rejects non-positive values, which would hang mlx-vlm's chunked-prefill loop.

**Added**
- `generate_vlm --prefill-step-size` — the memory knob for long prompts. On Qwen3.8-27B with a 1342-token prompt: **16.77 GB peak vs 21.28 GB** at the default, for 2.1× slower prefill.
- Qwen3.8-27B validated: `tq4-g64` 15.15 GiB, `tq3-g64` 12.88 GiB, both passing an Opencode agentic task and a 4/4 vision battery. Verified on mlx-vlm 0.6.3 and 0.6.13.

557 passed, 5 skipped.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Qwen3.5-family vision-language models.

* **Bug Fixes**
  * Prevented large-vocabulary language-model output layers from using an incompatible quantization path.

* **Release**
  * Updated the package to version 0.24.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->