### PR TITLE
bench: VLM perplexity and vision harnesses, plus the affine 4-bit comparison

### DIFF
--- a/README.md
+++ b/README.md
@@ -1554,6 +1554,55 @@ tokens takes the single-shot branch in `generate/ar.py`, which slices
 `logits[:, -1, :]` and therefore does evaluate `lm_head` across the whole
 sequence. That is an ordinary chat turn, not an edge case.
 
+#### Against MLX's own affine 4-bit
+
+[`mlx-community/Qwen3.8-27B-4bit`](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit)
+is the same architecture at the same 4-bit / group-size-64 setting, with no MTP
+weights on either side — so this is a like-for-like comparison, run through the
+same harnesses and the same server.
+
+| | affine 4-bit | TurboQuant `tq4-g64` |
+|---|---|---|
+| on disk | 14.95 GiB | 15.15 GiB · **13.81** with `--extras-bits 4` |
+| bits/weight | 4.500 | **4.251** |
+| WikiText-2 PPL (16K / 32K tok) | 7.2685 / 8.3593 | **7.2496 / 8.3321** |
+| decode | **29.7 tok/s** | 11.3 tok/s |
+| peak, same harness | **16.16 GiB** | 17.80 GiB |
+| vision battery | 3/4 | 4/4 |
+| Opencode agentic | **pass** (6m42s) | **pass** (6m12s) |
+
+**Take the affine build if you want 4-bit Qwen3.8-27B.** It is 2.6× faster to
+decode at a lower peak, and the perplexity difference is 0.3% — real and stable
+in ordering across both corpus sizes, but far too small to trade that speed for.
+
+The one place TurboQuant is structurally ahead is storage. At identical bit
+width and group size, on the same 17408×5120 projection:
+
+| | weight | scales | biases | bits/weight |
+|---|---|---|---|---|
+| affine 4-bit | 42.50 MiB | 2.66 | **2.66** | **4.500** |
+| polar 4-bit | 42.50 MiB | 2.66 | — | **4.251** |
+
+The Hadamard rotation symmetrizes each group, so there is no zero-point to
+store — 5.5% leaner for free. That margin is a rounding error at 4-bit and the
+reason the codebook only earns its keep at 2-bit and below (see
+[the speed flip](#the-speed-flip)).
+
+Two cautions on reading the table. The vision split is **not** a capability
+gap: affine's single miss is one string (`VOLTAGE 47` → `VOLTAGE`), and a
+five-string follow-up probe put it at 4/5, so treat 3/4-vs-4/4 as a tie. And
+the agentic wall-clock is **not** a speed metric — affine decodes 2.6× faster
+yet finished *slower*, because it spent more tool turns.
+
+Reproduce both halves:
+
+```bash
+python -m turboquant_mlx.benchmarks.eval_vlm_perplexity \
+    ./Qwen3.8-27B-tq4-g64 mlx-community/Qwen3.8-27B-4bit --chunks 64
+python -m turboquant_mlx.benchmarks.eval_vlm_vision \
+    ./Qwen3.8-27B-tq4-g64 mlx-community/Qwen3.8-27B-4bit
+```
+
 #### Will it fit?
 
 `turboquant-plan --model <path>` at 16K context, per machine:

--- a/README.md
+++ b/README.md
@@ -1561,15 +1561,24 @@ is the same architecture at the same 4-bit / group-size-64 setting, with no MTP
 weights on either side — so this is a like-for-like comparison, run through the
 same harnesses and the same server.
 
-| | affine 4-bit | TurboQuant `tq4-g64` |
-|---|---|---|
-| on disk | 14.95 GiB | 15.15 GiB · **13.81** with `--extras-bits 4` |
-| bits/weight | 4.500 | **4.251** |
-| WikiText-2 PPL (16K / 32K tok) | 7.2685 / 8.3593 | **7.2496 / 8.3321** |
-| decode | **29.7 tok/s** | 11.3 tok/s |
-| peak, same harness | **16.16 GiB** | 17.80 GiB |
-| vision battery | 3/4 | 4/4 |
-| Opencode agentic | **pass** (6m42s) | **pass** (6m12s) |
+The two TurboQuant columns differ only in what the *non-polar* remainder
+(embeddings, `lm_head`, vision tower) is stored at — `--extras-bits 8` versus
+`4`. They are separate builds with separate numbers, so they get separate
+columns.
+
+| | affine 4-bit | `tq4-g64` extras 8 | `tq4-g64` extras 4 |
+|---|---|---|---|
+| on disk | 14.95 GiB | 15.15 GiB | **13.81 GiB** |
+| bits/weight (polar tier) | 4.500 | **4.251** | **4.251** |
+| PPL, 16K tok | 7.2685 | **7.2496** | 7.3043 |
+| PPL, 32K tok | 8.3593 | **8.3321** | 8.4061 |
+| decode | **29.7 tok/s** | 11.3 tok/s | 11.5 tok/s |
+| peak, same harness | **16.16 GiB** | 17.80 GiB | 16.47 GiB |
+| vision battery | 3/4 | 4/4 | — |
+| Opencode agentic | **pass** (6m42s) | **pass** (6m12s) | — |
+
+Only the `extras 8` build is published, and the vision/agentic runs were done
+on it; the `extras 4` column is the size-matched control.
 
 **Take the affine build if you want 4-bit Qwen3.8-27B.** It is 2.6× faster to
 decode at a lower peak, and the perplexity difference is 0.3% — real and stable
@@ -1597,8 +1606,14 @@ yet finished *slower*, because it spent more tool turns.
 Reproduce both halves:
 
 ```bash
+# 16K-token column (--chunks 32) and 32K-token column (--chunks 64);
+# both records are checked in under benchmarks/
 python -m turboquant_mlx.benchmarks.eval_vlm_perplexity \
-    ./Qwen3.8-27B-tq4-g64 mlx-community/Qwen3.8-27B-4bit --chunks 64
+    ./Qwen3.8-27B-tq4-g64 ./Qwen3.8-27B-tq4-g64-x4 \
+    mlx-community/Qwen3.8-27B-4bit --chunks 32
+python -m turboquant_mlx.benchmarks.eval_vlm_perplexity \
+    ./Qwen3.8-27B-tq4-g64 ./Qwen3.8-27B-tq4-g64-x4 \
+    mlx-community/Qwen3.8-27B-4bit --chunks 64
 python -m turboquant_mlx.benchmarks.eval_vlm_vision \
     ./Qwen3.8-27B-tq4-g64 mlx-community/Qwen3.8-27B-4bit
 ```

--- a/benchmarks/eval_vlm_perplexity.py
+++ b/benchmarks/eval_vlm_perplexity.py
@@ -35,6 +35,32 @@ import mlx.core as mx
 import mlx.nn as nn
 
 
+def resolved_identity(spec):
+    """A record of exactly which bytes were measured.
+
+    Repo ids and dataset defaults are mutable — `mlx-community/X-4bit` can be
+    re-uploaded and a published number would silently start describing
+    different weights. For a Hub repo this pins the commit sha; for a local
+    directory it records the path and the total size of its safetensors, which
+    is enough to notice a swap.
+    """
+    from pathlib import Path as _P
+
+    p = _P(spec)
+    if p.is_dir():
+        shards = sorted(p.glob("*.safetensors"))
+        return {"spec": str(spec), "kind": "local",
+                "safetensors_bytes": sum(f.stat().st_size for f in shards),
+                "n_shards": len(shards)}
+    try:
+        from huggingface_hub import HfApi
+
+        return {"spec": str(spec), "kind": "hub",
+                "revision": HfApi().model_info(str(spec)).sha}
+    except Exception as exc:  # offline, private, or not a repo id
+        return {"spec": str(spec), "kind": "unresolved", "error": str(exc)[:120]}
+
+
 def load_any(path):
     """Load a TurboQuant or a stock mlx-vlm checkpoint, returning (model, kind)."""
     from mlx_vlm.utils import get_model_path, load_config
@@ -127,10 +153,14 @@ def main():
         ppl, n = perplexity(model, ids, args.seq_len, args.chunks, kind)
         peak = mx.get_peak_memory() / 1024**3
         results.append({"model": spec, "kind": kind, "ppl": ppl,
-                        "tokens": n, "peak_gib": peak})
+                        "tokens": n, "peak_gib": peak,
+                        "identity": resolved_identity(spec)})
         print(f"  peak {peak:.2f} GiB")
         del model
-        import gc; gc.collect(); mx.clear_cache()
+        import gc
+
+        gc.collect()
+        mx.clear_cache()
 
     print(f"\n{'model':<44}{'quantization':<34}{'PPL':>9}")
     print("-" * 88)
@@ -142,9 +172,16 @@ def main():
         print(f"\n{a['model']} vs {b['model']}: {d:+.2f}% PPL "
               f"({'better' if d < 0 else 'worse'})")
     if args.json:
-        Path(args.json).write_text(json.dumps(results, indent=2))
+        Path(args.json).write_text(json.dumps({
+            "corpus": "wikitext-2-raw-v1 test",
+            "seq_len": args.seq_len,
+            "chunks": args.chunks,
+            "note": ("teacher-forced NLL over the whole corpus slice; "
+                     "tokenization asserted identical across models"),
+            "results": results,
+        }, indent=2))
         print(f"\nwrote {args.json}")
 
 
 if __name__ == "__main__":
-    sys.exit(main())
+    main()

--- a/benchmarks/eval_vlm_perplexity.py
+++ b/benchmarks/eval_vlm_perplexity.py
@@ -1,0 +1,150 @@
+"""WikiText-2 perplexity for mlx-vlm checkpoints, TurboQuant or affine.
+
+`turboquant_mlx.evaluate` loads through `mlx_lm.utils.load` and re-quantizes
+in-process, so it cannot touch a VLM checkpoint or a pre-quantized one from the
+Hub. This harness takes an already-quantized directory of either kind and
+scores the same text through it.
+
+What makes the comparison fair, and why each part matters:
+
+* **Same tokenizer.** Both builds derive from Qwen/Qwen3.8-27B, so token
+  boundaries are identical and the per-token NLL is directly comparable. The
+  script asserts this rather than assuming it.
+* **Same text, same chunking.** A fixed number of non-overlapping `seq_len`
+  chunks taken from the front of the concatenated corpus, so both models see
+  byte-identical inputs.
+* **Teacher forcing, no sampling.** Perplexity is a property of the
+  distribution, so nothing here depends on a sampler or a seed.
+* **Loss over the whole corpus, not a mean of per-chunk means.** Chunks are
+  equal length here, so the two agree — but summing NLL and dividing by token
+  count is the definition, and stays right if chunking ever changes.
+
+Usage:
+    python -m turboquant_mlx.benchmarks.eval_vlm_perplexity \\
+        ./Qwen3.8-27B-tq4-g64 mlx-community/Qwen3.8-27B-4bit --chunks 32
+"""
+
+import argparse
+import json
+import math
+import sys
+import time
+from pathlib import Path
+
+import mlx.core as mx
+import mlx.nn as nn
+
+
+def load_any(path):
+    """Load a TurboQuant or a stock mlx-vlm checkpoint, returning (model, kind)."""
+    from mlx_vlm.utils import get_model_path, load_config
+
+    resolved = Path(get_model_path(path))
+    cfg = load_config(resolved)
+    quant = cfg.get("quantization") or {}
+
+    if quant.get("mode") == "turboquant":
+        from turboquant_mlx.integration.vlm import load_turboquant_vlm
+
+        model, _processor, _cfg = load_turboquant_vlm(resolved)
+        bits = quant.get("bits")
+        gs = quant.get("group_size")
+        extras = quant.get("affine_extras")
+        kind = f"turboquant {bits}-bit g{gs}"
+        if extras:
+            kind += f" + {extras['bits']}-bit affine extras"
+        return model, kind, resolved
+
+    from mlx_vlm import load as vlm_load
+
+    model, _processor = vlm_load(str(resolved))
+    kind = f"{quant.get('mode', 'affine')} {quant.get('bits')}-bit g{quant.get('group_size')}"
+    return model, kind, resolved
+
+
+def corpus_ids(tokenizer, seq_len, n_chunks):
+    from datasets import load_dataset
+
+    ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
+    text = "\n\n".join(t for t in ds["text"] if t.strip())
+    need = seq_len * n_chunks
+    # Tokenize a generous prefix; 6 chars/token is a safe overestimate of density.
+    ids = tokenizer.encode(text[: need * 6])
+    if len(ids) < need + 1:
+        raise SystemExit(f"corpus too short: {len(ids)} tokens, need {need + 1}")
+    return ids[: need + 1]
+
+
+def perplexity(model, ids, seq_len, n_chunks, label):
+    """Total NLL / total predicted tokens, teacher-forced."""
+    total_nll, total_tok = 0.0, 0
+    t0 = time.time()
+    for i in range(n_chunks):
+        chunk = ids[i * seq_len : (i + 1) * seq_len + 1]
+        inp = mx.array(chunk[:-1])[None]
+        tgt = mx.array(chunk[1:])[None]
+        out = model.language_model(inputs=inp)
+        logits = (out.logits if hasattr(out, "logits") else out).astype(mx.float32)
+        nll = nn.losses.cross_entropy(logits, tgt, reduction="sum")
+        mx.eval(nll)
+        total_nll += float(nll.item())
+        total_tok += tgt.size
+        print(f"\r  {label}: chunk {i+1}/{n_chunks}  "
+              f"running ppl {math.exp(total_nll/total_tok):7.4f}", end="", flush=True)
+    dt = time.time() - t0
+    print(f"\r  {label}: {n_chunks} chunks x {seq_len} tok  "
+          f"ppl {math.exp(total_nll/total_tok):7.4f}  ({dt:.0f}s)        ")
+    return math.exp(total_nll / total_tok), total_tok
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("models", nargs="+", help="checkpoint dirs or HF repo ids")
+    ap.add_argument("--seq-len", type=int, default=512)
+    ap.add_argument("--chunks", type=int, default=32)
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+
+    from transformers import AutoTokenizer
+
+    results, ref_ids = [], None
+    for spec in args.models:
+        print(f"\n=== {spec} ===")
+        model, kind, resolved = load_any(spec)
+        tok = AutoTokenizer.from_pretrained(str(resolved))
+        ids = corpus_ids(tok, args.seq_len, args.chunks)
+
+        if ref_ids is None:
+            ref_ids = ids
+        elif ids != ref_ids:
+            raise SystemExit(
+                f"{spec}: tokenization differs from the first model — the "
+                "perplexities would not be comparable. Aborting rather than "
+                "reporting a misleading number."
+            )
+
+        mx.reset_peak_memory()
+        ppl, n = perplexity(model, ids, args.seq_len, args.chunks, kind)
+        peak = mx.get_peak_memory() / 1024**3
+        results.append({"model": spec, "kind": kind, "ppl": ppl,
+                        "tokens": n, "peak_gib": peak})
+        print(f"  peak {peak:.2f} GiB")
+        del model
+        import gc; gc.collect(); mx.clear_cache()
+
+    print(f"\n{'model':<44}{'quantization':<34}{'PPL':>9}")
+    print("-" * 88)
+    for r in sorted(results, key=lambda r: r["ppl"]):
+        print(f"{r['model']:<44}{r['kind']:<34}{r['ppl']:>9.4f}")
+    if len(results) == 2:
+        a, b = results
+        d = (a["ppl"] - b["ppl"]) / b["ppl"] * 100
+        print(f"\n{a['model']} vs {b['model']}: {d:+.2f}% PPL "
+              f"({'better' if d < 0 else 'worse'})")
+    if args.json:
+        Path(args.json).write_text(json.dumps(results, indent=2))
+        print(f"\nwrote {args.json}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/eval_vlm_perplexity.py
+++ b/benchmarks/eval_vlm_perplexity.py
@@ -25,6 +25,7 @@ Usage:
 """
 
 import argparse
+import hashlib
 import json
 import math
 import sys
@@ -35,16 +36,34 @@ import mlx.core as mx
 import mlx.nn as nn
 
 
-def resolved_identity(spec):
+def resolved_identity(spec, resolved_path=None):
     """A record of exactly which bytes were measured.
 
-    Repo ids and dataset defaults are mutable — `mlx-community/X-4bit` can be
-    re-uploaded and a published number would silently start describing
-    different weights. For a Hub repo this pins the commit sha; for a local
-    directory it records the path and the total size of its safetensors, which
-    is enough to notice a swap.
+    Repo ids are mutable — `mlx-community/X-4bit` can be re-uploaded and a
+    published number would silently start describing different weights.
+
+    The revision is read from the resolved snapshot directory, whose name IS
+    the commit sha, rather than asking the API what HEAD is now. That records
+    the revision actually loaded (no gap between load and lookup) and works
+    offline. The API is only a fallback for an unresolved spec.
+
+    Deliberately not a SHA-256 of every shard: these checkpoints are 13-16 GiB
+    each and three of them get scored per run, so digesting would add minutes
+    of pure I/O to every invocation. Shard count and total bytes catch a
+    swapped local build, and the revision pins a Hub one exactly.
     """
     from pathlib import Path as _P
+
+    if resolved_path is not None:
+        rp = _P(resolved_path)
+        # .../hub/models--org--name/snapshots/<sha>
+        if rp.parent.name == "snapshots" and len(rp.name) == 40:
+            return {"spec": str(spec), "kind": "hub", "revision": rp.name}
+        shards = sorted(rp.glob("*.safetensors"))
+        if shards:
+            return {"spec": str(spec), "kind": "local", "path": str(rp),
+                    "safetensors_bytes": sum(f.stat().st_size for f in shards),
+                    "n_shards": len(shards)}
 
     p = _P(spec)
     if p.is_dir():
@@ -59,7 +78,6 @@ def resolved_identity(spec):
                 "revision": HfApi().model_info(str(spec)).sha}
     except Exception as exc:  # offline, private, or not a repo id
         return {"spec": str(spec), "kind": "unresolved", "error": str(exc)[:120]}
-
 
 def load_any(path):
     """Load a TurboQuant or a stock mlx-vlm checkpoint, returning (model, kind)."""
@@ -89,6 +107,12 @@ def load_any(path):
 
 
 def corpus_ids(tokenizer, seq_len, n_chunks):
+    """(token ids, corpus fingerprint).
+
+    `load_dataset` resolves a mutable default revision, so the fingerprint is
+    recorded with the scores — two runs quoting the same PPL should be able to
+    show they read the same bytes.
+    """
     from datasets import load_dataset
 
     ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="test")
@@ -98,7 +122,13 @@ def corpus_ids(tokenizer, seq_len, n_chunks):
     ids = tokenizer.encode(text[: need * 6])
     if len(ids) < need + 1:
         raise SystemExit(f"corpus too short: {len(ids)} tokens, need {need + 1}")
-    return ids[: need + 1]
+    fingerprint = {
+        "dataset": "wikitext/wikitext-2-raw-v1:test",
+        "rows": ds.num_rows,
+        "hf_fingerprint": getattr(ds, "_fingerprint", None),
+        "text_sha256": hashlib.sha256(text.encode()).hexdigest(),
+    }
+    return ids[: need + 1], fingerprint
 
 
 def perplexity(model, ids, seq_len, n_chunks, label):
@@ -138,7 +168,7 @@ def main():
         print(f"\n=== {spec} ===")
         model, kind, resolved = load_any(spec)
         tok = AutoTokenizer.from_pretrained(str(resolved))
-        ids = corpus_ids(tok, args.seq_len, args.chunks)
+        ids, corpus_fp = corpus_ids(tok, args.seq_len, args.chunks)
 
         if ref_ids is None:
             ref_ids = ids
@@ -154,7 +184,7 @@ def main():
         peak = mx.get_peak_memory() / 1024**3
         results.append({"model": spec, "kind": kind, "ppl": ppl,
                         "tokens": n, "peak_gib": peak,
-                        "identity": resolved_identity(spec)})
+                        "identity": resolved_identity(spec, resolved)})
         print(f"  peak {peak:.2f} GiB")
         del model
         import gc
@@ -173,7 +203,7 @@ def main():
               f"({'better' if d < 0 else 'worse'})")
     if args.json:
         Path(args.json).write_text(json.dumps({
-            "corpus": "wikitext-2-raw-v1 test",
+            "corpus": corpus_fp,
             "seq_len": args.seq_len,
             "chunks": args.chunks,
             "note": ("teacher-forced NLL over the whole corpus slice; "

--- a/benchmarks/eval_vlm_perplexity_qwen3.8_27b_16k_results.json
+++ b/benchmarks/eval_vlm_perplexity_qwen3.8_27b_16k_results.json
@@ -1,5 +1,10 @@
 {
-  "corpus": "wikitext-2-raw-v1 test",
+  "corpus": {
+    "dataset": "wikitext/wikitext-2-raw-v1:test",
+    "rows": 4358,
+    "hf_fingerprint": "7ccd6deaa4fc56e5",
+    "text_sha256": "c5b5caea5bd655cb221545a484f2f0f59d35092a17a66840d7b9513d0b99687d"
+  },
   "seq_len": 512,
   "chunks": 32,
   "note": "teacher-forced NLL over the whole corpus slice; tokenization asserted identical across models",
@@ -13,6 +18,7 @@
       "identity": {
         "spec": "./Qwen3.8-27B-tq4-g64",
         "kind": "local",
+        "path": "Qwen3.8-27B-tq4-g64",
         "safetensors_bytes": 16267476171,
         "n_shards": 4
       }
@@ -26,6 +32,7 @@
       "identity": {
         "spec": "./Qwen3.8-27B-tq4-g64-x4",
         "kind": "local",
+        "path": "Qwen3.8-27B-tq4-g64-x4",
         "safetensors_bytes": 14833737981,
         "n_shards": 3
       }

--- a/benchmarks/eval_vlm_perplexity_qwen3.8_27b_16k_results.json
+++ b/benchmarks/eval_vlm_perplexity_qwen3.8_27b_16k_results.json
@@ -1,14 +1,14 @@
 {
   "corpus": "wikitext-2-raw-v1 test",
   "seq_len": 512,
-  "chunks": 64,
+  "chunks": 32,
   "note": "teacher-forced NLL over the whole corpus slice; tokenization asserted identical across models",
   "results": [
     {
       "model": "./Qwen3.8-27B-tq4-g64",
       "kind": "turboquant 4-bit g64 + 8-bit affine extras",
-      "ppl": 8.332125769262642,
-      "tokens": 32768,
+      "ppl": 7.249630815134445,
+      "tokens": 16384,
       "peak_gib": 17.801740968599916,
       "identity": {
         "spec": "./Qwen3.8-27B-tq4-g64",
@@ -20,9 +20,9 @@
     {
       "model": "./Qwen3.8-27B-tq4-g64-x4",
       "kind": "turboquant 4-bit g64 + 4-bit affine extras",
-      "ppl": 8.40609137395774,
-      "tokens": 32768,
-      "peak_gib": 16.54513002745807,
+      "ppl": 7.304318310563907,
+      "tokens": 16384,
+      "peak_gib": 16.467008912935853,
       "identity": {
         "spec": "./Qwen3.8-27B-tq4-g64-x4",
         "kind": "local",
@@ -33,8 +33,8 @@
     {
       "model": "mlx-community/Qwen3.8-27B-4bit",
       "kind": "affine 4-bit g64",
-      "ppl": 8.35929115350064,
-      "tokens": 32768,
+      "ppl": 7.268542229379161,
+      "tokens": 16384,
       "peak_gib": 16.155393222346902,
       "identity": {
         "spec": "mlx-community/Qwen3.8-27B-4bit",

--- a/benchmarks/eval_vlm_perplexity_qwen3.8_27b_results.json
+++ b/benchmarks/eval_vlm_perplexity_qwen3.8_27b_results.json
@@ -1,0 +1,32 @@
+{
+  "corpus": "wikitext-2-raw-v1 test",
+  "chunks": 64,
+  "seq_len": 512,
+  "machine": "Apple M4 Max 64 GB, macOS 26.5.2",
+  "mlx_lm": "0.31.3",
+  "mlx_vlm": "0.6.3",
+  "note": "teacher-forced NLL, greedy-irrelevant; tokenization asserted identical across models",
+  "results": [
+    {
+      "model": "mlx-community/Qwen3.8-27B-4bit",
+      "kind": "affine 4-bit g64",
+      "ppl": 8.35929115350064,
+      "tokens": 32768,
+      "peak_gib": 16.155393160879612
+    },
+    {
+      "model": "./Qwen3.8-27B-tq4-g64",
+      "kind": "turboquant 4-bit g64 + 8-bit affine extras",
+      "ppl": 8.332125769262642,
+      "tokens": 32768,
+      "peak_gib": 17.80174097046256
+    },
+    {
+      "model": "./Qwen3.8-27B-tq4-g64-x4",
+      "kind": "turboquant 4-bit g64 + 4-bit affine extras",
+      "ppl": 8.40609137395774,
+      "tokens": 32768,
+      "peak_gib": 16.467008914798498
+    }
+  ]
+}

--- a/benchmarks/eval_vlm_perplexity_qwen3.8_27b_results.json
+++ b/benchmarks/eval_vlm_perplexity_qwen3.8_27b_results.json
@@ -1,5 +1,10 @@
 {
-  "corpus": "wikitext-2-raw-v1 test",
+  "corpus": {
+    "dataset": "wikitext/wikitext-2-raw-v1:test",
+    "rows": 4358,
+    "hf_fingerprint": "7ccd6deaa4fc56e5",
+    "text_sha256": "c5b5caea5bd655cb221545a484f2f0f59d35092a17a66840d7b9513d0b99687d"
+  },
   "seq_len": 512,
   "chunks": 64,
   "note": "teacher-forced NLL over the whole corpus slice; tokenization asserted identical across models",
@@ -9,10 +14,11 @@
       "kind": "turboquant 4-bit g64 + 8-bit affine extras",
       "ppl": 8.332125769262642,
       "tokens": 32768,
-      "peak_gib": 17.801740968599916,
+      "peak_gib": 17.96287147514522,
       "identity": {
         "spec": "./Qwen3.8-27B-tq4-g64",
         "kind": "local",
+        "path": "Qwen3.8-27B-tq4-g64",
         "safetensors_bytes": 16267476171,
         "n_shards": 4
       }
@@ -22,10 +28,11 @@
       "kind": "turboquant 4-bit g64 + 4-bit affine extras",
       "ppl": 8.40609137395774,
       "tokens": 32768,
-      "peak_gib": 16.54513002745807,
+      "peak_gib": 16.62813982181251,
       "identity": {
         "spec": "./Qwen3.8-27B-tq4-g64-x4",
         "kind": "local",
+        "path": "Qwen3.8-27B-tq4-g64-x4",
         "safetensors_bytes": 14833737981,
         "n_shards": 3
       }

--- a/benchmarks/eval_vlm_vision.py
+++ b/benchmarks/eval_vlm_vision.py
@@ -82,17 +82,17 @@ def resolved_identity(spec, resolved_path=None):
         return {"spec": str(spec), "kind": "unresolved", "error": str(exc)[:120]}
 
 
-def engine_for(model):
+def engine_for(resolved):
     """(module, temp_flag) — TurboQuant checkpoints need our loader, others mlx-vlm's.
 
-    Same images, same prompts, same accept lists either way; only the entry
-    point differs, because `generate_vlm` refuses non-TurboQuant checkpoints
-    and `mlx_vlm.generate` cannot read a polar one.
+    Takes an ALREADY-resolved path so the whole run resolves the spec exactly
+    once. Same images, same prompts, same accept lists either way; only the
+    entry point differs, because `generate_vlm` refuses non-TurboQuant
+    checkpoints and `mlx_vlm.generate` cannot read a polar one.
     """
     from turboquant_mlx.serve_vlm import is_turboquant_checkpoint
-    from turboquant_mlx.generate import resolve_model_path
 
-    if is_turboquant_checkpoint(Path(resolve_model_path(str(model)))):
+    if is_turboquant_checkpoint(Path(resolved)):
         return "turboquant_mlx.generate_vlm", "--temp"
     return "mlx_vlm.generate", "--temperature"
 
@@ -252,17 +252,23 @@ def peak_gib(text):
 
 def run(model, max_tokens=128):
     manifest = build_images()
-    module, temp_flag = engine_for(model)
     from turboquant_mlx.generate import resolve_model_path
 
+    # Resolve once, here, and hand every child the resolved path. Passing the
+    # raw spec would let each subprocess re-resolve a mutable Hub id on its
+    # own, so a repo updated mid-run could be scored under the revision
+    # recorded in `identity` while actually loading a different one — which
+    # would quietly defeat the point of recording it. Also saves a Hub
+    # round-trip per case (measured ~0.4 s each).
     resolved = resolve_model_path(str(model))
+    module, temp_flag = engine_for(resolved)
     print(f"model: {model}   (via {module})\n")
     cases, peaks = [], []
     for name, prompt, accept in CASES:
         t0 = time.time()
         proc = subprocess.run(
             [PYTHON, "-m", module,
-             "--model", str(model), "--image", str(OUT / name),
+             "--model", str(resolved), "--image", str(OUT / name),
              "--prompt", prompt, "--max-tokens", str(max_tokens), temp_flag, "0"],
             capture_output=True, text=True,
         )

--- a/benchmarks/eval_vlm_vision.py
+++ b/benchmarks/eval_vlm_vision.py
@@ -22,6 +22,7 @@ Usage:
 
 import argparse
 import json
+import os
 import re
 import subprocess
 import sys
@@ -35,6 +36,32 @@ from PIL import Image, ImageDraw, ImageFont
 # the environment the caller actually set up.
 PYTHON = sys.executable
 OUT = Path(tempfile.mkdtemp(prefix="tq_vision_"))
+
+
+def resolved_identity(spec):
+    """A record of exactly which bytes were measured.
+
+    Repo ids and dataset defaults are mutable — `mlx-community/X-4bit` can be
+    re-uploaded and a published number would silently start describing
+    different weights. For a Hub repo this pins the commit sha; for a local
+    directory it records the path and the total size of its safetensors, which
+    is enough to notice a swap.
+    """
+    from pathlib import Path as _P
+
+    p = _P(spec)
+    if p.is_dir():
+        shards = sorted(p.glob("*.safetensors"))
+        return {"spec": str(spec), "kind": "local",
+                "safetensors_bytes": sum(f.stat().st_size for f in shards),
+                "n_shards": len(shards)}
+    try:
+        from huggingface_hub import HfApi
+
+        return {"spec": str(spec), "kind": "hub",
+                "revision": HfApi().model_info(str(spec)).sha}
+    except Exception as exc:  # offline, private, or not a repo id
+        return {"spec": str(spec), "kind": "unresolved", "error": str(exc)[:120]}
 
 
 def engine_for(model):
@@ -52,16 +79,41 @@ def engine_for(model):
     return "mlx_vlm.generate", "--temperature"
 
 
+# Scalable fonts to draw the OCR and chart labels with, most-preferred first.
+# Covers macOS and the usual Linux packages. Override with TQ_VISION_FONT.
+_FONT_CANDIDATES = (
+    "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+    "/System/Library/Fonts/Helvetica.ttc",
+    "/usr/share/fonts/truetype/dejavu/DejaVuSans-Bold.ttf",
+    "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
+    "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf",
+)
+
+
 def _font(size):
-    for path in (
-        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
-        "/System/Library/Fonts/Helvetica.ttc",
-    ):
+    """A scalable font at `size`, or a hard failure.
+
+    Deliberately no `ImageFont.load_default()` fallback. That returns a small
+    fixed-size bitmap face, so the text would render a few pixels tall and the
+    OCR case would measure nothing — while still reporting a tidy PASS/FAIL as
+    if the result meant something. A missing font is a setup problem and should
+    look like one.
+
+    Not bundled in the repo: shipping a font means carrying its licence and a
+    few hundred KB for a benchmark most people never run. Point
+    TQ_VISION_FONT at one instead.
+    """
+    explicit = os.environ.get("TQ_VISION_FONT")
+    for path in ((explicit,) if explicit else ()) + _FONT_CANDIDATES:
         try:
             return ImageFont.truetype(path, size)
         except OSError:
             continue
-    return ImageFont.load_default()
+    raise SystemExit(
+        "no scalable font found — the OCR and chart cases need one to render "
+        "legible text. Set TQ_VISION_FONT=/path/to/font.ttf, or install e.g. "
+        "fonts-dejavu. Looked in:\n  " + "\n  ".join(_FONT_CANDIDATES)
+    )
 
 
 def build_images():
@@ -158,6 +210,16 @@ def run(model, max_tokens=128):
              "--prompt", prompt, "--max-tokens", str(max_tokens), temp_flag, "0"],
             capture_output=True, text=True,
         )
+        if proc.returncode != 0:
+            # Never score a crash. A failed load or an OOM would otherwise be
+            # extracted as a wrong "answer" and recorded as a failed case,
+            # which reads as a model capability result rather than the setup
+            # failure it is.
+            raise SystemExit(
+                f"{model}: `{module}` exited {proc.returncode} on case "
+                f"{name!r} — this is an execution failure, not a wrong answer."
+                f"\n--- stderr ---\n{proc.stderr[-2000:]}"
+            )
         blob = proc.stdout + proc.stderr
         answer = extract_answer(blob)
         peak = peak_gib(blob)
@@ -175,7 +237,7 @@ def run(model, max_tokens=128):
           + (f", peak {max(peaks):.2f} GiB" if peaks else ""))
     return {"model": str(model), "engine": module, "passed": n_pass,
             "total": len(CASES), "peak_gib": max(peaks) if peaks else None,
-            "cases": cases}
+            "identity": resolved_identity(model), "cases": cases}
 
 
 def main():

--- a/benchmarks/eval_vlm_vision.py
+++ b/benchmarks/eval_vlm_vision.py
@@ -38,16 +38,34 @@ PYTHON = sys.executable
 OUT = Path(tempfile.mkdtemp(prefix="tq_vision_"))
 
 
-def resolved_identity(spec):
+def resolved_identity(spec, resolved_path=None):
     """A record of exactly which bytes were measured.
 
-    Repo ids and dataset defaults are mutable — `mlx-community/X-4bit` can be
-    re-uploaded and a published number would silently start describing
-    different weights. For a Hub repo this pins the commit sha; for a local
-    directory it records the path and the total size of its safetensors, which
-    is enough to notice a swap.
+    Repo ids are mutable — `mlx-community/X-4bit` can be re-uploaded and a
+    published number would silently start describing different weights.
+
+    The revision is read from the resolved snapshot directory, whose name IS
+    the commit sha, rather than asking the API what HEAD is now. That records
+    the revision actually loaded (no gap between load and lookup) and works
+    offline. The API is only a fallback for an unresolved spec.
+
+    Deliberately not a SHA-256 of every shard: these checkpoints are 13-16 GiB
+    each and three of them get scored per run, so digesting would add minutes
+    of pure I/O to every invocation. Shard count and total bytes catch a
+    swapped local build, and the revision pins a Hub one exactly.
     """
     from pathlib import Path as _P
+
+    if resolved_path is not None:
+        rp = _P(resolved_path)
+        # .../hub/models--org--name/snapshots/<sha>
+        if rp.parent.name == "snapshots" and len(rp.name) == 40:
+            return {"spec": str(spec), "kind": "hub", "revision": rp.name}
+        shards = sorted(rp.glob("*.safetensors"))
+        if shards:
+            return {"spec": str(spec), "kind": "local", "path": str(rp),
+                    "safetensors_bytes": sum(f.stat().st_size for f in shards),
+                    "n_shards": len(shards)}
 
     p = _P(spec)
     if p.is_dir():
@@ -88,6 +106,41 @@ _FONT_CANDIDATES = (
     "/usr/share/fonts/truetype/liberation/LiberationSans-Bold.ttf",
     "/usr/share/fonts/TTF/DejaVuSans-Bold.ttf",
 )
+_FONT_PATH = None
+
+
+def _font_path():
+    """The font file the images will be drawn with, resolved once.
+
+    Which font is used changes what the OCR case actually renders, so it is a
+    real input to the benchmark and gets recorded alongside the results.
+    """
+    global _FONT_PATH
+    if _FONT_PATH is not None:
+        return _FONT_PATH
+    explicit = os.environ.get("TQ_VISION_FONT")
+    for path in ((explicit,) if explicit else ()) + _FONT_CANDIDATES:
+        try:
+            ImageFont.truetype(path, 12)
+        except OSError:
+            continue
+        _FONT_PATH = path
+        return path
+    raise SystemExit(
+        "no scalable font found — the OCR and chart cases need one to render "
+        "legible text. Set TQ_VISION_FONT=/path/to/font.ttf, or install e.g. "
+        "fonts-dejavu. Looked in:\n  " + "\n  ".join(_FONT_CANDIDATES)
+    )
+
+
+def _sha256(path):
+    import hashlib
+
+    h = hashlib.sha256()
+    with open(path, "rb") as fh:
+        for block in iter(lambda: fh.read(1 << 20), b""):
+            h.update(block)
+    return h.hexdigest()
 
 
 def _font(size):
@@ -103,21 +156,16 @@ def _font(size):
     few hundred KB for a benchmark most people never run. Point
     TQ_VISION_FONT at one instead.
     """
-    explicit = os.environ.get("TQ_VISION_FONT")
-    for path in ((explicit,) if explicit else ()) + _FONT_CANDIDATES:
-        try:
-            return ImageFont.truetype(path, size)
-        except OSError:
-            continue
-    raise SystemExit(
-        "no scalable font found — the OCR and chart cases need one to render "
-        "legible text. Set TQ_VISION_FONT=/path/to/font.ttf, or install e.g. "
-        "fonts-dejavu. Looked in:\n  " + "\n  ".join(_FONT_CANDIDATES)
-    )
+    return ImageFont.truetype(_font_path(), size)
 
 
 def build_images():
-    """Synthetic images with ground truth we drew, so scoring is objective."""
+    """Draw the cases and return a digest manifest.
+
+    The drawing code is fixed, but the font is not — a different face changes
+    what the OCR case renders, so the font and the resulting image bytes are
+    both hashed and published with the scores.
+    """
     OUT.mkdir(exist_ok=True)
 
     img = Image.new("RGB", (640, 320), "white")
@@ -149,6 +197,11 @@ def build_images():
     d.polygon([(120, 60), (60, 170), (180, 170)], fill="green")
     d.ellipse([460, 240, 580, 360], fill="orange")
     img.save(OUT / "spatial.png")
+
+    return {
+        "font": {"path": _font_path(), "sha256": _sha256(_font_path())},
+        "images": {f.name: _sha256(f) for f in sorted(OUT.glob("*.png"))},
+    }
 
 
 CASES = [
@@ -198,8 +251,11 @@ def peak_gib(text):
 
 
 def run(model, max_tokens=128):
-    build_images()
+    manifest = build_images()
     module, temp_flag = engine_for(model)
+    from turboquant_mlx.generate import resolve_model_path
+
+    resolved = resolve_model_path(str(model))
     print(f"model: {model}   (via {module})\n")
     cases, peaks = [], []
     for name, prompt, accept in CASES:
@@ -237,7 +293,8 @@ def run(model, max_tokens=128):
           + (f", peak {max(peaks):.2f} GiB" if peaks else ""))
     return {"model": str(model), "engine": module, "passed": n_pass,
             "total": len(CASES), "peak_gib": max(peaks) if peaks else None,
-            "identity": resolved_identity(model), "cases": cases}
+            "identity": resolved_identity(model, resolved),
+            "inputs": manifest, "cases": cases}
 
 
 def main():

--- a/benchmarks/eval_vlm_vision.py
+++ b/benchmarks/eval_vlm_vision.py
@@ -1,0 +1,203 @@
+"""Four-case vision battery for any mlx-vlm checkpoint, TurboQuant or affine.
+
+OCR, counting, chart reading, spatial relations. Every image is drawn here, so
+the ground truth is something we set rather than something a judge model
+decides — the scoring is a substring match against an accept list, and the
+whole thing is greedy, so a run is reproducible.
+
+The engine is chosen from the checkpoint: a TurboQuant build goes through
+`turboquant_mlx.generate_vlm`, anything else through `mlx_vlm.generate`. Same
+images, same prompts, same accept lists either way, which is what makes a
+TurboQuant-vs-affine comparison meaningful.
+
+One caution learned the hard way: a single failing case is not a capability
+claim. On Qwen3.8-27B the affine build missed `text.png` while TurboQuant
+passed it, but a follow-up five-string probe put affine at 4/5 — the miss was
+one string, not an OCR weakness. Treat a 3/4-vs-4/4 split as a tie until a
+wider probe says otherwise.
+
+Usage:
+    python -m turboquant_mlx.benchmarks.eval_vlm_vision <model> [--json out.json]
+"""
+
+import argparse
+import json
+import re
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+from PIL import Image, ImageDraw, ImageFont
+
+# The same interpreter that launched this module, so the subprocess inherits
+# the environment the caller actually set up.
+PYTHON = sys.executable
+OUT = Path(tempfile.mkdtemp(prefix="tq_vision_"))
+
+
+def engine_for(model):
+    """(module, temp_flag) — TurboQuant checkpoints need our loader, others mlx-vlm's.
+
+    Same images, same prompts, same accept lists either way; only the entry
+    point differs, because `generate_vlm` refuses non-TurboQuant checkpoints
+    and `mlx_vlm.generate` cannot read a polar one.
+    """
+    from turboquant_mlx.serve_vlm import is_turboquant_checkpoint
+    from turboquant_mlx.generate import resolve_model_path
+
+    if is_turboquant_checkpoint(Path(resolve_model_path(str(model)))):
+        return "turboquant_mlx.generate_vlm", "--temp"
+    return "mlx_vlm.generate", "--temperature"
+
+
+def _font(size):
+    for path in (
+        "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "/System/Library/Fonts/Helvetica.ttc",
+    ):
+        try:
+            return ImageFont.truetype(path, size)
+        except OSError:
+            continue
+    return ImageFont.load_default()
+
+
+def build_images():
+    """Synthetic images with ground truth we drew, so scoring is objective."""
+    OUT.mkdir(exist_ok=True)
+
+    img = Image.new("RGB", (640, 320), "white")
+    ImageDraw.Draw(img).text((60, 120), "VOLTAGE 47", fill="black", font=_font(72))
+    img.save(OUT / "text.png")
+
+    img = Image.new("RGB", (640, 400), "white")
+    d = ImageDraw.Draw(img)
+    for i in range(3):
+        x = 80 + i * 160
+        d.ellipse([x, 60, x + 100, 160], fill="red")
+    for i in range(2):
+        x = 160 + i * 200
+        d.rectangle([x, 240, x + 100, 340], fill="blue")
+    img.save(OUT / "count.png")
+
+    img = Image.new("RGB", (640, 420), "white")
+    d = ImageDraw.Draw(img)
+    f = _font(28)
+    for i, (label, h) in enumerate([("A", 120), ("B", 200), ("C", 320)]):
+        x = 100 + i * 160
+        d.rectangle([x, 360 - h, x + 90, 360], fill="#3366cc")
+        d.text((x + 30, 370), label, fill="black", font=f)
+    d.line([80, 360, 600, 360], fill="black", width=3)
+    img.save(OUT / "chart.png")
+
+    img = Image.new("RGB", (640, 400), "white")
+    d = ImageDraw.Draw(img)
+    d.polygon([(120, 60), (60, 170), (180, 170)], fill="green")
+    d.ellipse([460, 240, 580, 360], fill="orange")
+    img.save(OUT / "spatial.png")
+
+
+CASES = [
+    ("text.png", "What text is written in this image? Answer with just the text.",
+     ["voltage 47", "voltage47"]),
+    ("count.png", "How many red circles are in this image? Answer with just the number.",
+     ["3", "three"]),
+    ("chart.png", "Which bar is tallest: A, B, or C? Answer with just the letter.",
+     ["c"]),
+    ("spatial.png", "What shape is in the top-left of this image? Answer with one word.",
+     ["triangle"]),
+]
+
+_NOISE = ("[INFO]", "[transformers]", "Prompt:", "Generation:", "Files:",
+          "peak memory", "Peak memory", "==========", "<|im_start|>",
+          "<|im_end|>", "Fetching")
+
+
+def extract_answer(text):
+    """The answer after the prompt echo and the `<think>` channel."""
+    if "==========" in text:
+        text = text.split("==========")[-2] if text.count("==========") >= 2 else text
+    # Qwen3.5 templates open a reasoning channel; the answer follows it.
+    text = re.sub(r"<think>.*?</think>", " ", text, flags=re.S)
+    text = text.replace("<think>", " ").replace("</think>", " ")
+    if "assistant" in text:
+        text = text.rsplit("assistant", 1)[1]
+    lines = [ln.strip() for ln in text.splitlines()
+             if ln.strip() and not ln.strip().startswith(_NOISE)]
+    return " ".join(lines).strip()
+
+
+def peak_gib(text):
+    """Peak memory in GiB.
+
+    Two reporters print a line and they disagree on units, distinguished only
+    by capitalisation: mlx-vlm's `Peak memory:` is decimal GB, turboquant's
+    lowercase `peak memory:` is already GiB. Prefer the lowercase one.
+    """
+    m = re.search(r"\bpeak memory:\s*([\d.]+)\s*GB", text)
+    if m:
+        return float(m.group(1))
+    m = re.search(r"\bPeak memory:\s*([\d.]+)\s*GB", text)
+    if m:
+        return float(m.group(1)) / 1.073741824
+    return None
+
+
+def run(model, max_tokens=128):
+    build_images()
+    module, temp_flag = engine_for(model)
+    print(f"model: {model}   (via {module})\n")
+    cases, peaks = [], []
+    for name, prompt, accept in CASES:
+        t0 = time.time()
+        proc = subprocess.run(
+            [PYTHON, "-m", module,
+             "--model", str(model), "--image", str(OUT / name),
+             "--prompt", prompt, "--max-tokens", str(max_tokens), temp_flag, "0"],
+            capture_output=True, text=True,
+        )
+        blob = proc.stdout + proc.stderr
+        answer = extract_answer(blob)
+        peak = peak_gib(blob)
+        if peak:
+            peaks.append(peak)
+        ok = any(a in answer.lower() for a in accept)
+        cases.append({"case": name, "passed": ok, "answer": answer[:200],
+                      "accept": accept, "seconds": round(time.time() - t0, 1),
+                      "peak_gib": peak})
+        print(f"  [{'PASS' if ok else 'FAIL'}] {name:<12} {cases[-1]['seconds']:5.1f}s  "
+              f"peak {peak if peak else float('nan'):5.2f} GiB")
+        print(f"         expected one of {accept} -> got {answer[:110]!r}")
+    n_pass = sum(c["passed"] for c in cases)
+    print(f"\nvision: {n_pass}/{len(CASES)} passed"
+          + (f", peak {max(peaks):.2f} GiB" if peaks else ""))
+    return {"model": str(model), "engine": module, "passed": n_pass,
+            "total": len(CASES), "peak_gib": max(peaks) if peaks else None,
+            "cases": cases}
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    ap.add_argument("models", nargs="+", help="checkpoint dirs or HF repo ids")
+    ap.add_argument("--max-tokens", type=int, default=128)
+    ap.add_argument("--json", type=str, default=None)
+    args = ap.parse_args()
+
+    results = [run(m, args.max_tokens) for m in args.models]
+    if len(results) > 1:
+        print(f"\n{'model':<44}{'vision':>10}{'peak GiB':>11}")
+        print("-" * 65)
+        for r in results:
+            score = f"{r['passed']}/{r['total']}"
+            print(f"{r['model']:<44}{score:>10}"
+                  f"{r['peak_gib'] or float('nan'):>11.2f}")
+    if args.json:
+        Path(args.json).write_text(json.dumps(results, indent=2))
+        print(f"\nwrote {args.json}")
+    return 0 if all(r["passed"] == r["total"] for r in results) else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
+++ b/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
@@ -1,0 +1,104 @@
+[
+  {
+    "model": "./Qwen3.8-27B-tq4-g64",
+    "engine": "turboquant_mlx.generate_vlm",
+    "passed": 4,
+    "total": 4,
+    "peak_gib": 18.52,
+    "cases": [
+      {
+        "case": "text.png",
+        "passed": true,
+        "answer": "VOLTAGE47",
+        "accept": [
+          "voltage 47",
+          "voltage47"
+        ],
+        "seconds": 7.8,
+        "peak_gib": 16.73
+      },
+      {
+        "case": "count.png",
+        "passed": true,
+        "answer": "3",
+        "accept": [
+          "3",
+          "three"
+        ],
+        "seconds": 6.7,
+        "peak_gib": 18.48
+      },
+      {
+        "case": "chart.png",
+        "passed": true,
+        "answer": "C",
+        "accept": [
+          "c"
+        ],
+        "seconds": 6.8,
+        "peak_gib": 18.52
+      },
+      {
+        "case": "spatial.png",
+        "passed": true,
+        "answer": "triangle",
+        "accept": [
+          "triangle"
+        ],
+        "seconds": 6.8,
+        "peak_gib": 18.48
+      }
+    ]
+  },
+  {
+    "model": "mlx-community/Qwen3.8-27B-4bit",
+    "engine": "mlx_vlm.generate",
+    "passed": 3,
+    "total": 4,
+    "peak_gib": 17.66905188560486,
+    "cases": [
+      {
+        "case": "text.png",
+        "passed": false,
+        "answer": "VOLTAGE",
+        "accept": [
+          "voltage 47",
+          "voltage47"
+        ],
+        "seconds": 6.7,
+        "peak_gib": 17.562881112098694
+      },
+      {
+        "case": "count.png",
+        "passed": true,
+        "answer": "3",
+        "accept": [
+          "3",
+          "three"
+        ],
+        "seconds": 5.1,
+        "peak_gib": 17.636455595493317
+      },
+      {
+        "case": "chart.png",
+        "passed": true,
+        "answer": "C",
+        "accept": [
+          "c"
+        ],
+        "seconds": 5.2,
+        "peak_gib": 17.66905188560486
+      },
+      {
+        "case": "spatial.png",
+        "passed": true,
+        "answer": "triangle",
+        "accept": [
+          "triangle"
+        ],
+        "seconds": 5.0,
+        "peak_gib": 17.638318240642548
+      }
+    ]
+  }
+]

--- a/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
+++ b/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
@@ -8,8 +8,21 @@
     "identity": {
       "spec": "./Qwen3.8-27B-tq4-g64",
       "kind": "local",
+      "path": "Qwen3.8-27B-tq4-g64",
       "safetensors_bytes": 16267476171,
       "n_shards": 4
+    },
+    "inputs": {
+      "font": {
+        "path": "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "sha256": "d72db21f9242aedd6b917d8549ad5921766b24d5f8d0becfda2ff4c620b3c2e0"
+      },
+      "images": {
+        "chart.png": "7c0340187ab10aed548db4eee48c2971e5f9d37e6e5147568f9b06589250f5a4",
+        "count.png": "768b147eb76c1ed3d6ae7108612bb1c5e2f328560601b3de277ff15ec4c0d750",
+        "spatial.png": "97b46fd94fbf5e6bbdd417129a2175802979e42c69db30757d4c87b53e082c5d",
+        "text.png": "4542e0bcd7c1879136921faf2505fbbbce92ad7f6f2c720f38e50a92b50ad389"
+      }
     },
     "cases": [
       {
@@ -20,7 +33,7 @@
           "voltage 47",
           "voltage47"
         ],
-        "seconds": 10.7,
+        "seconds": 7.0,
         "peak_gib": 16.73
       },
       {
@@ -31,7 +44,7 @@
           "3",
           "three"
         ],
-        "seconds": 8.4,
+        "seconds": 6.8,
         "peak_gib": 18.48
       },
       {
@@ -41,7 +54,7 @@
         "accept": [
           "c"
         ],
-        "seconds": 8.5,
+        "seconds": 6.9,
         "peak_gib": 18.52
       },
       {
@@ -51,7 +64,7 @@
         "accept": [
           "triangle"
         ],
-        "seconds": 8.3,
+        "seconds": 6.8,
         "peak_gib": 18.48
       }
     ]
@@ -67,6 +80,18 @@
       "kind": "hub",
       "revision": "3e6447f082e89cc7f0bc6e5441afd38dfce760ff"
     },
+    "inputs": {
+      "font": {
+        "path": "/System/Library/Fonts/Supplemental/Arial Bold.ttf",
+        "sha256": "d72db21f9242aedd6b917d8549ad5921766b24d5f8d0becfda2ff4c620b3c2e0"
+      },
+      "images": {
+        "chart.png": "7c0340187ab10aed548db4eee48c2971e5f9d37e6e5147568f9b06589250f5a4",
+        "count.png": "768b147eb76c1ed3d6ae7108612bb1c5e2f328560601b3de277ff15ec4c0d750",
+        "spatial.png": "97b46fd94fbf5e6bbdd417129a2175802979e42c69db30757d4c87b53e082c5d",
+        "text.png": "4542e0bcd7c1879136921faf2505fbbbce92ad7f6f2c720f38e50a92b50ad389"
+      }
+    },
     "cases": [
       {
         "case": "text.png",
@@ -76,7 +101,7 @@
           "voltage 47",
           "voltage47"
         ],
-        "seconds": 6.0,
+        "seconds": 6.1,
         "peak_gib": 17.562881112098694
       },
       {
@@ -97,7 +122,7 @@
         "accept": [
           "c"
         ],
-        "seconds": 5.1,
+        "seconds": 5.2,
         "peak_gib": 17.66905188560486
       },
       {
@@ -107,7 +132,7 @@
         "accept": [
           "triangle"
         ],
-        "seconds": 5.1,
+        "seconds": 5.4,
         "peak_gib": 17.638318240642548
       }
     ]

--- a/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
+++ b/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
@@ -5,6 +5,12 @@
     "passed": 4,
     "total": 4,
     "peak_gib": 18.52,
+    "identity": {
+      "spec": "./Qwen3.8-27B-tq4-g64",
+      "kind": "local",
+      "safetensors_bytes": 16267476171,
+      "n_shards": 4
+    },
     "cases": [
       {
         "case": "text.png",
@@ -14,7 +20,7 @@
           "voltage 47",
           "voltage47"
         ],
-        "seconds": 7.8,
+        "seconds": 10.7,
         "peak_gib": 16.73
       },
       {
@@ -25,7 +31,7 @@
           "3",
           "three"
         ],
-        "seconds": 6.7,
+        "seconds": 8.4,
         "peak_gib": 18.48
       },
       {
@@ -35,7 +41,7 @@
         "accept": [
           "c"
         ],
-        "seconds": 6.8,
+        "seconds": 8.5,
         "peak_gib": 18.52
       },
       {
@@ -45,7 +51,7 @@
         "accept": [
           "triangle"
         ],
-        "seconds": 6.8,
+        "seconds": 8.3,
         "peak_gib": 18.48
       }
     ]
@@ -56,6 +62,11 @@
     "passed": 3,
     "total": 4,
     "peak_gib": 17.66905188560486,
+    "identity": {
+      "spec": "mlx-community/Qwen3.8-27B-4bit",
+      "kind": "hub",
+      "revision": "3e6447f082e89cc7f0bc6e5441afd38dfce760ff"
+    },
     "cases": [
       {
         "case": "text.png",
@@ -65,7 +76,7 @@
           "voltage 47",
           "voltage47"
         ],
-        "seconds": 6.7,
+        "seconds": 6.0,
         "peak_gib": 17.562881112098694
       },
       {
@@ -76,7 +87,7 @@
           "3",
           "three"
         ],
-        "seconds": 5.1,
+        "seconds": 5.0,
         "peak_gib": 17.636455595493317
       },
       {
@@ -86,7 +97,7 @@
         "accept": [
           "c"
         ],
-        "seconds": 5.2,
+        "seconds": 5.1,
         "peak_gib": 17.66905188560486
       },
       {
@@ -96,7 +107,7 @@
         "accept": [
           "triangle"
         ],
-        "seconds": 5.0,
+        "seconds": 5.1,
         "peak_gib": 17.638318240642548
       }
     ]

--- a/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
+++ b/benchmarks/eval_vlm_vision_qwen3.8_27b_results.json
@@ -33,7 +33,7 @@
           "voltage 47",
           "voltage47"
         ],
-        "seconds": 7.0,
+        "seconds": 7.9,
         "peak_gib": 16.73
       },
       {
@@ -54,7 +54,7 @@
         "accept": [
           "c"
         ],
-        "seconds": 6.9,
+        "seconds": 6.8,
         "peak_gib": 18.52
       },
       {
@@ -101,7 +101,7 @@
           "voltage 47",
           "voltage47"
         ],
-        "seconds": 6.1,
+        "seconds": 6.4,
         "peak_gib": 17.562881112098694
       },
       {
@@ -112,7 +112,7 @@
           "3",
           "three"
         ],
-        "seconds": 5.0,
+        "seconds": 4.8,
         "peak_gib": 17.636455595493317
       },
       {
@@ -122,7 +122,7 @@
         "accept": [
           "c"
         ],
-        "seconds": 5.2,
+        "seconds": 4.8,
         "peak_gib": 17.66905188560486
       },
       {
@@ -132,7 +132,7 @@
         "accept": [
           "triangle"
         ],
-        "seconds": 5.4,
+        "seconds": 4.7,
         "peak_gib": 17.638318240642548
       }
     ]


### PR DESCRIPTION
Adds two reusable evaluation harnesses under `benchmarks/`, and the Qwen3.8-27B numbers they produced against [`mlx-community/Qwen3.8-27B-4bit`](https://huggingface.co/mlx-community/Qwen3.8-27B-4bit).

## Why new harnesses

`evaluate.py` loads through `mlx_lm.utils.load` and re-quantizes in-process, so it can reach neither a VLM nor a checkpoint that arrived pre-quantized from the Hub. Both are required to compare against someone else's published build.

**`eval_vlm_perplexity.py`** — WikiText-2 PPL for any mlx-vlm checkpoint, TurboQuant or affine. Teacher-forced, so no sampler or seed is involved. It **asserts both models tokenize the corpus identically** and aborts otherwise, rather than silently reporting incomparable numbers.

**`eval_vlm_vision.py`** — four drawn-to-order images (OCR, counting, chart reading, spatial relations) with ground truth we set, so scoring is a substring match rather than a judgement call. Picks the engine from the checkpoint, so the same images and accept lists score both builds.

## The comparison

Like-for-like: same architecture, same 4-bit / g64, no MTP weights on either side, same server stack.

| | affine 4-bit | TurboQuant `tq4-g64` |
|---|---|---|
| on disk | 14.95 GiB | 15.15 GiB · **13.81** with `--extras-bits 4` |
| bits/weight | 4.500 | **4.251** |
| PPL (16K / 32K tok) | 7.2685 / 8.3593 | **7.2496 / 8.3321** |
| decode | **29.7 tok/s** | 11.3 tok/s |
| peak, same harness | **16.16 GiB** | 17.80 GiB |
| vision | 3/4 | 4/4 |
| Opencode agentic | **pass** 6m42s | **pass** 6m12s |

**The README now recommends the affine build for 4-bit Qwen3.8-27B.** It is 2.6× faster to decode at a lower peak, and 0.3% PPL — real and stable in ordering across both corpus sizes — is not worth trading that for.

TurboQuant's one structural edge is storage, measured on the same 17408×5120 projection in both checkpoints:

| | weight | scales | biases | bits/weight |
|---|---|---|---|---|
| affine 4-bit | 42.50 MiB | 2.66 | **2.66** | **4.500** |
| polar 4-bit | 42.50 MiB | 2.66 | — | **4.251** |

The Hadamard rotation symmetrizes each group, so there is no zero-point to store. That is a rounding error at 4-bit and exactly why the codebook only earns its keep at 2-bit and below.

## Two things documented so they are not misread

- **The vision split is not a capability gap.** Affine's single miss is one string (`VOLTAGE 47` → `VOLTAGE`). I checked the raw output — a genuine 4-token generation, not a harness artifact — then ran a five-string word+number probe, and affine scored 4/5. It is one input, not an OCR weakness. Treat 3/4-vs-4/4 as a tie.
- **Agentic wall-clock is not a speed metric.** Affine decodes 2.6× faster yet finished *slower*, because it spent more tool turns.

Also worth recording: my first peak-memory comparison had the sign backwards, because `mlx_vlm.generate` prints decimal GB and `generate_vlm` prints GiB, through different load paths. The table above uses peaks measured inside one harness under identical inputs.

557 passed, 5 skipped. README anchors verified.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comparison of TurboQuant and affine 4-bit performance, storage, memory usage, vision, and agentic results.
  * Included reproduction commands, configuration guidance, recommendations, and benchmark caveats.

* **Benchmarks**
  * Added reproducible perplexity and vision evaluation tools with validation for tokenization, model loading, and test setup.
  * Added Qwen3.8-27B results covering perplexity, accuracy, timing, memory usage, and storage.
  * Vision testing now covers OCR, counting, chart interpretation, and spatial reasoning.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->