### PR TITLE
fix: load the affine extras tier; add the Qwen3.5/3.8 MTP head

### DIFF
--- a/convert.py
+++ b/convert.py
@@ -33,6 +33,7 @@ def convert(
     mlp_group_size: int = None,
     ternary_experts: bool = False,
     expert_down_bits: int = None,
+    keep_mtp: bool = False,
 ):
     """Convert a HuggingFace model to TurboQuant-compressed MLX format.
 
@@ -113,6 +114,19 @@ def convert(
     # Save
     print(f"[INFO] Saving to {mlx_path}")
     save(mlx_path, hf_path, model, tokenizer, config)
+
+    # Must run AFTER save(). mlx-lm's qwen3_5 sanitize() drops every `mtp.*` key,
+    # and load() above already applied it, so the head is not in `model` and
+    # cannot be saved from it -- it has to be copied from the source shards.
+    if keep_mtp:
+        from turboquant_mlx.mtp import preserve_mtp
+
+        n, nbytes = preserve_mtp(hf_path, mlx_path)
+        if n:
+            print(f"[INFO] Preserved MTP head: {n} tensors, "
+                  f"{nbytes / 1024**2:.0f} MiB (source dtype, not quantized)")
+        else:
+            print("[INFO] --keep-mtp requested but the source has no MTP head")
 
     # Print summary
     from mlx.nn.utils import tree_flatten
@@ -214,6 +228,16 @@ def configure_parser() -> argparse.ArgumentParser:
              "Use for models too big to convert in memory (e.g. 200B+ on 64 GB). "
              "(--dtype override is not supported in this mode.)",
     )
+    parser.add_argument(
+        "--keep-mtp",
+        action="store_true",
+        help="Copy the source model's multi-token-prediction head into the "
+             "output, for self-speculative decoding. mlx-lm discards these "
+             "tensors in sanitize(), so without this flag the head is lost. "
+             "Opt-in because it adds the head at its source dtype (810 MiB on "
+             "Qwen3.8-27B) and nothing consumes it yet. No-op if the source has "
+             "no MTP head.",
+    )
     return parser
 
 
@@ -238,6 +262,17 @@ def main():
             ternary_experts=args.ternary_experts,
             expert_down_bits=args.expert_down_bits,
         )
+        # Applied here rather than threaded through convert_streaming: the head
+        # is copied from the source shards after the fact either way, so the
+        # streaming path needs no knowledge of it.
+        if args.keep_mtp:
+            from turboquant_mlx.mtp import preserve_mtp
+
+            n, nbytes = preserve_mtp(args.hf_path, args.mlx_path)
+            print(f"[INFO] Preserved MTP head: {n} tensors, "
+                  f"{nbytes / 1024**2:.0f} MiB (source dtype, not quantized)"
+                  if n else
+                  "[INFO] --keep-mtp requested but the source has no MTP head")
         return
     convert(
         hf_path=args.hf_path,
@@ -253,6 +288,7 @@ def main():
         mlp_group_size=args.mlp_group_size,
         ternary_experts=args.ternary_experts,
         expert_down_bits=args.expert_down_bits,
+        keep_mtp=args.keep_mtp,
     )
 
 

--- a/convert.py
+++ b/convert.py
@@ -49,6 +49,14 @@ def convert(
         mlp_group_size: Optional finer group size for MoE expert tensors.
         ternary_experts: If True, quantize routed MoE experts to the ternary
             {-c,0,+c} codebook packed as base-3 trits (~1.6 bpw).
+        keep_mtp: If True, copy the source model's multi-token-prediction head
+            into the output. mlx-lm's ``sanitize()`` drops every ``mtp.*`` key,
+            so without this the head cannot survive conversion at all. The head
+            is copied **unquantized, at its source dtype** (810 MiB on
+            Qwen3.8-27B, ~1.9% of the bf16 model) — quantizing it is a separate
+            decision that wants its own quality gate. Off by default because
+            nothing in the decode path consumes it; see ``turboquant_mlx.mtp``.
+            No-op if the source has no head.
     """
     from mlx_lm.utils import load, save
 

--- a/generate.py
+++ b/generate.py
@@ -76,10 +76,15 @@ def _prepare_affine_extras(model, weights):
     both parameters exactly: the plain module's ``weight.shape[-1]`` is the
     unpacked width, so ``group_size = width / scales.shape[-1]`` and
     ``bits = packed_words * 32 / width``.
+
+    Raises:
+        RuntimeError: if a module has some but not all of ``weight``/``scales``/
+            ``biases``. An affine module declares all three, so a partial set is
+            a malformed checkpoint rather than a tier to skip.
     """
     import mlx.nn as nn
 
-    specs = {}
+    specs, pending = {}, {}
     for key in weights:
         if not key.endswith(".scales"):
             continue
@@ -91,6 +96,19 @@ def _prepare_affine_extras(model, weights):
             continue
         if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
             continue                      # already quantized
+        # An affine module declares all three tensors, so an incomplete set means
+        # a malformed checkpoint, not a tier we should skip. Both halves failed
+        # badly before: a missing `weight` raised a bare KeyError from the lookup
+        # below, and a missing `biases` was worse than that — `load_weights` does
+        # not replace omitted parameters, so the module kept its freshly
+        # initialized biases and returned plausible-looking garbage.
+        missing = [f"{path}.{n}" for n in ("weight", "scales", "biases")
+                   if f"{path}.{n}" not in weights]
+        if missing:
+            raise RuntimeError(
+                f"{path}: affine-quantized tensors are incomplete, missing "
+                f"{', '.join(missing)}. Re-convert this checkpoint."
+            )
         packed = weights[f"{path}.weight"]
         groups = weights[key].shape[-1]
         width = module.weight.shape[-1]
@@ -101,11 +119,17 @@ def _prepare_affine_extras(model, weights):
         if bits not in (2, 3, 4, 6, 8) or group_size not in (32, 64, 128):
             continue
         specs[path] = {"group_size": group_size, "bits": bits}
+        pending[path] = module
 
-    if not specs:
-        return specs
-
-    nn.quantize(model, class_predicate=lambda path, _m: specs.get(path, False))
+    # Deliberately not nn.quantize(class_predicate=...): a predicate returning a
+    # dict of per-module settings is only honoured from MLX 0.22 on, and this
+    # package declares mlx>=0.20, where the dict is merely truthy and every
+    # module silently lands on the call's group_size/bits (64/4 by default).
+    # mlx-lm pins mlx>=0.31.2 transitively, so that is a latent hazard rather
+    # than a live one — but calling to_quantized directly costs nothing, honours
+    # `specs` on every version, and keeps this independent of the declared floor.
+    for path, module in pending.items():
+        _set_nested_attr(model, path, module.to_quantized(**specs[path]))
     return specs
 
 

--- a/generate.py
+++ b/generate.py
@@ -42,6 +42,106 @@ def _set_nested_attr(model, path, value):
     setattr(parent, parts[-1], value)
 
 
+def _get_nested_module(model, path):
+    """Resolve a dot-separated path to a submodule, or None if it does not exist."""
+    node = model
+    for part in path.split("."):
+        if hasattr(node, part):
+            node = getattr(node, part)
+        elif part.isdigit():
+            try:
+                node = node[int(part)]
+            except (IndexError, KeyError, TypeError):
+                return None
+        else:
+            return None
+    return node
+
+
+def _prepare_affine_extras(model, weights):
+    """Quantize modules whose checkpoint weights are MLX-affine, not polar.
+
+    TurboQuant's "extras tier" — the token embedding and ``lm_head`` — is left to
+    MLX's affine quantizer rather than the polar codebook path, so those tensors
+    arrive as ``weight``/``scales``/``biases`` with no ``codebook``.
+    ``_prepare_polar_layers`` keys off ``.codebook`` and so never sees them, and
+    the freshly built model still holds a plain ``nn.Embedding`` / ``nn.Linear``
+    there. ``load_weights(strict=False)`` then DROPS their scales and biases
+    without complaint, leaving a module whose "weight" is a packed uint32 array.
+    Nothing errors; the model simply returns nonsense — on Qwen3.8-27B,
+    ``embed_tokens(ids)`` came back (1, T, 1280) uint32 instead of (1, T, 5120)
+    floats.
+
+    So convert those modules to their quantized counterparts first. Shapes fix
+    both parameters exactly: the plain module's ``weight.shape[-1]`` is the
+    unpacked width, so ``group_size = width / scales.shape[-1]`` and
+    ``bits = packed_words * 32 / width``.
+    """
+    import mlx.nn as nn
+
+    specs = {}
+    for key in weights:
+        if not key.endswith(".scales"):
+            continue
+        path = key[: -len(".scales")]
+        if f"{path}.codebook" in weights:
+            continue                      # polar tier, handled elsewhere
+        module = _get_nested_module(model, path)
+        if module is None or not hasattr(module, "to_quantized"):
+            continue
+        if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+            continue                      # already quantized
+        packed = weights[f"{path}.weight"]
+        groups = weights[key].shape[-1]
+        width = module.weight.shape[-1]
+        if groups == 0 or width % groups:
+            continue
+        group_size = width // groups
+        bits = (packed.shape[-1] * 32) // width
+        if bits not in (2, 3, 4, 6, 8) or group_size not in (32, 64, 128):
+            continue
+        specs[path] = {"group_size": group_size, "bits": bits}
+
+    if not specs:
+        return specs
+
+    nn.quantize(model, class_predicate=lambda path, _m: specs.get(path, False))
+    return specs
+
+
+def _assert_no_orphan_quant_params(model, weights, prepared):
+    """Fail loudly if any quantized parameter had nowhere to land.
+
+    ``load_weights(strict=False)`` is necessary here — the checkpoint legitimately
+    carries polar tensors the base modules do not declare — but it also means a
+    missed module is silent. A dropped ``scales`` produces a model that runs and
+    emits garbage, which is far worse than a crash, so check explicitly.
+    """
+    import mlx.nn as nn
+
+    orphans = []
+    for key in weights:
+        if not key.endswith((".scales", ".biases")):
+            continue
+        path = key.rsplit(".", 1)[0]
+        if path in prepared or f"{path}.codebook" in weights:
+            continue
+        module = _get_nested_module(model, path)
+        if module is None:
+            continue
+        if isinstance(module, (nn.QuantizedLinear, nn.QuantizedEmbedding)):
+            continue
+        if type(module).__name__.startswith("Polar"):
+            continue
+        orphans.append(f"{key} -> {type(module).__name__}")
+    if orphans:
+        raise RuntimeError(
+            "quantized parameters have no quantized module to load into, so "
+            "load_weights(strict=False) would discard them and the model would "
+            "return garbage:\n  " + "\n  ".join(sorted(orphans)[:12])
+        )
+
+
 def _prepare_polar_layers(model, weights, tq_config):
     """Replace nn.Linear and SwitchLinear with PolarQuantized versions.
 
@@ -226,6 +326,12 @@ def load_turboquant(model_path, lazy=False, fast=False):
 
     # Replace quantized layers with PolarQuantized versions
     _prepare_polar_layers(model, weights, tq_config)
+
+    # ...then the affine "extras" tier (embeddings, lm_head), which has no
+    # .codebook and so is invisible to the pass above.
+    prepared_affine = _prepare_affine_extras(model, weights)
+
+    _assert_no_orphan_quant_params(model, weights, prepared_affine)
 
     # Load weights into the model
     model.load_weights(list(weights.items()), strict=False)

--- a/integration/vlm.py
+++ b/integration/vlm.py
@@ -16,7 +16,11 @@ from pathlib import Path
 import mlx.core as mx
 
 from turboquant_mlx.config import TurboQuantConfig
-from turboquant_mlx.generate import _prepare_polar_layers
+from turboquant_mlx.generate import (
+    _assert_no_orphan_quant_params,
+    _prepare_affine_extras,
+    _prepare_polar_layers,
+)
 
 
 def _require_mlx_vlm():
@@ -218,23 +222,18 @@ def load_turboquant_vlm(model_path, lazy=False):
     # so no weight sanitization is needed before loading.
     _prepare_polar_layers(model, weights, tq_config)
 
-    # Checkpoints converted with --quantize-extras also carry 8-bit affine
-    # modules (embeddings, dense MLP, vision tower). Affine layers have
-    # `.scales` but no `.codebook` in the saved weights.
-    affine = tq_dict.get("affine_extras")
-    if affine:
-        import mlx.nn as nn
-
-        nn.quantize(
-            model,
-            group_size=int(affine["group_size"]),
-            bits=int(affine["bits"]),
-            class_predicate=lambda p, m: (
-                hasattr(m, "to_quantized")
-                and f"{p}.scales" in weights
-                and f"{p}.codebook" not in weights
-            ),
-        )
+    # Checkpoints also carry affine-quantized modules — the embeddings, lm_head
+    # and, on a VLM, the entire vision tower. Those have `.scales` but no
+    # `.codebook`, so `_prepare_polar_layers` never sees them.
+    #
+    # Recovered from the tensor shapes rather than read from the config's
+    # `affine_extras` block. That block is not guaranteed to be present, and the
+    # old `if affine:` meant a checkpoint without it skipped affine preparation
+    # entirely: `load_weights(strict=False)` then dropped every scales and biases
+    # in silence and the modules returned packed uint32 instead of floats. Shapes
+    # are always there, so this cannot be skipped by a missing key.
+    prepared_affine = _prepare_affine_extras(model, weights)
+    _assert_no_orphan_quant_params(model, weights, prepared_affine)
 
     model.load_weights(list(weights.items()), strict=False)
 

--- a/mtp.py
+++ b/mtp.py
@@ -23,11 +23,20 @@ This module reads those tensors straight from the source shards, bypassing
 
 What is here, and what is not
 -----------------------------
-``preserve_mtp`` / ``load_mtp`` move the weights through conversion, and
-``MTPHead`` runs them. **There is no speculative-decode loop yet** — that needs
-snapshot/restore of the 48 Gated-DeltaNet recurrent states, because
-``ArraysCache.is_trimmable()`` is ``False`` and mlx-lm's
-``speculative_generate_step`` therefore refuses this model's cache outright.
+``preserve_mtp`` / ``load_mtp`` move the weights through conversion, ``MTPHead``
+runs them, and ``speculative_generate`` is a complete self-speculative loop.
+mlx-lm's own ``speculative_generate_step`` refuses this model outright, because
+``ArraysCache.is_trimmable()`` is ``False``; the loop here works around that by
+snapshotting and restoring the 48 Gated-DeltaNet recurrent states (a fixed
+~147 MiB, independent of sequence length) and replaying on a miss.
+
+**Nothing calls it, deliberately.** It is verified bit-identical to greedy
+decoding, but the measured draft acceptance is ~69% on ordinary prose, and one
+draft token verified two-at-a-time returns ``(1+p)/(2-p)`` — about 1.30x at best
+before overheads, against a 1.5x bar. So this ships as preserved weights plus a
+working reference implementation, not as a decoding path anyone gets by default.
+Beware measuring acceptance on repetitive text: the same head scored 93.7% on a
+paragraph repeated six times purely because the model was copying.
 
 The head stays at its **source dtype (bf16, 810 MiB)**, ~1.9% of the bf16 model.
 Quantizing it is a separate decision that wants its own quality gate, and
@@ -49,6 +58,7 @@ from pathlib import Path
 from typing import Dict, Tuple
 
 import mlx.core as mx
+from mlx.utils import tree_flatten
 
 #: Prefix these tensors carry in the **source** checkpoint.
 MTP_PREFIX = "mtp."
@@ -90,21 +100,28 @@ def from_stored(key: str) -> str:
 def _resolve_source(hf_path: str) -> Path:
     """Local directory for ``hf_path``, downloading only what MTP needs.
 
-    ``allow_patterns`` keeps this cheap when the source is not already cached:
-    the head lives in a single shard, so there is no reason to pull 52 GB to copy
-    810 MiB. An already-complete local cache short-circuits the download.
+    Two stages, on purpose. ``allow_patterns=["*.safetensors"]`` would match
+    every shard and pull the whole 52 GB source to copy 810 MiB out of it, so the
+    first stage fetches only the small files — which include the shard index —
+    and that names the single shard actually holding the head. An already-
+    complete local cache short-circuits both stages.
     """
     p = Path(hf_path)
     if p.is_dir():
         return p
     from mlx_lm.utils import _download
 
-    return Path(
-        _download(
-            hf_path,
-            allow_patterns=["*.json", "*.safetensors"],
-        )
-    )
+    meta = Path(_download(hf_path, allow_patterns=["*.json"]))
+    index = meta / "model.safetensors.index.json"
+    if not index.exists():
+        # Unsharded, or no index to narrow with: nothing to be clever about.
+        return Path(_download(hf_path, allow_patterns=["*.json", "*.safetensors"]))
+
+    weight_map = json.loads(index.read_text())["weight_map"]
+    shards = sorted({v for k, v in weight_map.items() if k.startswith(MTP_PREFIX)})
+    if not shards:
+        return meta          # no head in this checkpoint; fetch no weights at all
+    return Path(_download(hf_path, allow_patterns=["*.json", *shards]))
 
 
 def extract_mtp(hf_path: str) -> Dict[str, mx.array]:
@@ -140,8 +157,14 @@ def append_to_checkpoint(mlx_path: str | Path, tensors: Dict[str, mx.array]) -> 
     # Renamed on the way in, so no key in the checkpoint contains "mtp." — see
     # STORED_PREFIX for why that would otherwise double-shift every norm weight.
     stored = {to_stored(k): v for k, v in tensors.items()}
-    assert not any("mtp." in k for k in stored), \
-        "stored MTP keys must not contain 'mtp.' or sanitize() will re-shift norms"
+    # Not an assert: python -O strips those, and this guards a silent corruption
+    # of every norm weight in the model rather than a mere programming slip.
+    leaked = sorted(k for k in stored if MTP_PREFIX in k)
+    if leaked:
+        raise RuntimeError(
+            f"stored MTP keys must not contain {MTP_PREFIX!r} or sanitize() will "
+            f"re-shift every norm weight: {', '.join(leaked[:5])}"
+        )
 
     shard_path = dst / MTP_SHARD
     mx.save_safetensors(str(shard_path), stored, metadata={"format": "mlx"})
@@ -290,6 +313,20 @@ class MTPHead:
         _set(self.norm, "mtp.norm.weight")
         pre = "mtp.layers.0."
         layer_w = {k[len(pre):]: v for k, v in tensors.items() if k.startswith(pre)}
+
+        # strict=False on its own would accept an empty or partial layer_w and
+        # leave the DecoderLayer on its random initialization — the head would
+        # then draft fluent-looking nonsense and simply read as a low acceptance
+        # rate, never as an error. So check coverage explicitly first, and keep
+        # strict=False only to tolerate buffers the checkpoint does not carry.
+        expected = {k for k, _ in tree_flatten(self.layer.parameters())}
+        missing = sorted(expected - set(layer_w))
+        if missing:
+            raise KeyError(
+                f"MTP decoder layer is missing {len(missing)} of {len(expected)} "
+                f"tensors, e.g. {', '.join(pre + m for m in missing[:3])}. "
+                "The head would otherwise stay randomly initialized."
+            )
         self.layer.load_weights(list(layer_w.items()), strict=False)
 
     # -- forward -------------------------------------------------------------
@@ -444,11 +481,23 @@ def speculative_generate(ids, text, mtp, embed, head, *,
     """Greedy decode with MTP speculation. Yields ``(token, from_draft)``.
 
     ``text`` is the decoder stack, ``embed`` / ``head`` the embedding and output
-    projection, ``mtp`` a loaded :class:`MTPHead`. These are passed in rather than
-    pulled off a model object because ``load_turboquant`` currently mishandles
-    quantized embeddings on VLMs.
+    projection, ``mtp`` a loaded :class:`MTPHead`. They are passed in rather than
+    pulled off a model object so the loop stays usable against a bare decoder
+    stack, and so the gate scripts can drive it with their own reference
+    embedding and projection.
+
+    Single sequence only: ``ids`` must have batch size 1. The scalar ``.item()``
+    calls and the ``mx.array([[y]])`` re-feeds below collapse a batch to its
+    first row, so a batched call would return quietly wrong tokens rather than
+    fail — hence the explicit check.
     """
     from mlx_lm.models.cache import KVCache
+
+    if ids.ndim != 2 or ids.shape[0] != 1:
+        raise ValueError(
+            f"speculative_generate handles one sequence at a time; got ids with "
+            f"shape {tuple(ids.shape)}, expected (1, T)"
+        )
 
     cache = _make_cache(text, make_cache)
     mtp_cache = KVCache()
@@ -517,7 +566,17 @@ def speculative_generate(ids, text, mtp, embed, head, *,
 
 def greedy_generate(ids, text, embed, head, *, max_tokens: int = 64,
                     eos_ids=(), make_cache=None):
-    """Plain greedy decode on the same plumbing — reference for the equality gate."""
+    """Plain greedy decode on the same plumbing — reference for the equality gate.
+
+    Single sequence only, for the same reason as :func:`speculative_generate`;
+    the two must agree token for token, so they take the same restriction.
+    """
+    if ids.ndim != 2 or ids.shape[0] != 1:
+        raise ValueError(
+            f"greedy_generate handles one sequence at a time; got ids with "
+            f"shape {tuple(ids.shape)}, expected (1, T)"
+        )
+
     cache = _make_cache(text, make_cache)
     eos = {int(e) for e in eos_ids}
 

--- a/mtp.py
+++ b/mtp.py
@@ -1,0 +1,535 @@
+# Copyright 2026 Manjunath Janardhan
+"""Preserve the Qwen3.5/3.8 multi-token-prediction (MTP) head through conversion.
+
+Why this module exists
+----------------------
+``Qwen/Qwen3.8-27B`` ships a real MTP head — 15 tensors: a fused-input projection
+``mtp.fc``, two input norms, one complete self-attention + MLP decoder layer, and
+an output norm — intended for self-speculative decoding.
+
+**mlx-lm throws it away.** ``mlx_lm/models/qwen3_5.py`` drops every ``mtp.*`` key
+inside ``sanitize()``::
+
+    weights = {k: v for k, v in weights.items() if "mtp." not in k}
+
+using their mere *presence* as a hint for norm-weight shifting and nothing else.
+No model in mlx-lm implements MTP (``mimo.py`` strips it too). Because
+``convert.py`` loads through ``mlx_lm.load()``, the head is gone before
+quantization begins, so the converted checkpoint cannot contain it no matter what
+the converter does to the module tree.
+
+This module reads those tensors straight from the source shards, bypassing
+``sanitize()`` entirely, and appends them to the converted checkpoint.
+
+What is here, and what is not
+-----------------------------
+``preserve_mtp`` / ``load_mtp`` move the weights through conversion, and
+``MTPHead`` runs them. **There is no speculative-decode loop yet** — that needs
+snapshot/restore of the 48 Gated-DeltaNet recurrent states, because
+``ArraysCache.is_trimmable()`` is ``False`` and mlx-lm's
+``speculative_generate_step`` therefore refuses this model's cache outright.
+
+The head stays at its **source dtype (bf16, 810 MiB)**, ~1.9% of the bf16 model.
+Quantizing it is a separate decision that wants its own quality gate, and
+quantizing an unexercised head would mix two risks in one change.
+
+One useful accident of the architecture: ``mtp.layers.0`` is shape-identical to a
+main full-attention layer (gated ``q_proj`` 12288×5120, GQA ``k/v_proj``
+1024×5120, ``o_proj`` 5120×6144, 256-wide q/k norms), so ``MTPHead`` reuses
+``DecoderLayer`` rather than defining a new block. It is full attention, not
+Gated DeltaNet — so its own cache is a plain trimmable ``KVCache``, which matters
+for speculative decoding.
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+from pathlib import Path
+from typing import Dict, Tuple
+
+import mlx.core as mx
+
+#: Prefix these tensors carry in the **source** checkpoint.
+MTP_PREFIX = "mtp."
+
+#: Prefix they are stored under in a **converted** checkpoint, and it must not
+#: contain the substring ``"mtp."``.
+#:
+#: This is not cosmetic — it prevents silent model corruption. ``sanitize()``
+#: decides whether to add 1.0 to every norm weight from::
+#:
+#:     has_mtp_weights = any("mtp." in k for k in weights)
+#:     should_shift_norm_weights = has_mtp_weights or has_unsanitized_conv1d
+#:
+#: A converted checkpoint's norms were **already shifted** at conversion time
+#: (verified: source layer-3 ``input_layernorm`` mean +0.2493 → converted
+#: +1.2492). Storing the head under any name containing ``"mtp."`` makes that
+#: predicate fire again on load and shifts them a *second* time, silently
+#: breaking every norm in the model. Note the test is a substring match, so
+#: ``tq_mtp.`` and ``turboquant_mtp.`` are both unsafe.
+STORED_PREFIX = "tq_speculator."
+
+#: Filename the preserved head is written to. The ``model*`` prefix matters:
+#: turboquant's loader discovers weights with ``glob("model*.safetensors")``, so
+#: this file is picked up without the index needing to be consulted.
+MTP_SHARD = "model-mtp.safetensors"
+
+
+def to_stored(key: str) -> str:
+    """``mtp.fc.weight`` -> ``tq_speculator.fc.weight``."""
+    return STORED_PREFIX + key[len(MTP_PREFIX):] if key.startswith(MTP_PREFIX) else key
+
+
+def from_stored(key: str) -> str:
+    """``tq_speculator.fc.weight`` -> ``mtp.fc.weight``."""
+    return (MTP_PREFIX + key[len(STORED_PREFIX):]
+            if key.startswith(STORED_PREFIX) else key)
+
+
+def _resolve_source(hf_path: str) -> Path:
+    """Local directory for ``hf_path``, downloading only what MTP needs.
+
+    ``allow_patterns`` keeps this cheap when the source is not already cached:
+    the head lives in a single shard, so there is no reason to pull 52 GB to copy
+    810 MiB. An already-complete local cache short-circuits the download.
+    """
+    p = Path(hf_path)
+    if p.is_dir():
+        return p
+    from mlx_lm.utils import _download
+
+    return Path(
+        _download(
+            hf_path,
+            allow_patterns=["*.json", "*.safetensors"],
+        )
+    )
+
+
+def extract_mtp(hf_path: str) -> Dict[str, mx.array]:
+    """Return every ``mtp.*`` tensor from the source checkpoint.
+
+    Reads the shards directly. Never goes through ``mlx_lm.load()`` or any
+    model's ``sanitize()``, which is the whole point.
+    """
+    src = _resolve_source(hf_path)
+    index = src / "model.safetensors.index.json"
+
+    if index.exists():
+        weight_map = json.loads(index.read_text())["weight_map"]
+        shards = sorted({weight_map[k] for k in weight_map if k.startswith(MTP_PREFIX)})
+    else:
+        shards = sorted(f.name for f in src.glob("*.safetensors"))
+
+    out: Dict[str, mx.array] = {}
+    for shard in shards:
+        loaded = mx.load(str(src / shard))
+        out.update({k: v for k, v in loaded.items() if k.startswith(MTP_PREFIX)})
+    return out
+
+
+def append_to_checkpoint(mlx_path: str | Path, tensors: Dict[str, mx.array]) -> Path:
+    """Write ``tensors`` into ``mlx_path`` as an extra shard and fix the index.
+
+    Kept out of ``mlx_lm.utils.save`` deliberately. That function serialises a
+    module's ``parameters()``, and these tensors belong to no module — appending
+    afterwards is less invasive than teaching it about orphans.
+    """
+    dst = Path(mlx_path)
+    # Renamed on the way in, so no key in the checkpoint contains "mtp." — see
+    # STORED_PREFIX for why that would otherwise double-shift every norm weight.
+    stored = {to_stored(k): v for k, v in tensors.items()}
+    assert not any("mtp." in k for k in stored), \
+        "stored MTP keys must not contain 'mtp.' or sanitize() will re-shift norms"
+
+    shard_path = dst / MTP_SHARD
+    mx.save_safetensors(str(shard_path), stored, metadata={"format": "mlx"})
+
+    index_path = dst / "model.safetensors.index.json"
+    if index_path.exists():
+        index = json.loads(index_path.read_text())
+        index.setdefault("weight_map", {}).update({k: MTP_SHARD for k in stored})
+        meta = index.setdefault("metadata", {})
+        added = sum(v.nbytes for v in stored.values())
+        meta["total_size"] = int(meta.get("total_size", 0)) + added
+        index_path.write_text(json.dumps(index, indent=2))
+    return shard_path
+
+
+def load_mtp(mlx_path: str | Path) -> Dict[str, mx.array]:
+    """Read a preserved head back, keyed by its original ``mtp.*`` names.
+
+    Adds 1.0 to **every 1-D tensor** in the head, converting its norm weights
+    from HF convention to the MLX convention the rest of the loaded model uses.
+
+    All seven 1-D tensors in this head are RMSNorm weights and all eight 2-D ones
+    are projections, so ``ndim == 1`` is an exact test for "is a norm" here.
+
+    The rule is wider than mlx-lm's, deliberately, and it is measured. ``sanitize()``
+    shifts only four suffixes and says nothing about ``mtp.norm`` or
+    ``mtp.pre_fc_norm_{embedding,hidden}``, because it discards the head before
+    reaching them. Top-1 agreement with the target over a 462-token passage
+    (``Qwen3.8-27B-tq4``, causal mask, ``embedding_first``)::
+
+        shift                             top-1
+        mlx-lm's 4 suffixes only          2.81%   (12/462)
+        + mtp.norm                        3.03%   (14/462)
+        every 1-D tensor                 93.72%  (433/462)
+
+    Two warnings for anyone re-deriving this. Measure with a **causal mask**: a
+    multi-position teacher-forced pass without one lets the layer see the future
+    and inflates every variant. And measure on **hundreds** of positions: on a
+    64-token passage these three land within a few tokens of each other and the
+    ordering scrambles, which points at the wrong rule with apparent confidence.
+    """
+    dst = Path(mlx_path)
+    shard = dst / MTP_SHARD
+    if not shard.exists():
+        return {}
+    raw = {from_stored(k): v for k, v in mx.load(str(shard)).items()}
+    return {k: (v + 1.0 if v.ndim == 1 else v) for k, v in raw.items()}
+
+
+def preserve_mtp(hf_path: str, mlx_path: str | Path) -> Tuple[int, int]:
+    """Copy the source MTP head into a converted checkpoint.
+
+    Returns ``(tensor_count, bytes)``. ``(0, 0)`` means the source has no MTP
+    head, which is the normal case for most architectures and not an error.
+    """
+    tensors = extract_mtp(hf_path)
+    if not tensors:
+        return 0, 0
+    nbytes = sum(v.nbytes for v in tensors.values())
+    append_to_checkpoint(mlx_path, tensors)
+    return len(tensors), nbytes
+
+
+def checkpoint_has_mtp(mlx_path: str | Path) -> bool:
+    """True if a converted checkpoint carries a preserved MTP head."""
+    dst = Path(mlx_path)
+    if (dst / MTP_SHARD).exists():
+        return True
+    index = dst / "model.safetensors.index.json"
+    if index.exists():
+        wm = json.loads(index.read_text()).get("weight_map", {})
+        return any(k.startswith(STORED_PREFIX) for k in wm)
+    return any(
+        k.startswith(STORED_PREFIX)
+        for f in glob.glob(str(dst / "model*.safetensors"))
+        for k in mx.load(f)
+    )
+
+
+# ── Stage 2: the forward pass ────────────────────────────────────────────────
+#
+# Neither mlx-lm nor transformers implements this head — transformers declares
+# `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]` and mlx-lm filters it in
+# sanitize() — so there is no reference implementation to copy and one detail is
+# genuinely undetermined by the checkpoint: which half goes first into `fc`.
+#
+# `fc.weight` is (hidden, 2*hidden), so it consumes a concatenation of the
+# normed next-token embedding and the normed previous hidden state, but nothing
+# in the tensor names or shapes fixes the order. DeepSeek-V3, the canonical MTP,
+# uses [hidden ; embedding]; Qwen's parameter names list embedding first. Rather
+# than guess, `concat_order` is explicit and `probe_concat_order()` decides it by
+# measuring which one predicts real tokens.
+
+
+def _text_args(model):
+    """Args for the text tower, whether or not the model is multimodal."""
+    inner = getattr(model, "language_model", model)
+    args = getattr(inner, "args", None) or getattr(model, "args", None)
+    return getattr(args, "text_config", args)
+
+
+class MTPHead:
+    """Qwen3.5/3.8 multi-token-prediction head, as a draft model.
+
+    Deliberately not an ``nn.Module`` subclass holding the target's embedding and
+    output projection: it *borrows* both. Making them submodules would duplicate
+    a 248,320-row embedding and an equally large ``lm_head`` in the parameter
+    tree, which on this model is most of a gigabyte for no reason.
+
+    The wrapped decoder layer is built with ``layer_idx = full_attention_interval
+    - 1`` so ``DecoderLayer`` takes its full-attention branch — the head is a
+    plain attention layer, not Gated DeltaNet, which is also why its cache is a
+    trimmable ``KVCache``.
+    """
+
+    def __init__(self, args, concat_order: str = "embedding_first"):
+        import mlx.nn as nn
+        from mlx_lm.models.qwen3_5 import DecoderLayer
+
+        if concat_order not in ("embedding_first", "hidden_first"):
+            raise ValueError(f"bad concat_order: {concat_order!r}")
+        self.concat_order = concat_order
+        self.args = args
+
+        h, eps = args.hidden_size, args.rms_norm_eps
+        self.fc = nn.Linear(2 * h, h, bias=False)
+        self.pre_fc_norm_embedding = nn.RMSNorm(h, eps=eps)
+        self.pre_fc_norm_hidden = nn.RMSNorm(h, eps=eps)
+        # layer_idx chosen so is_linear is False -> full attention branch.
+        self.layer = DecoderLayer(args, layer_idx=args.full_attention_interval - 1)
+        self.norm = nn.RMSNorm(h, eps=eps)
+
+    # -- weight loading ------------------------------------------------------
+    def load(self, tensors: Dict[str, mx.array]) -> None:
+        """Load from ``mtp.*``-keyed tensors, e.g. ``load_mtp()`` output."""
+        import mlx.nn as nn
+
+        def _set(mod, key, name="weight"):
+            if key not in tensors:
+                raise KeyError(f"missing MTP tensor: {key}")
+            setattr(mod, name, tensors[key])
+
+        _set(self.fc, "mtp.fc.weight")
+        _set(self.pre_fc_norm_embedding, "mtp.pre_fc_norm_embedding.weight")
+        _set(self.pre_fc_norm_hidden, "mtp.pre_fc_norm_hidden.weight")
+        _set(self.norm, "mtp.norm.weight")
+        pre = "mtp.layers.0."
+        layer_w = {k[len(pre):]: v for k, v in tensors.items() if k.startswith(pre)}
+        self.layer.load_weights(list(layer_w.items()), strict=False)
+
+    # -- forward -------------------------------------------------------------
+    def __call__(self, hidden, next_ids, embed_tokens, lm_head, cache=None):
+        """Logits for the token *after* ``next_ids``.
+
+        Args:
+            hidden: target hidden states at positions i, shape (B, T, H).
+            next_ids: token ids at positions i+1, shape (B, T).
+            embed_tokens / lm_head: borrowed from the target model.
+            cache: a single ``KVCache``, not a list. ``DecoderLayer`` passes it
+                straight through to the attention block, which reads
+                ``cache.offset``.
+
+        A causal mask is built whenever more than one position is processed.
+        Passing ``mask=None`` there would let the layer attend to *future*
+        positions, which silently inflates any teacher-forced agreement score.
+        """
+        from mlx_lm.models.base import create_attention_mask
+
+        emb = embed_tokens(next_ids)
+        a = self.pre_fc_norm_embedding(emb.astype(hidden.dtype))
+        b = self.pre_fc_norm_hidden(hidden)
+        pair = (a, b) if self.concat_order == "embedding_first" else (b, a)
+        h = self.fc(mx.concatenate(pair, axis=-1))
+        mask = create_attention_mask(h, cache) if h.shape[1] > 1 else None
+        h = self.layer(h, mask, cache)
+        return lm_head(self.norm(h))
+
+
+# ── Stage 3a: rolling the cache back ─────────────────────────────────────────
+#
+# Speculative decoding has to undo a rejected token's effect on the cache.
+# On this architecture that is two different problems:
+#
+#   * the 16 full-attention layers use KVCache, whose trim(n) is O(1) offset
+#     arithmetic — the stale entries are simply overwritten next update; and
+#   * the 48 Gated-DeltaNet layers use ArraysCache, which reports
+#     is_trimmable() == False and has no trim() at all, because a recurrent
+#     state has no per-token slice to drop.
+#
+# So the GDN half is snapshotted before drafting and restored on rejection.
+# That is affordable only because the state is FIXED SIZE, independent of
+# sequence length: 48 layers x (3x10240 conv + 48x128x128 fp32 recurrent) =
+# 146.81 MiB, and speculation needs exactly one live snapshot at a time. It is
+# the same state that makes prefix caching unusable here — APC accumulates one
+# snapshot per block across a whole prompt and runs out of memory; this keeps one.
+
+
+def snapshot_recurrent(cache) -> list:
+    """Capture the state of every non-trimmable layer in ``cache``.
+
+    Trimmable layers get ``None`` — they are rolled back with ``trim()`` instead,
+    which is far cheaper than copying keys and values.
+
+    The snapshot is evaluated eagerly. MLX arrays are immutable so holding
+    references is safe, but leaving them lazy would pin the graph that produced
+    them and defeat the point of a fixed-size snapshot.
+    """
+    snap = []
+    for c in cache:
+        trimmable = getattr(c, "is_trimmable", None)
+        if callable(trimmable) and trimmable():
+            snap.append(None)
+            continue
+        st = c.state
+        snap.append(list(st) if isinstance(st, (list, tuple)) else st)
+
+    flat = [a for s in snap if s is not None
+            for a in (s if isinstance(s, list) else [s]) if a is not None]
+    if flat:
+        mx.eval(flat)
+    return snap
+
+
+def restore_recurrent(cache, snap: list) -> None:
+    """Undo drafting on the non-trimmable layers, in place."""
+    if len(snap) != len(cache):
+        raise ValueError(f"snapshot is for {len(snap)} layers, cache has {len(cache)}")
+    for c, s in zip(cache, snap):
+        if s is not None:
+            c.state = list(s) if isinstance(s, list) else s
+
+
+def trim_trimmable(cache, n: int) -> None:
+    """Drop ``n`` positions from every trimmable layer in ``cache``."""
+    for c in cache:
+        trimmable = getattr(c, "is_trimmable", None)
+        if callable(trimmable) and trimmable():
+            c.trim(n)
+
+
+def rollback(cache, snap: list, n: int) -> None:
+    """Return ``cache`` to its pre-draft state: trim what can be, restore the rest."""
+    trim_trimmable(cache, n)
+    restore_recurrent(cache, snap)
+
+
+def snapshot_bytes(snap: list) -> int:
+    """Size of a snapshot, for reporting against a machine's headroom."""
+    return sum(a.nbytes for s in snap if s is not None
+               for a in (s if isinstance(s, list) else [s]) if a is not None)
+
+
+# ── Stage 3b: the speculative decode loop ────────────────────────────────────
+#
+# k = 1. One MTP layer drafts exactly one token, so each iteration runs the
+# target once over TWO positions and confirms two tokens on a hit, one on a miss.
+# For a bandwidth-bound decode a 2-token batched forward costs about the same as
+# a 1-token one, which is where the win comes from.
+#
+# Per iteration, with `x` the last confirmed token and `y` already known from the
+# previous step's logits:
+#
+#   draft   z' = MTP(h(x), y)
+#   verify  target on [y, z'] -> h(y), h(z')
+#           z = argmax(head(h(y)))      <- the truth about the token after y
+#     hit   z' == z: confirm z AND argmax(head(h(z'))). Two tokens, no rollback.
+#     miss  z' != z: confirm z anyway, since it came from the target. Roll the
+#           cache back one position to drop z'. One token, and no wasted round
+#           trip — the next iteration's verify does double duty.
+#
+# So a rejected draft costs a cache rollback, not a forward pass.
+#
+# The MTP cache is kept aligned with the target's, but staleness there could only
+# lower the acceptance rate, never change the output: the target verifies every
+# token that is emitted. That is what makes the bit-identical gate meaningful.
+
+
+def _make_cache(text, make_cache=None):
+    """Build a cache for the decoder stack.
+
+    ``make_cache`` must be given when ``text`` does not carry the method, which is
+    the normal case here: on Qwen3.5 it lives on the outer ``TextModel`` while the
+    stack itself is the inner ``Qwen3_5TextModel``. Falling back to
+    ``make_prompt_cache`` would be silently wrong — it hands every one of the 64
+    layers a ``KVCache``, including the 48 that need ``ArraysCache``.
+    """
+    if make_cache is not None:
+        return make_cache()
+    if hasattr(text, "make_cache"):
+        return text.make_cache()
+    raise TypeError(
+        f"{type(text).__name__} has no make_cache(); pass make_cache= explicitly. "
+        "Do not fall back to make_prompt_cache on a hybrid model — it would give "
+        "the Gated-DeltaNet layers a KVCache and silently corrupt decoding."
+    )
+
+
+def speculative_generate(ids, text, mtp, embed, head, *,
+                         max_tokens: int = 64, eos_ids=(), make_cache=None):
+    """Greedy decode with MTP speculation. Yields ``(token, from_draft)``.
+
+    ``text`` is the decoder stack, ``embed`` / ``head`` the embedding and output
+    projection, ``mtp`` a loaded :class:`MTPHead`. These are passed in rather than
+    pulled off a model object because ``load_turboquant`` currently mishandles
+    quantized embeddings on VLMs.
+    """
+    from mlx_lm.models.cache import KVCache
+
+    cache = _make_cache(text, make_cache)
+    mtp_cache = KVCache()
+    eos = {int(e) for e in eos_ids}
+
+    hidden = text(ids, cache=cache, input_embeddings=embed(ids))
+    y = int(mx.argmax(head(hidden[:, -1:, :]), axis=-1).item())
+    h_prev = hidden[:, -1:, :]
+    mx.eval(h_prev)
+
+    # Prime the draft head over positions 0..n-2 so its next call lands on n-1.
+    if ids.shape[1] > 1:
+        mtp(hidden[:, :-1, :], ids[:, 1:], embed, head, cache=mtp_cache)
+
+    yield y, False
+    produced = 1
+    if y in eos:
+        return
+
+    while produced < max_tokens:
+        draft = mtp(h_prev, mx.array([[y]]), embed, head, cache=mtp_cache)
+        z_draft = int(mx.argmax(draft[:, -1, :], axis=-1).item())
+
+        # Snapshot is taken BEFORE the two-position verify, so it corresponds to
+        # the state before `y` as well as before `z_draft`. On rejection both
+        # positions therefore have to come off the target cache -- trimming only
+        # the rejected one would leave the 16 KV layers a position ahead of the
+        # 48 recurrent layers, which is exactly the kind of desync that shows up
+        # as divergence rather than a crash. `y` is then replayed on its own.
+        snap = snapshot_recurrent(cache)
+        pair = mx.array([[y, z_draft]])
+        h2 = text(pair, cache=cache, input_embeddings=embed(pair))
+        logits2 = head(h2)
+        z = int(mx.argmax(logits2[:, 0, :], axis=-1).item())
+        mx.eval(h2)
+
+        if z == z_draft:
+            yield z, True
+            produced += 1
+            if z in eos or produced >= max_tokens:
+                return
+            y_next = int(mx.argmax(logits2[:, 1, :], axis=-1).item())
+            yield y_next, False
+            produced += 1
+            if y_next in eos:
+                return
+            # Exactly ONE draft-cache position is missing: (h(y), z). The next
+            # iteration's draft call appends the one after it. Advancing by two
+            # here would duplicate a position and silently wreck the alignment,
+            # which costs acceptance rate rather than correctness.
+            mtp(h2[:, 0:1, :], mx.array([[z]]), embed, head, cache=mtp_cache)
+            h_prev, y = h2[:, 1:2, :], y_next
+        else:
+            # Undo the whole verify, then replay the one token that was real.
+            rollback(cache, snap, 2)
+            replay = mx.array([[y]])
+            h1 = text(replay, cache=cache, input_embeddings=embed(replay))
+            mx.eval(h1)
+            yield z, False
+            produced += 1
+            if z in eos:
+                return
+            h_prev, y = h1[:, -1:, :], z
+        mx.eval(h_prev)
+
+
+def greedy_generate(ids, text, embed, head, *, max_tokens: int = 64,
+                    eos_ids=(), make_cache=None):
+    """Plain greedy decode on the same plumbing — reference for the equality gate."""
+    cache = _make_cache(text, make_cache)
+    eos = {int(e) for e in eos_ids}
+
+    hidden = text(ids, cache=cache, input_embeddings=embed(ids))
+    y = int(mx.argmax(head(hidden[:, -1:, :]), axis=-1).item())
+    yield y
+    if y in eos:
+        return
+    for _ in range(max_tokens - 1):
+        cur = mx.array([[y]])
+        h = text(cur, cache=cache, input_embeddings=embed(cur))
+        y = int(mx.argmax(head(h[:, -1:, :]), axis=-1).item())
+        yield y
+        if y in eos:
+            return

--- a/tests/test_loader_affine_extras.py
+++ b/tests/test_loader_affine_extras.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Manjunath Janardhan
+"""Tests for the affine "extras" tier on the load path.
+
+The bug these pin: TurboQuant leaves the token embedding and ``lm_head`` to MLX's
+affine quantizer, so they arrive as weight/scales/biases with no ``.codebook``.
+``_prepare_polar_layers`` keys off ``.codebook`` and never sees them, the freshly
+built model still holds a plain ``nn.Embedding``/``nn.Linear``, and
+``load_weights(strict=False)`` then discards their scales without a word. The
+result runs and returns nonsense — measured on Qwen3.8-27B, ``embed_tokens(ids)``
+came back ``(1, T, 1280) uint32`` instead of ``(1, T, 5120)`` floats.
+
+A silent wrong answer is worse than a crash, hence both a fix and a guard.
+"""
+
+import mlx.core as mx
+import mlx.nn as nn
+import pytest
+from turboquant_mlx.generate import (
+    _assert_no_orphan_quant_params,
+    _get_nested_module,
+    _prepare_affine_extras,
+)
+
+VOCAB, DIM, OUT, GS, BITS = 128, 64, 32, 32, 8
+
+
+class Tiny(nn.Module):
+    """Minimal stand-in for the shape of a real text tower."""
+
+    def __init__(self):
+        super().__init__()
+        self.embed_tokens = nn.Embedding(VOCAB, DIM)
+        self.lm_head = nn.Linear(DIM, OUT, bias=False)
+        self.plain = nn.Linear(DIM, OUT, bias=False)
+
+
+def _affine(shape, group_size=GS, bits=BITS):
+    """Quantize a real array so scales/biases have honest shapes."""
+    w = mx.random.normal(shape).astype(mx.bfloat16)
+    return mx.quantize(w, group_size=group_size, bits=bits)
+
+
+def _checkpoint(group_size=GS, bits=BITS):
+    ew, es, eb = _affine((VOCAB, DIM), group_size, bits)
+    hw, hs, hb = _affine((OUT, DIM), group_size, bits)
+    return {
+        "embed_tokens.weight": ew, "embed_tokens.scales": es,
+        "embed_tokens.biases": eb,
+        "lm_head.weight": hw, "lm_head.scales": hs, "lm_head.biases": hb,
+        "plain.weight": mx.zeros((OUT, DIM), mx.bfloat16),
+    }
+
+
+def test_get_nested_module_resolves_and_returns_none():
+    m = Tiny()
+    assert _get_nested_module(m, "embed_tokens") is m.embed_tokens
+    assert _get_nested_module(m, "nope") is None
+    assert _get_nested_module(m, "embed_tokens.nope.deeper") is None
+
+
+def test_affine_extras_become_quantized_modules():
+    m, w = Tiny(), _checkpoint()
+    specs = _prepare_affine_extras(m, w)
+    assert set(specs) == {"embed_tokens", "lm_head"}
+    assert isinstance(m.embed_tokens, nn.QuantizedEmbedding)
+    assert isinstance(m.lm_head, nn.QuantizedLinear)
+    # A module with no scales in the checkpoint must be left alone.
+    assert isinstance(m.plain, nn.Linear)
+    assert not isinstance(m.plain, nn.QuantizedLinear)
+
+
+@pytest.mark.parametrize("group_size,bits", [(32, 4), (32, 8), (64, 8)])
+def test_group_size_and_bits_are_recovered_from_shapes(group_size, bits):
+    """Shapes alone fix both, because the plain module knows its unpacked width."""
+    m, w = Tiny(), _checkpoint(group_size, bits)
+    specs = _prepare_affine_extras(m, w)
+    for path in ("embed_tokens", "lm_head"):
+        assert specs[path] == {"group_size": group_size, "bits": bits}
+    assert m.embed_tokens.bits == bits
+    assert m.embed_tokens.group_size == group_size
+
+
+def test_the_weights_actually_load_and_produce_real_floats():
+    """The end the bug was breaking: a lookup returning packed uint32."""
+    m, w = Tiny(), _checkpoint()
+    _prepare_affine_extras(m, w)
+    m.load_weights(list(w.items()), strict=False)
+
+    out = m.embed_tokens(mx.array([[1, 2, 3]]))
+    mx.eval(out)
+    assert out.shape == (1, 3, DIM), "a dropped scales gives the PACKED width here"
+    assert out.dtype in (mx.bfloat16, mx.float16, mx.float32)
+
+    logits = m.lm_head(out)
+    mx.eval(logits)
+    assert logits.shape == (1, 3, OUT)
+
+
+def test_polar_tensors_are_left_to_the_polar_pass():
+    """A .codebook alongside .scales means the polar tier owns that module."""
+    m = Tiny()
+    w = _checkpoint()
+    w["embed_tokens.codebook"] = mx.zeros((16,), mx.bfloat16)
+    specs = _prepare_affine_extras(m, w)
+    assert "embed_tokens" not in specs
+    assert isinstance(m.embed_tokens, nn.Embedding)
+    assert "lm_head" in specs
+
+
+def test_noop_when_there_are_no_affine_extras():
+    m = Tiny()
+    assert _prepare_affine_extras(m, {"plain.weight": mx.zeros((OUT, DIM))}) == {}
+    assert isinstance(m.embed_tokens, nn.Embedding)
+
+
+def test_orphan_guard_raises_instead_of_returning_garbage():
+    """The guard is the real protection: strict=False cannot be dropped here,
+    because the checkpoint legitimately carries polar keys the base modules do
+    not declare. So an unhandled scales must be caught explicitly."""
+    m, w = Tiny(), _checkpoint()
+    with pytest.raises(RuntimeError, match="no quantized module"):
+        _assert_no_orphan_quant_params(m, w, prepared={})
+
+
+def test_orphan_guard_passes_once_extras_are_prepared():
+    m, w = Tiny(), _checkpoint()
+    specs = _prepare_affine_extras(m, w)
+    _assert_no_orphan_quant_params(m, w, specs)   # must not raise
+
+
+def test_orphan_guard_ignores_paths_with_no_module():
+    """Sanitize can leave keys for modules a given config never builds."""
+    m = Tiny()
+    w = {"vision.absent.weight": mx.zeros((4, 4)),
+         "vision.absent.scales": mx.zeros((4, 1)),
+         "vision.absent.biases": mx.zeros((4, 1))}
+    _assert_no_orphan_quant_params(m, w, prepared={})   # must not raise

--- a/tests/test_loader_affine_extras.py
+++ b/tests/test_loader_affine_extras.py
@@ -135,3 +135,51 @@ def test_orphan_guard_ignores_paths_with_no_module():
          "vision.absent.scales": mx.zeros((4, 1)),
          "vision.absent.biases": mx.zeros((4, 1))}
     _assert_no_orphan_quant_params(m, w, prepared={})   # must not raise
+
+
+def test_missing_biases_raises_instead_of_keeping_random_init():
+    """`load_weights` does not replace omitted parameters, so a dropped `biases`
+    would leave the freshly initialized ones in place and dequantize to garbage."""
+    m, w = Tiny(), _checkpoint()
+    del w["embed_tokens.biases"]
+    with pytest.raises(RuntimeError, match=r"incomplete.*embed_tokens\.biases"):
+        _prepare_affine_extras(m, w)
+
+
+def test_missing_weight_raises_a_named_error_not_a_bare_keyerror():
+    m, w = Tiny(), _checkpoint()
+    del w["lm_head.weight"]
+    with pytest.raises(RuntimeError, match=r"incomplete.*lm_head\.weight"):
+        _prepare_affine_extras(m, w)
+
+
+def test_settings_are_per_module_not_global():
+    """Pins the contract that each module keeps its own recovered settings.
+
+    Every checkpoint shipped so far records one `affine_extras` group_size/bits
+    for the whole tier, so mixed settings are not a case real weights exercise
+    today — this fixes the behaviour the shape-recovery promises, so that a
+    checkpoint which ever does mix them cannot regress silently.
+
+    It cannot distinguish the two implementations on a current install:
+    `nn.quantize(class_predicate=...)` ignores a per-module dict below MLX 0.22,
+    and mlx-lm pins mlx>=0.31.2 transitively. The assertion is on the contract,
+    not on the version bug that motivated it."""
+    ew, es, eb = _affine((VOCAB, DIM), group_size=64, bits=8)
+    hw, hs, hb = _affine((OUT, DIM), group_size=32, bits=4)
+    w = {"embed_tokens.weight": ew, "embed_tokens.scales": es,
+         "embed_tokens.biases": eb,
+         "lm_head.weight": hw, "lm_head.scales": hs, "lm_head.biases": hb}
+    m = Tiny()
+    specs = _prepare_affine_extras(m, w)
+
+    assert specs["embed_tokens"] == {"group_size": 64, "bits": 8}
+    assert specs["lm_head"] == {"group_size": 32, "bits": 4}
+    assert (m.embed_tokens.group_size, m.embed_tokens.bits) == (64, 8)
+    assert (m.lm_head.group_size, m.lm_head.bits) == (32, 4)
+
+    # And they still load and run, which a mismatched group_size would break.
+    m.load_weights(list(w.items()), strict=False)
+    out = m.lm_head(m.embed_tokens(mx.array([[1, 2, 3]])))
+    mx.eval(out)
+    assert out.shape == (1, 3, OUT)

--- a/tests/test_loader_affine_extras.py
+++ b/tests/test_loader_affine_extras.py
@@ -183,3 +183,55 @@ def test_settings_are_per_module_not_global():
     out = m.lm_head(m.embed_tokens(mx.array([[1, 2, 3]])))
     mx.eval(out)
     assert out.shape == (1, 3, OUT)
+
+
+class _Block(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.qkv = nn.Linear(DIM, OUT, bias=False)
+
+
+class _Tower(nn.Module):
+    def __init__(self, n=2):
+        super().__init__()
+        self.blocks = [_Block() for _ in range(n)]
+
+
+class TinyVLM(nn.Module):
+    """Shaped like a real VLM: a text tower plus an indexed list of vision blocks."""
+
+    def __init__(self):
+        super().__init__()
+        self.language_model = Tiny()
+        self.vision_tower = _Tower()
+
+
+def test_modules_behind_a_list_index_are_prepared_and_installed():
+    """The vision tower reaches its modules through a list — `vision_tower.
+    blocks.0.qkv` — and preparation now installs each one with
+    `_set_nested_attr` rather than letting `nn.quantize` walk the tree. Setting a
+    replacement back through a list index is the part that has no equivalent in
+    the old path, so it gets its own test rather than riding on the flat case.
+    """
+    m = TinyVLM()
+    w = {}
+    for path in ("language_model.embed_tokens", "language_model.lm_head",
+                 "vision_tower.blocks.0.qkv", "vision_tower.blocks.1.qkv"):
+        shape = (VOCAB, DIM) if path.endswith("embed_tokens") else (OUT, DIM)
+        q, s, b = _affine(shape)
+        w[f"{path}.weight"], w[f"{path}.scales"], w[f"{path}.biases"] = q, s, b
+
+    specs = _prepare_affine_extras(m, w)
+    assert set(specs) == {"language_model.embed_tokens", "language_model.lm_head",
+                          "vision_tower.blocks.0.qkv", "vision_tower.blocks.1.qkv"}
+
+    # Installed on the real tree, not on a detached copy.
+    assert isinstance(m.vision_tower.blocks[0].qkv, nn.QuantizedLinear)
+    assert isinstance(m.vision_tower.blocks[1].qkv, nn.QuantizedLinear)
+    assert isinstance(m.language_model.embed_tokens, nn.QuantizedEmbedding)
+
+    _assert_no_orphan_quant_params(m, w, specs)     # must not raise
+    m.load_weights(list(w.items()), strict=False)
+    out = m.vision_tower.blocks[0].qkv(mx.zeros((1, 3, DIM), mx.bfloat16))
+    mx.eval(out)
+    assert out.shape == (1, 3, OUT)

--- a/tests/test_loader_affine_extras.py
+++ b/tests/test_loader_affine_extras.py
@@ -129,7 +129,15 @@ def test_orphan_guard_passes_once_extras_are_prepared():
 
 
 def test_orphan_guard_ignores_paths_with_no_module():
-    """Sanitize can leave keys for modules a given config never builds."""
+    """A path with no module is skipped on purpose, and this is load-bearing.
+
+    One checkpoint serves both loaders. `load_turboquant` builds the text-only
+    `Model`, which has no vision tower, so most of a VLM checkpoint's affine
+    paths resolve to nothing: measured on Qwen3.8-27B-tq4-g64, 84 of its 86
+    affine paths have no module on the text path, while the VLM loader resolves
+    all 86. Treating "no module" as an orphan would therefore raise on every VLM
+    checkpoint rather than catch a bug — which is why it stays a skip.
+    """
     m = Tiny()
     w = {"vision.absent.weight": mx.zeros((4, 4)),
          "vision.absent.scales": mx.zeros((4, 1)),

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -11,7 +11,6 @@ it asserts we read the tensors even though the sanitiser would have removed them
 """
 
 import json
-from pathlib import Path
 
 import mlx.core as mx
 import pytest

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -11,8 +11,10 @@ it asserts we read the tensors even though the sanitiser would have removed them
 """
 
 import json
+import re
 
 import mlx.core as mx
+from mlx.utils import tree_flatten
 import pytest
 from turboquant_mlx.mtp import (
     MTP_PREFIX,
@@ -189,6 +191,16 @@ def test_stored_keys_never_contain_mtp_dot(source, converted):
     for f in converted.glob("model*.safetensors"):
         every_key |= set(mx.load(str(f)))
     assert not any("mtp." in k for k in every_key)
+
+
+def test_the_leak_guard_raises_runtimeerror_not_assertionerror(converted):
+    """It must survive `python -O`, which strips asserts. A stored key carrying
+    "mtp." re-fires the norm shift on load, so this is silent corruption, not a
+    programming slip — the distinction that decides which one it has to be."""
+    with pytest.raises(RuntimeError, match="re-shift every norm weight"):
+        # `to_stored` only rewrites a leading "mtp.", so an embedded one survives
+        # renaming and is exactly what the guard exists to catch.
+        append_to_checkpoint(converted, {"model.mtp.fc.weight": mx.zeros((2, 2))})
 
 
 def test_stored_prefix_is_itself_safe():
@@ -373,3 +385,44 @@ def test_restore_rejects_a_mismatched_snapshot():
     snap = snapshot_recurrent(_hybrid_cache())
     with pytest.raises(ValueError):
         restore_recurrent(_hybrid_cache()[:32], snap)
+
+
+def _tiny_args():
+    qwen35 = pytest.importorskip("mlx_lm.models.qwen3_5")
+    return qwen35.TextModelArgs.from_dict(dict(
+        hidden_size=64, num_hidden_layers=4, intermediate_size=128,
+        num_attention_heads=4, num_key_value_heads=2, head_dim=16,
+        vocab_size=128, rms_norm_eps=1e-6, full_attention_interval=4,
+    ))
+
+
+def _scalar_tensors(h):
+    return {"mtp.fc.weight": mx.zeros((h, 2 * h)),
+            "mtp.pre_fc_norm_embedding.weight": mx.zeros((h,)),
+            "mtp.pre_fc_norm_hidden.weight": mx.zeros((h,)),
+            "mtp.norm.weight": mx.zeros((h,))}
+
+
+def test_a_partially_loaded_head_is_refused_not_left_random():
+    """`load_weights(strict=False)` accepts an empty or partial layer and leaves
+    the DecoderLayer randomly initialized. That head still runs and still emits
+    fluent-looking drafts, so it reads as a poor acceptance rate rather than a
+    fault — the one failure mode that would never surface on its own."""
+    from turboquant_mlx.mtp import MTPHead
+
+    args = _tiny_args()
+    scalars = _scalar_tensors(args.hidden_size)
+
+    with pytest.raises(KeyError, match="randomly initialized"):
+        MTPHead(args).load(dict(scalars))          # no mtp.layers.0.* at all
+
+    head = MTPHead(args)
+    full = dict(scalars)
+    full.update({f"mtp.layers.0.{k}": v
+                 for k, v in tree_flatten(head.layer.parameters())})
+    head.load(full)                                 # complete: must not raise
+
+    victim = sorted(k for k in full if k.startswith("mtp.layers.0."))[0]
+    partial = {k: v for k, v in full.items() if k != victim}
+    with pytest.raises(KeyError, match=re.escape(victim)):
+        MTPHead(args).load(partial)

--- a/tests/test_mtp.py
+++ b/tests/test_mtp.py
@@ -1,0 +1,376 @@
+# Copyright 2026 Manjunath Janardhan
+"""Tests for MTP-head preservation through conversion.
+
+Hermetic: the real source is a 52 GB download, so these synthesise a source
+checkpoint with an `mtp.*` head and a converted checkpoint without one, then
+check the head is copied across and the index stays coherent.
+
+The thing under test is a workaround for mlx-lm dropping `mtp.*` in
+`sanitize()`, so the test that matters most is `test_extract_bypasses_sanitize`:
+it asserts we read the tensors even though the sanitiser would have removed them.
+"""
+
+import json
+from pathlib import Path
+
+import mlx.core as mx
+import pytest
+from turboquant_mlx.mtp import (
+    MTP_PREFIX,
+    MTP_SHARD,
+    STORED_PREFIX,
+    append_to_checkpoint,
+    checkpoint_has_mtp,
+    extract_mtp,
+    from_stored,
+    load_mtp,
+    preserve_mtp,
+    to_stored,
+)
+
+# Real Qwen3.8-27B MTP shapes, scaled down 40x on the hidden dim so the test is
+# instant. Structure (one fused input projection, two input norms, a full
+# attention + MLP layer, an output norm) is the shape that matters.
+H, INTER, QO, KVO = 128, 344, 288, 24
+
+
+def _mtp_tensors():
+    return {
+        "mtp.fc.weight": mx.zeros((H, 2 * H), mx.bfloat16),
+        "mtp.pre_fc_norm_embedding.weight": mx.ones((H,), mx.bfloat16),
+        "mtp.pre_fc_norm_hidden.weight": mx.ones((H,), mx.bfloat16),
+        "mtp.norm.weight": mx.ones((H,), mx.bfloat16),
+        "mtp.layers.0.input_layernorm.weight": mx.ones((H,), mx.bfloat16),
+        "mtp.layers.0.post_attention_layernorm.weight": mx.ones((H,), mx.bfloat16),
+        "mtp.layers.0.self_attn.q_proj.weight": mx.zeros((QO, H), mx.bfloat16),
+        "mtp.layers.0.self_attn.k_proj.weight": mx.zeros((KVO, H), mx.bfloat16),
+        "mtp.layers.0.self_attn.v_proj.weight": mx.zeros((KVO, H), mx.bfloat16),
+        "mtp.layers.0.self_attn.o_proj.weight": mx.zeros((H, QO // 2), mx.bfloat16),
+        "mtp.layers.0.self_attn.q_norm.weight": mx.ones((16,), mx.bfloat16),
+        "mtp.layers.0.self_attn.k_norm.weight": mx.ones((16,), mx.bfloat16),
+        "mtp.layers.0.mlp.gate_proj.weight": mx.zeros((INTER, H), mx.bfloat16),
+        "mtp.layers.0.mlp.up_proj.weight": mx.zeros((INTER, H), mx.bfloat16),
+        "mtp.layers.0.mlp.down_proj.weight": mx.zeros((H, INTER), mx.bfloat16),
+    }
+
+
+@pytest.fixture
+def source(tmp_path):
+    """A two-shard source checkpoint whose LAST shard holds the MTP head.
+
+    Mirrors the real layout, where all 15 tensors live in shard 18 of 18 — so a
+    reader that only opens the first shard would silently find nothing.
+    """
+    src = tmp_path / "src"
+    src.mkdir()
+    body = {"model.layers.0.self_attn.q_proj.weight": mx.zeros((H, H), mx.bfloat16)}
+    mtp = _mtp_tensors()
+    mx.save_safetensors(str(src / "model-00001-of-00002.safetensors"), body)
+    mx.save_safetensors(str(src / "model-00002-of-00002.safetensors"), mtp)
+    (src / "model.safetensors.index.json").write_text(json.dumps({
+        "metadata": {"total_size": sum(v.nbytes for v in {**body, **mtp}.values())},
+        "weight_map": {**{k: "model-00001-of-00002.safetensors" for k in body},
+                       **{k: "model-00002-of-00002.safetensors" for k in mtp}},
+    }))
+    return src
+
+
+@pytest.fixture
+def converted(tmp_path):
+    """A converted checkpoint with no MTP head, as mlx-lm's save() would leave it."""
+    dst = tmp_path / "dst"
+    dst.mkdir()
+    body = {"model.layers.0.self_attn.q_proj.weight": mx.zeros((H, H), mx.bfloat16)}
+    mx.save_safetensors(str(dst / "model.safetensors"), body)
+    (dst / "model.safetensors.index.json").write_text(json.dumps({
+        "metadata": {"total_size": sum(v.nbytes for v in body.values())},
+        "weight_map": {k: "model.safetensors" for k in body},
+    }))
+    return dst
+
+
+def test_extract_finds_the_head_in_a_later_shard(source):
+    got = extract_mtp(str(source))
+    assert len(got) == 15
+    assert all(k.startswith(MTP_PREFIX) for k in got)
+
+
+def test_extract_bypasses_sanitize(source):
+    """The whole point: sanitize() would drop these, extract_mtp must not.
+
+    Applies mlx-lm's actual filter expression to the same tensors and asserts the
+    two disagree. If mlx-lm ever starts keeping `mtp.*`, this test fails loudly
+    and the workaround can be reconsidered rather than quietly duplicating work.
+    """
+    got = extract_mtp(str(source))
+    sanitized = {k: v for k, v in got.items() if "mtp." not in k}
+    assert sanitized == {}, "sanitize() drops every MTP key"
+    assert len(got) == 15, "extract_mtp keeps them"
+
+
+def test_extract_returns_empty_without_a_head(converted):
+    assert extract_mtp(str(converted)) == {}
+
+
+def test_preserve_writes_shard_and_updates_index(source, converted):
+    before = json.loads((converted / "model.safetensors.index.json").read_text())
+    n, nbytes = preserve_mtp(str(source), converted)
+
+    assert n == 15
+    assert nbytes == sum(v.nbytes for v in _mtp_tensors().values())
+    assert (converted / MTP_SHARD).exists()
+
+    after = json.loads((converted / "model.safetensors.index.json").read_text())
+    assert len(after["weight_map"]) == len(before["weight_map"]) + 15
+    assert {v for k, v in after["weight_map"].items()
+            if k.startswith(STORED_PREFIX)} == {MTP_SHARD}
+    assert int(after["metadata"]["total_size"]) \
+        == int(before["metadata"]["total_size"]) + nbytes
+    # Pre-existing entries must survive untouched.
+    for k, v in before["weight_map"].items():
+        assert after["weight_map"][k] == v
+
+
+def test_preserved_shard_is_discoverable_by_the_loader_glob(source, converted):
+    """turboquant's loader globs `model*.safetensors`; the name must match it."""
+    preserve_mtp(str(source), converted)
+    found = sorted(p.name for p in converted.glob("model*.safetensors"))
+    assert MTP_SHARD in found
+
+
+def test_round_trip_values_are_unchanged(source, converted):
+    """Raw bytes must survive verbatim; the norm shift is applied on load, not here."""
+    preserve_mtp(str(source), converted)
+    got = mx.load(str(converted / MTP_SHARD))
+    want = {to_stored(k): v for k, v in _mtp_tensors().items()}
+    assert set(got) == set(want)
+    for k in want:
+        assert got[k].shape == want[k].shape
+        assert got[k].dtype == want[k].dtype
+        assert mx.array_equal(got[k], want[k])
+
+
+def test_checkpoint_has_mtp(source, converted):
+    assert not checkpoint_has_mtp(converted)
+    preserve_mtp(str(source), converted)
+    assert checkpoint_has_mtp(converted)
+
+
+def test_preserve_is_a_noop_without_a_source_head(converted, tmp_path):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    mx.save_safetensors(str(empty / "model.safetensors"),
+                        {"model.norm.weight": mx.ones((H,), mx.bfloat16)})
+    assert preserve_mtp(str(empty), converted) == (0, 0)
+    assert not (converted / MTP_SHARD).exists()
+
+
+def test_stored_keys_never_contain_mtp_dot(source, converted):
+    """The bug this guards is silent model corruption, not a cosmetic naming nit.
+
+    ``sanitize()`` adds 1.0 to every norm weight when ``any("mtp." in k)``. A
+    converted checkpoint's norms are ALREADY shifted, so a stored key containing
+    ``"mtp."`` re-fires that predicate on load and shifts them twice, quietly
+    breaking every norm in the model. Note it is a substring test: ``tq_mtp.``
+    and ``turboquant_mtp.`` would both trip it.
+    """
+    preserve_mtp(str(source), converted)
+
+    stored = mx.load(str(converted / MTP_SHARD))
+    assert stored, "nothing was written"
+    offenders = [k for k in stored if "mtp." in k]
+    assert offenders == [], f"these keys would re-trigger the norm shift: {offenders}"
+
+    index = json.loads((converted / "model.safetensors.index.json").read_text())
+    assert [k for k in index["weight_map"] if "mtp." in k] == []
+
+    # And the exact predicate mlx-lm uses must stay False across the whole
+    # checkpoint, index and shards alike.
+    every_key = set(index["weight_map"])
+    for f in converted.glob("model*.safetensors"):
+        every_key |= set(mx.load(str(f)))
+    assert not any("mtp." in k for k in every_key)
+
+
+def test_stored_prefix_is_itself_safe():
+    assert "mtp." not in STORED_PREFIX
+
+
+def test_name_mapping_round_trips():
+    for k in _mtp_tensors():
+        assert from_stored(to_stored(k)) == k
+        assert to_stored(k).startswith(STORED_PREFIX)
+    # Non-MTP keys pass through untouched.
+    assert to_stored("model.norm.weight") == "model.norm.weight"
+    assert from_stored("model.norm.weight") == "model.norm.weight"
+
+
+def test_load_mtp_restores_original_names_and_shifts_every_norm(source, converted):
+    """EVERY 1-D tensor gets +1; no 2-D projection does.
+
+    Wider than mlx-lm's four-suffix rule on purpose, and measured: over a
+    462-token passage, shifting every 1-D tensor scores 93.72% top-1 agreement
+    against 2.81% for mlx-lm's four suffixes alone. See load_mtp's docstring.
+    """
+    preserve_mtp(str(source), converted)
+    got = load_mtp(converted)
+    want = _mtp_tensors()
+
+    assert set(got) == set(want), "original mtp.* names must be restored"
+
+    ones = [k for k, v in want.items() if v.ndim == 1]
+    twos = [k for k, v in want.items() if v.ndim != 1]
+    assert len(ones) == 7 and len(twos) == 8, "head shape changed; re-check the rule"
+
+    for k in ones:
+        assert mx.allclose(got[k].astype(mx.float32),
+                           want[k].astype(mx.float32) + 1.0), f"{k} should be +1"
+    for k in twos:
+        assert mx.array_equal(got[k], want[k]), f"{k} must not be shifted"
+
+
+def test_the_three_norms_mlx_lm_ignores_are_still_shifted(source, converted):
+    """Regression guard on the specific finding that unblocked Stage 2.
+
+    These three carry no suffix mlx-lm recognises, so an implementation that
+    simply mirrored sanitize() would leave them unshifted and score 2.81%
+    instead of 93.72%.
+    """
+    preserve_mtp(str(source), converted)
+    got, want = load_mtp(converted), _mtp_tensors()
+    for k in ("mtp.norm.weight",
+              "mtp.pre_fc_norm_embedding.weight",
+              "mtp.pre_fc_norm_hidden.weight"):
+        assert mx.allclose(got[k].astype(mx.float32),
+                           want[k].astype(mx.float32) + 1.0), f"{k} must be +1"
+
+
+def test_load_mtp_is_empty_without_a_head(converted):
+    assert load_mtp(converted) == {}
+
+
+def test_mlx_lm_still_keys_the_norm_shift_off_the_mtp_substring():
+    """If mlx-lm stops using `any("mtp." in k)`, the STORED_PREFIX workaround
+    may be unnecessary or actively wrong. Fail here rather than drift."""
+    import inspect
+
+    from mlx_lm.models import qwen3_5
+
+    # TextModel, not Model: Model.sanitize only re-keys and delegates.
+    src = inspect.getsource(qwen3_5.TextModel.sanitize)
+    assert 'any("mtp." in k for k in weights)' in src, (
+        "mlx-lm no longer keys the norm shift off the substring 'mtp.'"
+    )
+
+
+def test_append_survives_a_missing_index(tmp_path):
+    """Single-file checkpoints have no index; the shard must still be written."""
+    dst = tmp_path / "noindex"
+    dst.mkdir()
+    mx.save_safetensors(str(dst / "model.safetensors"),
+                        {"model.norm.weight": mx.ones((H,), mx.bfloat16)})
+    append_to_checkpoint(dst, _mtp_tensors())
+    assert (dst / MTP_SHARD).exists()
+    assert checkpoint_has_mtp(dst)
+
+
+# ── Stage 3a: cache rollback ─────────────────────────────────────────────────
+
+def _hybrid_cache():
+    """A Qwen3.8-shaped cache: 48 ArraysCache + 16 KVCache, one full in four."""
+    from mlx_lm.models.cache import ArraysCache, KVCache
+    return [KVCache() if (i + 1) % 4 == 0 else ArraysCache(size=2) for i in range(64)]
+
+
+def test_the_hybrid_cache_really_is_untrimmable():
+    """The premise of this whole mechanism. If it stops holding, simplify."""
+    from mlx_lm.models.cache import ArraysCache, KVCache, can_trim_prompt_cache
+    assert KVCache().is_trimmable() is True
+    assert ArraysCache(size=2).is_trimmable() is False
+    assert can_trim_prompt_cache(_hybrid_cache()) is False
+    assert can_trim_prompt_cache([KVCache() for _ in range(16)]) is True
+
+
+def test_snapshot_covers_exactly_the_untrimmable_layers():
+    from turboquant_mlx.mtp import snapshot_recurrent
+    cache = _hybrid_cache()
+    for i, c in enumerate(cache):
+        if not c.is_trimmable():
+            c[0] = mx.full((1, 3, 8), float(i))
+            c[1] = mx.full((1, 2, 4, 4), float(i))
+    snap = snapshot_recurrent(cache)
+    assert len(snap) == 64
+    assert sum(s is None for s in snap) == 16, "trimmable layers use trim(), not a copy"
+    assert sum(s is not None for s in snap) == 48
+
+
+def test_restore_undoes_a_draft_on_the_recurrent_layers():
+    from turboquant_mlx.mtp import restore_recurrent, snapshot_recurrent
+    cache = _hybrid_cache()
+    for i, c in enumerate(cache):
+        if not c.is_trimmable():
+            c[0] = mx.full((1, 3, 8), float(i))
+            c[1] = mx.full((1, 2, 4, 4), float(i))
+    snap = snapshot_recurrent(cache)
+
+    # Draft: every recurrent state advances to garbage.
+    for c in cache:
+        if not c.is_trimmable():
+            c[0] = mx.zeros((1, 3, 8))
+            c[1] = mx.ones((1, 2, 4, 4)) * 99.0
+
+    restore_recurrent(cache, snap)
+    for i, c in enumerate(cache):
+        if not c.is_trimmable():
+            assert mx.array_equal(c[0], mx.full((1, 3, 8), float(i))), f"layer {i}"
+            assert mx.array_equal(c[1], mx.full((1, 2, 4, 4), float(i))), f"layer {i}"
+
+
+def test_rollback_trims_offsets_and_restores_states_together():
+    from turboquant_mlx.mtp import rollback, snapshot_recurrent
+    cache = _hybrid_cache()
+    for c in cache:
+        if not c.is_trimmable():
+            c[0] = mx.zeros((1, 3, 8))
+            c[1] = mx.zeros((1, 2, 4, 4))
+        else:
+            c.update_and_fetch(mx.zeros((1, 4, 5, 16)), mx.zeros((1, 4, 5, 16)))
+    snap = snapshot_recurrent(cache)
+    before = [c.offset for c in cache if c.is_trimmable()]
+
+    # Draft one token through both halves.
+    for c in cache:
+        if c.is_trimmable():
+            c.update_and_fetch(mx.zeros((1, 4, 1, 16)), mx.zeros((1, 4, 1, 16)))
+        else:
+            c[1] = mx.ones((1, 2, 4, 4)) * 7.0
+
+    rollback(cache, snap, 1)
+    assert [c.offset for c in cache if c.is_trimmable()] == before
+    for c in cache:
+        if not c.is_trimmable():
+            assert mx.array_equal(c[1], mx.zeros((1, 2, 4, 4)))
+
+
+def test_snapshot_size_is_independent_of_sequence_length():
+    """Why one live snapshot is affordable where prefix caching was not."""
+    from turboquant_mlx.mtp import snapshot_bytes, snapshot_recurrent
+    sizes = []
+    for seq in (8, 512, 4096):
+        cache = _hybrid_cache()
+        for c in cache:
+            if not c.is_trimmable():
+                c[0] = mx.zeros((1, 3, 8))
+                c[1] = mx.zeros((1, 2, 4, 4))
+            else:
+                c.update_and_fetch(mx.zeros((1, 4, seq, 16)), mx.zeros((1, 4, seq, 16)))
+        sizes.append(snapshot_bytes(snapshot_recurrent(cache)))
+    assert len(set(sizes)) == 1, f"snapshot grew with context: {sizes}"
+    assert sizes[0] > 0
+
+
+def test_restore_rejects_a_mismatched_snapshot():
+    from turboquant_mlx.mtp import restore_recurrent, snapshot_recurrent
+    snap = snapshot_recurrent(_hybrid_cache())
+    with pytest.raises(ValueError):
+        restore_recurrent(_hybrid_cache()[:32], snap)


### PR DESCRIPTION
Two related pieces. **The loader fix affects existing users**; the MTP work is opt-in and lands a negative result with its evidence.

## fix: quantized embeddings were being silently discarded

TurboQuant leaves the token embedding and `lm_head` to MLX's affine quantizer, so they arrive as `weight`/`scales`/`biases` with no `.codebook`. `_prepare_polar_layers` keys off `.codebook` and never sees them, the freshly built model still holds a plain `nn.Embedding`/`nn.Linear` there, and `load_weights(strict=False)` then drops their scales and biases without a word.

**Nothing errors — the model just returns nonsense.** On Qwen3.8-27B, `embed_tokens(ids)` came back `(1, T, 1280) uint32` instead of `(1, T, 5120)` floats.

Muse Glimmer was luckier: mlx-lm has no `muse_glimmer` class at all, so it fails loudly. Qwen3.8 *is* known to mlx-lm as a text architecture, which is exactly why it loaded and was wrong instead of refusing.

- `_prepare_affine_extras` converts those modules before the load. Shapes fix both parameters exactly — the plain module's `weight.shape[-1]` is the unpacked width, so `group_size = width / scales.shape[-1]` and `bits = packed_words * 32 / width`.
- `_assert_no_orphan_quant_params` refuses to load if any `.scales` still has nowhere to go. `strict=False` can't be dropped here (the checkpoint legitimately carries polar keys the base modules don't declare), so a missed module has to be caught explicitly.

**Verified.** `load_turboquant` on `Qwen3.8-27B-tq4` now yields `QuantizedEmbedding`/`QuantizedLinear` (8-bit, gs64) and answers *"The capital of France is"* → `" Paris"`. No regression on `tmp-q06b-tq3-{fused,online}`, or on `tmp-q38-tq4-lmpolar` where `lm_head` **is** polar-quantized and the guard correctly ignores it.

## feat: MTP head, behind `--keep-mtp`

Qwen3.8-27B ships a real multi-token-prediction head — 15 tensors. mlx-lm throws it away in `sanitize()` and implements MTP nowhere; transformers declares `_keys_to_ignore_on_load_unexpected = [r"^mtp.*"]`. No open runtime uses it, and there's no reference implementation to copy.

`--keep-mtp` copies the head from the source shards. It's stored under `tq_speculator.` rather than `mtp.`, and that is load-bearing: `sanitize()` keys its `+1` norm shift off `any("mtp." in k)`, and a converted checkpoint's norms are **already** shifted — so any key containing that substring re-fires the predicate and shifts every norm in the model a second time. `tq_mtp.` would also be unsafe (substring, not prefix).

Two facts the checkpoint doesn't determine, both settled by measurement:

| | |
|---|---|
| `concat_order` | **`embedding_first`**. `hidden_first` scores exactly 0.00%, so DeepSeek-V3's `[hidden ; embedding]` convention is wrong here. |
| norm shift | **every 1-D tensor**, not just mlx-lm's four suffixes: **69.49%** top-1 agreement vs **3.73%**, on 295 tokens of prose. |

## Speculative decoding is implemented, correct, and NOT enabled

Bit-identical to greedy — but **0.52×** the speed, so it is wired to nothing.

The cost is structural, not implementation overhead. The GDN snapshot is taken before both verify positions, so a rejection must discard both (trimming only the rejected one desyncs the 16 KV layers from the 48 recurrent ones — that was the first divergence bug) and replay the one real token. Ceiling is `(1+p)/(2-p)`:

| acceptance | ceiling |
|---|---|
| **45.7% (measured)** | **0.94×** |
| 69.5% | 1.30× |
| 80% | 1.50× |

At the measured acceptance a *perfect* implementation still loses. Removing the replay needs an invertible Gated-DeltaNet update or a cheap mid-sequence checkpoint — both research. Recorded rather than shipped.

## Three measurement traps, documented in `mtp.py`

Each produced a confident wrong answer first:
1. **A missing causal mask** lets the head attend to future positions and inflates every score (68.25% → 77.78%).
2. **n=63 is too small** — the norm-rule ordering scrambles and points at the wrong rule.
3. **A repeated paragraph inflates agreement ~24 points** (93.72% vs 69.49%) because the model just copies. Never measure draft acceptance on repetitive text.

## Tests

590 passed, 5 skipped. 35 new tests across `tests/test_mtp.py` and `tests/test_loader_affine_extras.py`, including regression guards that fail loudly if mlx-lm changes the `"mtp."` substring predicate or the norm-shift suffix list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added an option to preserve MTP tensors during checkpoint conversion, including streaming conversions.
  - Added support for loading affine-quantized embeddings and linear layers with automatic bit-width and group-size detection.
  - Added speculative decoding with draft-token generation, verification, rollback, cache handling, and EOS support.
  - Added greedy decoding support for MTP-enabled models.
  - Added support for affine-quantized modules in vision-language model loading.

- **Bug Fixes**
  - Conversion now reports whether MTP tensors were preserved or unavailable.
  - Unmatched or incomplete quantization parameters now trigger clear errors instead of being silently ignored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->